### PR TITLE
docs(provisioning): give the SDK-vs-Cloud-Control routing a page readers reach without knowing a flag name

### DIFF
--- a/docs/cli-deploy-safety.md
+++ b/docs/cli-deploy-safety.md
@@ -37,6 +37,15 @@ cdkd deploy MyStack --no-cfn-fallback        # cdkd-state-only cross-stack resol
 | `--allow-unaddressed` | deploy | Exit 0 instead of 2 when the deploy left a resource alive that it no longer tracks. |
 | `--no-cfn-fallback` | deploy, diff | Do not fall back to CloudFormation when a cross-stack reference is missing from cdkd state. |
 
+## Which routing flag, when
+
+Four of the flags above decide **which provisioning layer manages a resource** —
+cdkd's hand-written SDK provider or the Cloud Control API. They are easy to
+confuse, and the choice usually starts from what you want rather than from a
+flag name, so the decision map lives with the concept:
+[Provisioning Layers](provisioning-layers.md#choosing-a-flag). This page owns
+the per-flag detail each row links to.
+
 ## `--allow-unsupported-types` (deploy + destroy)
 
 cdkd rejects genuinely-unsupported resource types at **pre-flight** — before
@@ -163,7 +172,7 @@ properties.
 | Situation | Recommended action |
 | --- | --- |
 | Fresh deploy, template uses a silent-drop property | Default auto-route via Cloud Control — no flag needed |
-| Existing Cloud-Control-managed resource, want to stay there | Default routing is sticky — no flag needed |
+| Existing Cloud-Control-managed resource, want to stay there | Default routing is sticky — no flag needed, unless the type is exempt from stickiness ([`--pin-cc-api`](#pin-cc-api-deploy)) |
 | Existing SDK-managed resource, new silent-drop property appears | Default re-routes through Cloud Control; use this flag to stay on SDK |
 | You explicitly want SDK semantics and accept the drop | This flag |
 | The property is security-meaningful | Do not use the flag — let the auto-route close the drop |
@@ -303,12 +312,19 @@ resource.
 
 ### Going back to the SDK provider
 
-Once a resource is `provisionedBy: 'cc-api'` it stays there. A later cdkd
-release that wires the property you originally needed does not migrate it back
-— sticky state is what stops resources ping-ponging between layers on every
-release. Use
+Once a resource is `provisionedBy: 'cc-api'` it normally stays there. A later
+cdkd release that wires the property you originally needed does not by itself
+migrate it back — sticky state is what stops resources ping-ponging between
+layers on every release. Use
 [`--recreate-via-sdk-provider`](#recreate-via-sdk-provider-deploy) to move it
 back deliberately.
+
+The exception is a type carrying an `'sdk-coverage'` exemption from the sticky
+rule, for which the return happens automatically, in place, and without a
+recreate — see [`--pin-cc-api`](#pin-cc-api-deploy) and
+[State Management](state-management.md#version-7-adds-provisionedby-v7-writers).
+Check which case applies before reaching for the flag; the recreate is
+destructive and the automatic return is not.
 
 ### Nested stacks
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -48,7 +48,7 @@ cdkd deploys AWS CDK applications directly via the AWS SDK and Cloud Control API
 └────────┘ └────────┘
 ```
 
-Your CDK app synthesizes to an ordinary CloudFormation template — cdkd requires zero CDK code changes. cdkd then builds and publishes assets, analyzes the template's dependency graph, diffs it against the current state, and executes the plan in parallel, dispatching each resource the moment its dependencies complete. Each resource is provisioned by a hand-written SDK Provider where one exists, with Cloud Control API as the fallback for many additional types.
+Your CDK app synthesizes to an ordinary CloudFormation template — cdkd requires zero CDK code changes. cdkd then builds and publishes assets, analyzes the template's dependency graph, diffs it against the current state, and executes the plan in parallel, dispatching each resource the moment its dependencies complete. Each resource is provisioned by a hand-written SDK Provider where one exists, with Cloud Control API as the fallback for many additional types — see [Provisioning Layers](provisioning-layers.md) for how cdkd chooses, and when that choice changes.
 
 For a deeper look at each layer and a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI parsing, synthesis, asset publishing, per-stack deploy), see [Architecture](architecture.md).
 

--- a/docs/provisioning-layers.md
+++ b/docs/provisioning-layers.md
@@ -1,0 +1,137 @@
+---
+title: "Provisioning Layers"
+description: "How cdkd decides whether a resource is managed by a hand-written SDK provider or the Cloud Control API, when that decision changes, and which flag to reach for."
+---
+
+# Provisioning Layers
+
+cdkd provisions every resource through one of two layers:
+
+| Layer | `provisionedBy` | What it is |
+| --- | --- | --- |
+| **SDK provider** | `sdk` | A hand-written provider calling the service's own AWS SDK client directly. Fast, with service-specific error handling and a narrow IAM surface — but it only covers the properties someone wired. |
+| **Cloud Control API** | `cc-api` | AWS's generic resource API. Covers every property in the CloudFormation resource schema, for far more types than cdkd has SDK providers for, but each call is slower. |
+
+The hybrid is deliberate: the SDK provider is the fast path, and Cloud Control
+is the fallback that keeps cdkd correct for everything the fast path does not
+reach. Which types have which is in
+[Supported Resources](supported-resources.md).
+
+You mostly do not have to think about this. It becomes visible in three
+situations — a deploy that is slower than you expect, a `cdkd diff` annotation
+you did not ask for, and a property you set that does not show up in AWS — and
+each has a different answer.
+
+## How cdkd picks
+
+The layer is decided per resource, per deploy, in this order:
+
+1. **A resource already recorded `cc-api` normally stays there.** This is the
+   *sticky* rule. Without it, every release that added an SDK provider would
+   drag existing resources back across the boundary, and moving a resource
+   between layers used to mean destroying and recreating it.
+2. **Otherwise, if a hand-written SDK provider exists for the type, cdkd checks
+   the template's properties against it.** If the SDK provider covers all of
+   them, the resource goes to the SDK provider.
+3. **If the template carries a top-level property the SDK provider would
+   silently drop, cdkd routes the resource through Cloud Control instead**, so
+   the property actually reaches AWS. This is the *auto-route*, and it is on by
+   default because a silently dropped property is a bug class, not a
+   convenience.
+4. **If no SDK provider exists for the type**, Cloud Control handles it.
+
+Step 3 is what makes the choice look surprising: adding one property to a
+template can change which layer manages the resource. `cdkd diff` says so
+before it happens, annotating the resource `[via CC API: <property>]`.
+
+## Seeing which layer a resource is on
+
+```bash
+cdkd state show MyStack
+
+# MyTopic
+#   Type: AWS::SNS::Topic
+#   PhysicalID: arn:aws:sns:us-east-1:123456789012:MyTopic
+#   ProvisionedBy: cc-api
+```
+
+`ProvisionedBy: (sdk, legacy default)` means the record predates the field and
+is treated as SDK-managed. It is not pinned — routing is re-decided from
+scratch for such a resource.
+
+## Coming back from Cloud Control
+
+The sticky rule has narrow, per-type exemptions, and they are the reason a
+resource can move back to the SDK provider **without being destroyed and
+recreated**. Every exempt type has been verified to satisfy one hard
+requirement: the SDK provider addresses the resource by the *same* physical id
+Cloud Control stored, so the move costs no churn.
+
+Exempt types differ in why they were admitted, and that decides how automatic
+the move is:
+
+- **Cloud Control cannot manage the type correctly.** Staying pinned keeps a
+  live bug alive, so the move is unconditional and cannot be declined.
+- **Cloud Control works and is merely slower**, and cdkd has since gained full
+  property coverage for the type. The move happens on the next deploy that
+  changes the resource, provided neither the template's properties nor the
+  recorded ones carry anything the SDK provider would drop. It **can** be
+  declined for a single deploy.
+
+Either way it is an **update in place**: the physical id is preserved, so
+references to the resource and any out-of-band configuration attached to it
+survive. `cdkd diff` shows it first:
+
+```
+  [~] MyTopic (AWS::SNS::Topic) [returning to SDK provider]
+```
+
+and `cdkd deploy` names it as it happens:
+
+```
+MyTopic (AWS::SNS::Topic): returning to the SDK provider — cdkd now covers every property this resource uses. The physical id is preserved; pass --pin-cc-api MyTopic to decline this for a deploy.
+```
+
+Which types are exempt changes as coverage lands, so the list is not restated
+here — it is `STICKY_CC_MIGRATION_EXEMPT` in
+[`src/provisioning/provider-registry.ts`](https://github.com/go-to-k/cdkd/blob/main/src/provisioning/provider-registry.ts),
+and the rule it implements is in
+[State Management](state-management.md#version-7-adds-provisionedby-v7-writers).
+
+For a type that is **not** exempt, the move is still available, but it destroys
+and recreates the resource — see the table below.
+
+## Choosing a flag
+
+| You want | Situation | Do this |
+| --- | --- | --- |
+| A property the SDK provider drops to reach AWS | The resource is not in cdkd state yet | Nothing — the fresh deploy auto-routes it through Cloud Control |
+| The same, on a resource already deployed | `ProvisionedBy: sdk` | The routing decision is re-made every deploy, so the next one routes the resource through Cloud Control. For the cases that need the resource *recreated* on Cloud Control, see [`--recreate-via-cc-api`](cli-deploy-safety.md#recreate-via-cc-api-deploy) |
+| To keep SDK semantics and accept the dropped property instead | Either | [`--allow-unsupported-properties <Type>:<Prop>`](cli-deploy-safety.md#allow-unsupported-properties-deploy) |
+| To move a resource back to the SDK provider | `ProvisionedBy: cc-api`, type not exempt from the sticky rule | [`--recreate-via-sdk-provider <LogicalId>`](cli-deploy-safety.md#recreate-via-sdk-provider-deploy) — destroys and recreates |
+| The same, without destroying anything | `ProvisionedBy: cc-api`, type exempt because cdkd now covers it | Nothing — the next deploy that changes the resource moves it in place |
+| To decline that automatic move for one deploy | Same as above | [`--pin-cc-api <LogicalId>`](cli-deploy-safety.md#pin-cc-api-deploy) |
+
+Two things the shape of that table follows from:
+
+- **The two `--recreate-via-*` flags destroy and recreate the resource.** They
+  change which layer *created* it, not merely which one handles the next update.
+  Both are per-resource — no bulk form, so the cost is acknowledged for each
+  target — both refuse a stateful type unless
+  [`--force-stateful-recreation`](cli-deploy-safety.md#force-stateful-recreation)
+  is also passed, and both prompt before doing anything.
+- **`--pin-cc-api` destroys nothing.** It declines a routing change for one
+  deploy and is not stored anywhere, so it fits "I disagree with this deploy's
+  routing", not a standing preference. It has no effect on a type exempt because
+  Cloud Control cannot manage it — honouring the pin there would hold the
+  resource on the handler that cannot address it.
+
+Each flag's full behaviour, guards and refusals are in
+[Deploy: safety & compatibility flags](cli-deploy-safety.md).
+
+## Related
+
+- [Deploy: safety & compatibility flags](cli-deploy-safety.md) — the flags above, in full
+- [State Management](state-management.md#version-7-adds-provisionedby-v7-writers) — how `provisionedBy` is stored and migrated
+- [Supported Resources](supported-resources.md) — which types have an SDK provider
+- [Troubleshooting](troubleshooting.md#deployment-is-slow) — the symptom side

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -501,7 +501,8 @@ stacks is supported too.
 ### `version: 7` adds `provisionedBy` (v7+ writers)
 
 Schema `version: 7` adds an optional `provisionedBy` field to each
-`ResourceState`: `'sdk'`
+`ResourceState` — [Provisioning Layers](provisioning-layers.md) covers the same
+routing from the user's side. The value is `'sdk'`
 (cdkd's preferred fast path — direct synchronous AWS SDK calls) or `'cc-api'`
 (the Cloud Control API fallback), i.e. which provisioning layer owns the
 resource. A Custom Resource is recorded `'sdk'` too, so the field is always

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -22,6 +22,10 @@ cdkd uses a hybrid approach:
 - **Cloud Control API** — fallback for any resource type without a
   dedicated SDK Provider. Requires async polling.
 
+The layer is chosen per resource and per deploy, not fixed by the type alone —
+a property this table's SDK Provider does not cover sends that one resource
+through Cloud Control. See [Provisioning Layers](provisioning-layers.md).
+
 If a resource type has no SDK Provider AND AWS reports it as
 `ProvisioningType: NON_PROVISIONABLE` (Tier 3 — Cloud Control API cannot
 manage it), cdkd **rejects it at pre-flight** before any resource is touched,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1203,6 +1203,7 @@ HTTPS_PROXY=http://127.0.0.1:1 cdkd state list --profile <a working profile>
 - Long dependency chains in the DAG (the critical path caps how fast a deploy can finish, even with event-driven dispatch)
 - Cloud Control API rate limits
 - Asset publishing takes time
+- A resource pinned to the Cloud Control route (`ProvisionedBy: cc-api`), which is slower than cdkd's hand-written SDK provider
 
 **Solutions:**
 
@@ -1234,6 +1235,85 @@ const bucket = new s3.Bucket(this, 'Bucket');
 const role = new iam.Role(this, 'Role', { ... });
 // Dependencies auto-detected from Ref/GetAtt
 ```
+
+**3. Check whether a resource is pinned to the Cloud Control route**
+
+```bash
+cdkd state show MyStack
+
+# Example output:
+# MyTopic
+#   Type: AWS::SNS::Topic
+#   PhysicalID: arn:aws:sns:us-east-1:123456789012:MyTopic
+#   ProvisionedBy: cc-api
+```
+
+`ProvisionedBy: cc-api` means the resource is provisioned through the Cloud
+Control API — cdkd's fallback layer, and slower than a hand-written SDK
+provider. A resource lands there when its template carries a top-level property
+the SDK provider would silently drop, and the record is then **sticky**: a later
+cdkd release that adds SDK coverage for that property does not by itself move
+the resource back, because doing that unconditionally would mean
+destroy-and-recreate churn on every release. [Provisioning Layers](provisioning-layers.md) explains
+the two layers and how cdkd picks between them.
+
+Whether you need to do anything depends on the resource type:
+
+- **The type is exempt from the sticky rule**, because cdkd now covers it.
+  Nothing to do. The next deploy that changes the resource returns it to the SDK
+  provider automatically and **in place** — no flag, no physical-id churn. See
+  [`cdkd diff` shows `[returning to SDK provider]`](#cdkd-diff-shows-returning-to-sdk-provider)
+  below.
+- **The type has no exemption.** The migration is user-initiated, and it
+  destroys and recreates the resource:
+  [`--recreate-via-sdk-provider <LogicalId>`](cli-deploy-safety.md#recreate-via-sdk-provider-deploy).
+  The flag refuses while the template still carries the silent-drop property
+  that sent the resource to Cloud Control in the first place, so first either
+  remove that property or accept the drop with
+  `--allow-unsupported-properties <Type>:<Prop>`.
+
+### `cdkd diff` shows `[returning to SDK provider]`
+
+**Symptoms:**
+
+```
+  [~] MyTopic (AWS::SNS::Topic) [returning to SDK provider]
+```
+
+**Cause:**
+
+The resource is recorded `provisionedBy: cc-api`, and its type carries an
+`'sdk-coverage'` exemption from the sticky rule described above — Cloud Control
+manages the type correctly and is merely slower, and cdkd now covers every
+property this particular resource uses. The next mutating deploy moves it back
+to the faster SDK provider — see
+[Coming back from Cloud Control](provisioning-layers.md#coming-back-from-cloud-control).
+
+The annotation deliberately does not wear the `via CC API:` prefix its sibling
+tokens (`[via CC API: <property>]`, `[via CC API: sticky]`) share — the resource
+is *leaving* Cloud Control, not routing through it.
+
+**This is an update in place, not a replacement.** The physical id is preserved,
+so references to the resource and any out-of-band configuration attached to it
+survive. `cdkd deploy` names the move as it happens:
+
+```
+MyTopic (AWS::SNS::Topic): returning to the SDK provider — cdkd now covers every property this resource uses. The physical id is preserved; pass --pin-cc-api MyTopic to decline this for a deploy.
+```
+
+**Solutions:**
+
+Usually none — this is the routing improving itself. To decline it for a single
+deploy, for example to keep one deploy on the same layer as the last while
+investigating something, pass
+[`--pin-cc-api <LogicalId>`](cli-deploy-safety.md#pin-cc-api-deploy). It is
+per-deploy rather than a stored preference: pass it again next time, or stop
+passing it and let the move happen.
+
+A resource whose type is exempt for the opposite reason — Cloud Control
+*cannot* manage it correctly — moves for correctness rather than speed, logs a
+different line, and **ignores `--pin-cc-api`**, since honouring the pin would
+hold the resource on the handler that cannot address it.
 
 ### Cloud Control API Rate Limit
 

--- a/vite.docs.config.ts
+++ b/vite.docs.config.ts
@@ -30,6 +30,7 @@ const navigation: SsgNavigationGroup[] = [
     title: 'Features',
     items: [
       { title: 'Wait Modes', path: '/wait-modes' },
+      { title: 'Provisioning Layers', path: '/provisioning-layers' },
       { title: 'Rollback', path: '/rollback' },
       { title: 'Drift Detection', path: '/drift' },
       { title: 'Orphan vs Destroy', path: '/orphan-vs-destroy' },


### PR DESCRIPTION
## Summary

The SDK-provider / Cloud-Control routing story was fully documented and
structurally unfindable. Every entry point required a term the reader had no
way to have learned:

| Where it lived | What you had to already know |
| --- | --- |
| `docs/cli-deploy-safety.md`, under `--pin-cc-api` | the flag name |
| `docs/state-management.md`, under `provisionedBy` | the schema field name |
| `docs/concepts.md` | one sentence naming the two layers, silent on stickiness and on the flip |

Nothing was reachable from a **symptom**, and go-to-k/cdkd#2724 shipped two of
them: a resource whose deploys stay slow because it is pinned to Cloud Control
(the motivation for go-to-k/cdkd#2719 — the go-to-k/cdkd#609 backfill delivered
its speed benefit to new resources only), and a `[returning to SDK provider]`
annotation nobody asked for.

## What this adds

**`docs/provisioning-layers.md`**, in the site's **Features** group next to
Wait Modes and Rollback — not CLI Reference, which is consulted rather than
read. It covers what the two layers are, the order cdkd picks in, reading
`ProvisionedBy` from `cdkd state show`, the in-place return from Cloud Control,
and a decision table mapping intent to one of the four routing flags —
including the two rows whose answer is "nothing".

The division of labour, so nothing is said twice:

- **this page** — the concept and the flag choice (read)
- `cli-deploy-safety.md` — per-flag behaviour, guards, refusals (consulted); the
  old spot keeps a three-line pointer
- `state-management.md` — the `provisionedBy` schema
- `troubleshooting.md` — the symptom side

**`docs/troubleshooting.md`** gains the two missing symptom entries. `###
Deployment is Slow` listed three causes (DAG chains, Cloud Control rate limits,
asset publishing) and not the routing one; a new `### cdkd diff shows
[returning to SDK provider]` explains the annotation, that the physical id is
preserved, and how to decline it.

Exempt types are **not** listed on the new page — it points at
`STICKY_CC_MIGRATION_EXEMPT`, since membership changes as coverage lands.

## Two stale claims left behind by go-to-k/cdkd#2724, corrected here

- `### Going back to the SDK provider` still read *"Once a resource is
  `provisionedBy: 'cc-api'` it stays there"*. False for a type with an
  `'sdk-coverage'` exemption, which returns automatically and in place.
- The `--allow-unsupported-properties` decision summary still read *"Existing
  Cloud-Control-managed resource, want to stay there → no flag needed"*. For an
  exempt type that now takes `--pin-cc-api`.

## A contradiction found and deliberately NOT fixed here

`cli-deploy-safety.md` answers one question twice, oppositely, ~70 lines apart:
the `--allow-unsupported-properties` section (L152-158, and its table row) says
a still-SDK resource gaining a silent-drop property **re-routes on its own**,
while `--recreate-via-cc-api` (L226-232) says the property *"will not reach AWS,
because the SDK update path drops it silently"*.

`ProviderRegistry.getProviderFor` (`src/provisioning/provider-registry.ts:405`)
enters the sticky rule only for a record already at `'cc-api'`, so a `'sdk'`
record falls through to the silent-drop check every deploy — matching the first
passage, not the second. But the second may describe a real constraint under a
wrong reason (physicalId parity, or a create-only property), and settling that
needs a real-AWS run. Filed as go-to-k/cdkd#2744; the new page states
**neither** side — its table says the routing decision is re-made every deploy
and links out for the recreate case.

## Test plan

- `vp run check`, `typecheck:test`, `build` clean. `vp test run` — 931 files,
  19,999 tests, 0 failures (re-run after the last edit).
- `vp run gen:all-matrices` + `audit:coverage:check` — nothing stale.
- **Live-tested by building the site**, not by reading the markdown:
  `vp run docs:build` → 148 output files, `dist/site/provisioning-layers/index.html`
  present, "Provisioning Layers" in the sidebar of other pages, and every anchor
  this PR links to confirmed against the built HTML
  (`#coming-back-from-cloud-control`, `#choosing-a-flag`,
  `#cdkd-diff-shows-returning-to-sdk-provider`, `#pin-cc-api-deploy`,
  `#recreate-via-cc-api-deploy`, `#recreate-via-sdk-provider-deploy`,
  `#force-stateful-recreation`).
- The site's slugger **drops a heading's leading `--`**, unlike GitHub's. Nine
  links were wrong on the first pass and one pre-existing CORRECT link was
  "fixed" into the broken form before `docs-site-links.test.ts` settled it.
- No `src/` change, so no integ marker is in scope.

Refs go-to-k/cdkd#2719, go-to-k/cdkd#2724, go-to-k/cdkd#609, go-to-k/cdkd#2744
