### PR TITLE
chore(schemas): resolve the backfill umbrella by label, so moving it is not a code change

### DIFF
--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -358,10 +358,14 @@ jobs:
         if: steps.drift.outputs.drifted == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The standing umbrella issue that collects properties still to be
-          # wired into an SDK provider. Named here rather than in the script so
-          # moving the campaign is a workflow edit, not a code change.
-          BACKFILL_UMBRELLA: "609"
+          # The LABEL that marks the standing umbrella issue, not its number.
+          # A number goes stale silently the moment the campaign moves, and it
+          # did: the first destination carried months of design discussion and
+          # participants beyond the maintainer, so a daily bot comment notified
+          # all of them. Moving it is now `gh issue edit --add-label`, and the
+          # lookup below refuses to guess when the label is not on exactly one
+          # open issue.
+          BACKFILL_UMBRELLA_LABEL: backfill-umbrella
           # Same reasoning as the switch step: no `${{ }}` inside a shell body.
           PR_NUMBER: ${{ steps.open_pr.outputs.number }}
         run: |
@@ -468,6 +472,27 @@ jobs:
                 echo "Carried by https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
               fi
             } > /tmp/umbrella.md
-            gh issue comment "${BACKFILL_UMBRELLA}" --body-file /tmp/umbrella.md \
-              || echo "::warning::Could not comment on the backfill umbrella issue; the list is in the PR body."
+            # Resolve the destination by LABEL, and refuse to guess. Zero
+            # matches means the campaign has no home; two or more means nobody
+            # can say which is the running list. Posting to an arbitrary one is
+            # the silent-wrong-destination failure this job exists to avoid, so
+            # both are warnings rather than a pick — and neither undoes the PR,
+            # which carries the same list in its body.
+            # `|| true`: a bare command substitution here runs under
+            # `set -euo pipefail`, so a transient gh failure would abort the
+            # step — AFTER the PR has been created. The step's whole contract is
+            # that the umbrella fold never undoes the PR, which the previous
+            # `gh issue comment ... || echo` spelling preserved and this lookup
+            # would have quietly broken. An empty result falls through to the
+            # not-exactly-one warning below.
+            umbrella=$(gh issue list --state open --limit 100 \
+              --label "${BACKFILL_UMBRELLA_LABEL}" --json number \
+              --jq '[.[].number] | join(" ")' || true)
+            umbrella_count=$(printf '%s' "${umbrella}" | wc -w | tr -d ' ')
+            if [ "${umbrella_count}" = "1" ]; then
+              gh issue comment "${umbrella}" --body-file /tmp/umbrella.md \
+                || echo "::warning::Could not comment on backfill umbrella #${umbrella}; the list is in the PR body."
+            else
+              echo "::warning::Expected exactly one OPEN issue labelled '${BACKFILL_UMBRELLA_LABEL}', found ${umbrella_count} (${umbrella:-none}). The list is in the PR body; label one issue to restore the running list."
+            fi
           fi

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -361,7 +361,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(linkAt).toBeGreaterThan(-1);
       expect(guardAt).toBeLessThan(linkAt);
       // And the comment still fires outside that guard.
-      expect(publish.indexOf('${BACKFILL_UMBRELLA}')).toBeGreaterThan(linkAt);
+      expect(publish.indexOf('${BACKFILL_UMBRELLA_LABEL}')).toBeGreaterThan(linkAt);
     });
 
     it('passes the checker’s EXIT CODE, not only its output', () => {
@@ -578,10 +578,42 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(shellOf('Publish the refresh')).toContain(heading);
     });
 
-    it('names the backfill umbrella issue explicitly', () => {
-      // A typo here posts the backfill list to an unrelated issue, silently.
+    it('resolves the backfill umbrella by LABEL, never by a hardcoded number', () => {
+      // A number goes stale silently the moment the campaign moves, and it did:
+      // the first destination carried months of design discussion and
+      // participants beyond the maintainer, so a daily bot comment notified all
+      // of them. The label is the indirection that makes moving it a
+      // `gh issue edit`, not a workflow edit.
       const publish = steps.find((st) => st.name === 'Publish the refresh')!;
-      expect(publish.env?.['BACKFILL_UMBRELLA']).toBe('609');
+      expect(publish.env?.['BACKFILL_UMBRELLA_LABEL']).toBe('backfill-umbrella');
+      expect(
+        publish.env?.['BACKFILL_UMBRELLA'],
+        'the hardcoded issue number is back'
+      ).toBeUndefined();
+      const shell = shellOf('Publish the refresh');
+      expect(shell, 'an issue number is hardcoded in the shell').not.toMatch(
+        /gh issue comment "?\d+/
+      );
+    });
+
+    it('refuses to guess when the label is not on exactly one open issue', () => {
+      // Zero means the campaign has no home; two or more means nobody can say
+      // which is the running list. Posting to an arbitrary one is the
+      // silent-wrong-destination failure this whole job exists to avoid.
+      const shell = shellOf('Publish the refresh');
+      expect(shell).toMatch(/--label "\$\{BACKFILL_UMBRELLA_LABEL\}"/);
+      expect(shell).toMatch(/if \[ "\$\{umbrella_count\}" = "1" \]; then/);
+      // And the non-1 branch warns rather than picking one.
+      // The lookup must not abort the step: it runs under `set -euo pipefail`
+      // AFTER the PR exists, and this step's contract is that the umbrella fold
+      // never undoes the PR. The previous `gh issue comment ... || echo`
+      // spelling preserved that; a bare command substitution would not.
+      expect(shell, 'a transient gh failure aborts the step after the PR was made').toMatch(
+        /--jq '\[\.\[\]\.number\] \| join\(" "\)' \|\| true\)/
+      );
+      const elseAt = shell.indexOf('Expected exactly one OPEN issue');
+      expect(elseAt, 'the ambiguous case does not announce itself').toBeGreaterThan(-1);
+      expect(shell.slice(elseAt)).not.toMatch(/gh issue comment/);
     });
 
     it('re-checks the PR is still OPEN before pushing onto its branch', () => {


### PR DESCRIPTION
## Why

The daily CFn schema refresh posts its unaccounted-property list to a hardcoded issue number. The number was correct — that issue's body explicitly anticipates this inflow ("new properties surfaced by future schema refreshes are added as new sub-items") — and it was still the wrong destination, for a reason a number cannot express: that issue carries months of design discussion and has participants beyond the maintainer, so a daily bot comment notifies all of them.

## What

The destination is a **label** now, `backfill-umbrella`, resolved to the single open issue carrying it. Moving the campaign is `gh issue edit --add-label`; this workflow is not touched.

The lookup **refuses to guess**. Zero matches means the campaign has no home; two or more means nobody can say which is the running list. Either way it warns and leaves the list in the pull-request body rather than posting somewhere unintended — the silent-wrong-destination failure this job exists to avoid, and the one a hardcoded number re-introduces the moment the campaign moves.

## One regression caught by the inline review, in this change

`gh issue list` as a bare command substitution runs under `set -euo pipefail`, so a transient gh failure would abort the step — **after** the pull request has been created. That step's contract is that the umbrella fold never undoes the PR, which the previous `gh issue comment ... || echo` spelling preserved and this lookup would have quietly broken. It takes `|| true` and falls through to the not-exactly-one warning, pinned by a case and verified against a real bash run (`gh` failing still reaches the end of the step).

## Test plan

- Full suite green: 936 files / 20,186 tests.
- Four probes, each red on its own: restoring the hardcoded number; dropping the count check so the first match wins; dropping the `--label` filter; removing the `|| true`.
- The live query resolves to exactly one open issue.
- Shell semantics measured rather than reasoned: a failing lookup under `set -euo pipefail` warns and reaches the end of the step.
