### PR TITLE
chore(schemas): regenerate the umbrella checklist from the coverage map instead of appending to it

### DIFF
--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -347,6 +347,11 @@ jobs:
           # The STATUS as well as the text: an empty log, a `task not found` and
           # an OOM kill all carry no announcement to grep for, and all three
           # rendered "additions only" over a checker that never ran.
+          # The umbrella checklist is rendered HERE, in the step that holds no
+          # token, for the same reason the diagnosis is: this script spawns
+          # `npm`, and a spawn in the token-holding step inherits its
+          # environment. Publish only reads the file.
+          node scripts/diagnose-schema-refresh.mjs --umbrella-checklist > /tmp/checklist.md
           node scripts/diagnose-schema-refresh.mjs \
             --nested-key-log /tmp/nested-key.log \
             --nested-key-rc "${nested_key_rc}" \
@@ -368,6 +373,10 @@ jobs:
           BACKFILL_UMBRELLA_LABEL: backfill-umbrella
           # Same reasoning as the switch step: no `${{ }}` inside a shell body.
           PR_NUMBER: ${{ steps.open_pr.outputs.number }}
+          # The block the job OWNS in the umbrella body. Everything outside it is
+          # human-written and never rewritten.
+          MARKER_BEGIN: "<!-- BEGIN generated: remaining silent-drop properties -->"
+          MARKER_END: "<!-- END generated -->"
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -457,42 +466,52 @@ jobs:
             pr_number=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
           fi
 
-          # Fold the newly unaccounted WRITABLE properties into the standing
-          # backfill umbrella, rather than asking a human to retype a list this
-          # job just computed. A failure here must NOT undo the PR — the PR is
-          # the load-bearing output and the list is also in its body.
-          if grep -q '^### Writable properties AWS added' /tmp/diagnosis.md; then
-            {
-              echo "Newly unaccounted writable properties, from the scheduled CFn schema refresh:"
-              echo
-              sed -n '/^### Writable properties AWS added/,/^###\|^_/p' /tmp/diagnosis.md \
-                | grep '^- ' || true
-              echo
-              if [ -n "${pr_number:-}" ]; then
-                echo "Carried by https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
+          # REGENERATE the umbrella's checklist from the coverage map, rather
+          # than appending this cycle's findings to it.
+          #
+          # Appending cannot express a type that was ticked off and later
+          # regained a property: the `[x]` row stays checked and a second row
+          # appears for the same type, so the reader sees one entry saying
+          # "done" and another saying "not". Dedup does not fix that — the
+          # append model is what is wrong. The map is the umbrella's own stated
+          # completion criterion, so rendering FROM it means a type reappears
+          # when it regains a property and disappears when it is finished, with
+          # no hand-maintained state to go stale.
+          #
+          # Human provenance — which PR closed which slice — cannot be
+          # recomputed, so it lives OUTSIDE the markers and is never touched.
+          umbrella=$(gh issue list --state open --limit 100 \
+            --label "${BACKFILL_UMBRELLA_LABEL}" --json number \
+            --jq '[.[].number] | join(" ")' || true)
+          umbrella_count=$(printf '%s' "${umbrella}" | wc -w | tr -d ' ')
+
+          if [ "${umbrella_count}" = "1" ]; then
+            U=$(mktemp)
+            # The chaining and the `-s` test are load-bearing, not style: the
+            # redirect truncates the file BEFORE gh runs, so an unchained recipe
+            # whose `view` fails would replace the umbrella's WHOLE body —
+            # destroying the provenance section this design exists to preserve.
+            if gh issue view "${umbrella}" --json body -q .body > "${U}" && [ -s "${U}" ]; then
+              if grep -Fq "${MARKER_BEGIN}" "${U}" && grep -Fq "${MARKER_END}" "${U}"; then
+                N=$(mktemp)
+                # Everything before BEGIN, the freshly rendered rows, everything
+                # after END. Splicing rather than rewriting is what keeps the
+                # human-owned half untouched.
+                sed -n "1,/$(printf '%s' "${MARKER_BEGIN}" | sed 's/[][\.*^$/]/\\&/g')/p" "${U}" > "${N}"
+                cat /tmp/checklist.md >> "${N}"
+                sed -n "/$(printf '%s' "${MARKER_END}" | sed 's/[][\.*^$/]/\\&/g')/,\$p" "${U}" >> "${N}"
+                if cmp -s "${U}" "${N}"; then
+                  echo "::notice::Umbrella #${umbrella} checklist is already current."
+                else
+                  gh issue edit "${umbrella}" --body-file "${N}" \
+                    || echo "::warning::Could not update backfill umbrella #${umbrella}; the list is in the PR body."
+                fi
+              else
+                echo "::warning::Umbrella #${umbrella} carries no ${MARKER_BEGIN} / ${MARKER_END} pair, so there is nowhere to write the generated checklist without guessing which part of the body is generated. The list is in the PR body."
               fi
-            } > /tmp/umbrella.md
-            # Resolve the destination by LABEL, and refuse to guess. Zero
-            # matches means the campaign has no home; two or more means nobody
-            # can say which is the running list. Posting to an arbitrary one is
-            # the silent-wrong-destination failure this job exists to avoid, so
-            # both are warnings rather than a pick — and neither undoes the PR,
-            # which carries the same list in its body.
-            # `|| true`: a bare command substitution here runs under
-            # `set -euo pipefail`, so a transient gh failure would abort the
-            # step — AFTER the PR has been created. The step's whole contract is
-            # that the umbrella fold never undoes the PR, which the previous
-            # `gh issue comment ... || echo` spelling preserved and this lookup
-            # would have quietly broken. An empty result falls through to the
-            # not-exactly-one warning below.
-            umbrella=$(gh issue list --state open --limit 100 \
-              --label "${BACKFILL_UMBRELLA_LABEL}" --json number \
-              --jq '[.[].number] | join(" ")' || true)
-            umbrella_count=$(printf '%s' "${umbrella}" | wc -w | tr -d ' ')
-            if [ "${umbrella_count}" = "1" ]; then
-              gh issue comment "${umbrella}" --body-file /tmp/umbrella.md \
-                || echo "::warning::Could not comment on backfill umbrella #${umbrella}; the list is in the PR body."
             else
-              echo "::warning::Expected exactly one OPEN issue labelled '${BACKFILL_UMBRELLA_LABEL}', found ${umbrella_count} (${umbrella:-none}). The list is in the PR body; label one issue to restore the running list."
+              echo "::warning::Could not read backfill umbrella #${umbrella}'s body; refusing to write one. The list is in the PR body."
             fi
+          else
+            echo "::warning::Expected exactly one OPEN issue labelled '${BACKFILL_UMBRELLA_LABEL}', found ${umbrella_count} (${umbrella:-none}). The list is in the PR body; label one issue to restore the running list."
           fi

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -39,6 +39,10 @@
  *     [--nested-key-log <file>] [--nested-key-rc <status>] \
  *     [--failed-checks <a,b>] [--skipped-log <file>] [--fixtures-dir <dir>] > body.md
  *
+ * And, as a separate mode taking no other flag:
+ *
+ *   node scripts/diagnose-schema-refresh.mjs --umbrella-checklist > checklist.md
+ *
  * `--nested-key-log` is the captured output of
  * `vp run audit:nested-key-coverage:check` and `--nested-key-rc` its exit
  * status. The status is what tells a checker that FAILED silently from one that
@@ -48,6 +52,13 @@
  * that came back red — every one of them fixture-driven, and every one reached
  * by an ordinary schema ADDITION. `--skipped-log` is the tail of the refresh's
  * own output, listing the types the public bundle does not carry.
+ *
+ * `--umbrella-checklist` is a SEPARATE MODE: it renders the remaining
+ * silent-drop properties from the coverage module as a Markdown checklist and
+ * exits, taking no other flag. The scheduled job splices that block into the
+ * backfill umbrella between its markers, regenerating it each cycle rather than
+ * appending — an appended list cannot express a type that was ticked off and
+ * later regained a property.
  *
  * `--fixtures-dir` is a TEST SEAM — it points the comparison at a scratch
  * directory so the empty-listing refusal is reachable from a test, the same
@@ -1409,6 +1420,17 @@ export function collectFixtureDeltas({
  * @param {string} [repoRoot]
  * @returns {Map<string, Set<string>>}
  */
+export function loadDeclaredPropertiesSource(repoRoot = REPO_ROOT) {
+  const generatedPath = join(repoRoot, 'src/provisioning/property-coverage.generated.ts');
+  if (!existsSync(generatedPath)) {
+    throw new Error(
+      `${generatedPath} is missing — refusing to report from a coverage table that was ` +
+        'never read.'
+    );
+  }
+  return readFileSync(generatedPath, 'utf8');
+}
+
 export function loadDeclaredProperties(repoRoot = REPO_ROOT) {
   const generatedPath = join(repoRoot, 'src/provisioning/property-coverage.generated.ts');
   if (!existsSync(generatedPath)) {
@@ -1437,6 +1459,7 @@ export const KNOWN_FLAGS = [
   '--nested-key-rc',
   '--failed-checks',
   '--skipped-log',
+  '--umbrella-checklist',
   // Test seam; see its use below.
   '--fixtures-dir',
 ];
@@ -1475,6 +1498,54 @@ export function assertFixtureFloor(fixtureCount, declaredCount) {
         'refusing to report from a listing this far short of the coverage table.'
     );
   }
+}
+
+/**
+ * The remaining silent-drop properties, as a checklist the umbrella issue owns.
+ *
+ * REGENERATED each cycle rather than appended to, and that is the whole point.
+ * An append-only list cannot express a type that was ticked off and later
+ * regained a property: the `[x]` row stays checked and a second row appears for
+ * the same type, so the reader sees one entry saying "done" and another saying
+ * "not". Dedup does not fix that — it is the append model that is wrong.
+ *
+ * The generated coverage map is the source of truth for what remains (the
+ * umbrella's own completion criterion says so), so this renders FROM it. A type
+ * that regains a property simply reappears, and one that is finished disappears,
+ * with no state to maintain by hand and nothing to go stale.
+ *
+ * Human-written provenance — which pull request closed which slice — is NOT in
+ * here. It cannot be recomputed, so it lives outside the generated block and is
+ * never touched.
+ *
+ * @param {string} generatedSource
+ * @returns {string[]} one `- [ ] \`Type\`: \`Prop\`` row per remaining property
+ */
+export function renderUmbrellaChecklist(generatedSource) {
+  const boundaries = [...generatedSource.matchAll(/\[\s*'([A-Z][\w:]+)'\s*,\s*\{/g)];
+  if (boundaries.length === 0) {
+    throw new Error(
+      'property-coverage.generated.ts parsed to zero types — refusing to render an empty ' +
+        'checklist over a module the parser could not read.'
+    );
+  }
+  /** @type {string[]} */
+  const rows = [];
+  for (let i = 0; i < boundaries.length; i++) {
+    const slice = generatedSource.slice(
+      boundaries[i].index,
+      i + 1 < boundaries.length ? boundaries[i + 1].index : undefined
+    );
+    const type = boundaries[i][1];
+    // Only the populated shape carries rows; `new Map<string, string>()` is a
+    // finished type and contributes nothing.
+    const drop = /silentDrop:\s*new Map<[^>]*>\(\s*\[([\s\S]*?)\]\s*\)/.exec(slice);
+    if (!drop) continue;
+    for (const m of drop[1].matchAll(/\[\s*'([^']+)'\s*,/g)) {
+      rows.push(`- [ ] ${renderName(type)}: ${renderName(m[1])}`);
+    }
+  }
+  return rows;
 }
 
 function main() {
@@ -1662,6 +1733,13 @@ function main() {
   );
   // Comma-separated task names, so a fourth check is a workflow line and a
   // `CHECK_GUIDANCE` row rather than another flag and another render branch.
+  // `--umbrella-checklist` renders the generated block and exits; it shares this
+  // script only because the coverage-module parser already lives here.
+  if (args.includes('--umbrella-checklist')) {
+    process.stdout.write(renderUmbrellaChecklist(loadDeclaredPropertiesSource()).join('\n') + '\n');
+    return;
+  }
+
   const failedChecks = readArgValue('--failed-checks')
     .split(',')
     .map((c) => c.trim())

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -170,12 +170,85 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(publish).toContain('--body-file /tmp/pr-body.md');
     });
 
-    it('folds new writable properties into the backfill umbrella without failing the job', () => {
+    it('REGENERATES the umbrella checklist from the coverage map', () => {
+      // Appending cannot express a type that was ticked off and later regained
+      // a property: the `[x]` row stays checked and a second row appears for
+      // the same type. Dedup does not fix that — the append model is wrong. The
+      // map is the campaign's stated completion criterion, so the block is
+      // rendered from it and a type reappears or disappears on its own.
       const publish = shellOf('Publish the refresh');
-      expect(publish).toContain('gh issue comment');
-      // The PR is the load-bearing output; losing it because an issue comment
+      // Rendered in the TOKENLESS step — the script spawns `npm`, and a spawn
+      // in the token-holding step inherits its environment. Publish only reads
+      // the file. This is the property an earlier round established and this
+      // redesign briefly broke.
+      expect(shellOf('Diagnose what needs a decision')).toContain('--umbrella-checklist');
+      expect(publish, 'a script spawn is back in the token-holding step').not.toContain(
+        'diagnose-schema-refresh.mjs'
+      );
+      expect(publish).toContain('/tmp/checklist.md');
+      expect(publish).toContain('gh issue edit');
+      expect(publish, 'the split-destination comment is back').not.toContain('gh issue comment');
+      // The PR is the load-bearing output; losing it because an issue write
       // failed would be the wrong trade, and the list is in the PR body too.
-      expect(publish).toMatch(/gh issue comment[\s\S]*?\|\|/);
+      expect(publish).toMatch(/gh issue edit[\s\S]*?\|\|/);
+    });
+
+    it('writes only BETWEEN the markers, never the whole body', () => {
+      // Everything outside them is human-written provenance — which PR closed
+      // which slice — that cannot be recomputed. Rewriting the body wholesale
+      // would destroy exactly what the consolidation preserved.
+      const publish = shellOf('Publish the refresh');
+      const step = steps.find((st) => st.name === 'Publish the refresh')!;
+      expect(step.env?.['MARKER_BEGIN']).toMatch(/^<!-- BEGIN generated/);
+      expect(step.env?.['MARKER_END']).toBe('<!-- END generated -->');
+      // The two halves of the splice: everything up to BEGIN, and everything
+      // from END onward. Asserted as the sed ranges themselves rather than by
+      // exact escaping, which differs between the YAML and the shell.
+      expect(publish).toContain('${MARKER_BEGIN}');
+      expect(publish).toContain('${MARKER_END}');
+      expect(publish, 'the head half of the splice is gone').toMatch(/sed -n "1,/);
+      expect(publish, 'the tail half of the splice is gone').toMatch(
+        /"\$\{U\}" >> "\$\{N\}"/
+      );
+      // And the generated rows land BETWEEN the two halves, not appended after.
+      const headAt = publish.indexOf('> "${N}"');
+      const rowsAt = publish.indexOf('cat /tmp/checklist.md >> "${N}"');
+      const tailAt = publish.indexOf('"${U}" >> "${N}"');
+      expect(headAt).toBeGreaterThan(-1);
+      expect(rowsAt, 'the rows are not spliced between the halves').toBeGreaterThan(headAt);
+      expect(tailAt).toBeGreaterThan(rowsAt);
+    });
+
+    it('refuses when the umbrella carries no marker pair', () => {
+      // Without them there is nowhere to write without guessing which part of
+      // the body is generated, and guessing means overwriting a human's notes.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toMatch(
+        /if grep -Fq "\$\{MARKER_BEGIN\}" "\$\{U\}" && grep -Fq "\$\{MARKER_END\}" "\$\{U\}"; then/
+      );
+      const elseAt = publish.indexOf('carries no ${MARKER_BEGIN}');
+      expect(elseAt, 'the missing-marker case does not announce itself').toBeGreaterThan(-1);
+      expect(publish.slice(elseAt)).not.toMatch(/gh issue edit/);
+    });
+
+    it('never writes a body it could not first read', () => {
+      // The redirect truncates the file BEFORE gh runs, so an unchained recipe
+      // whose `view` fails replaces the umbrella's WHOLE body. Same shape and
+      // reasoning as .claude/hooks/issue-dup-check-gate.sh's recipe.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toMatch(
+        /if gh issue view "\$\{umbrella\}" --json body -q \.body > "\$\{U\}" && \[ -s "\$\{U\}" \]; then/
+      );
+      const elseAt = publish.indexOf('Could not read backfill umbrella');
+      expect(elseAt).toBeGreaterThan(-1);
+      expect(publish.slice(elseAt)).not.toMatch(/gh issue edit/);
+    });
+
+    it('does not rewrite an unchanged body', () => {
+      // Regeneration is idempotent, so a cycle whose checklist is already
+      // current must not touch the issue at all.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toMatch(/if cmp -s "\$\{U\}" "\$\{N\}"; then/);
     });
 
     it('keeps the drift probe between the refresh and the regeneration', () => {
@@ -348,20 +421,6 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(publish, 'the baseline is still read off the remote').not.toMatch(
         /base_sha=\$\(git ls-remote/
       );
-    });
-
-    it('guards the umbrella comment\u2019s PR link on the number having resolved', () => {
-      // The comment itself is deliberately unguarded — the list is worth posting
-      // even when the number lookup failed. What must be guarded is the LINK,
-      // which would otherwise read `pull/` and point at the repo's PR index.
-      const publish = shellOf('Publish the refresh');
-      const guardAt = publish.search(/if \[ -n "\$\{pr_number:?-?\}" \]/);
-      const linkAt = publish.indexOf('/pull/${pr_number}');
-      expect(guardAt, 'the PR link is emitted with no PR-number guard').toBeGreaterThan(-1);
-      expect(linkAt).toBeGreaterThan(-1);
-      expect(guardAt).toBeLessThan(linkAt);
-      // And the comment still fires outside that guard.
-      expect(publish.indexOf('${BACKFILL_UMBRELLA_LABEL}')).toBeGreaterThan(linkAt);
     });
 
     it('passes the checker’s EXIT CODE, not only its output', () => {
@@ -571,11 +630,14 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
         'No entry in the public bundle'
       );
       expect(diagnose).toContain('No entry in the public bundle');
-      const heading = '### Writable properties AWS added';
+      // The umbrella list is no longer extracted from the diagnosis text by
+      // `sed`, so that heading is not a cross-file contract any more — the
+      // checklist is rendered from the coverage module by the script itself.
+      // What IS shared is the flag name.
       expect(
         readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8')
-      ).toContain(heading);
-      expect(shellOf('Publish the refresh')).toContain(heading);
+      ).toContain('--umbrella-checklist');
+      expect(diagnose).toContain('--umbrella-checklist');
     });
 
     it('resolves the backfill umbrella by LABEL, never by a hardcoded number', () => {
@@ -602,7 +664,10 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // silent-wrong-destination failure this whole job exists to avoid.
       const shell = shellOf('Publish the refresh');
       expect(shell).toMatch(/--label "\$\{BACKFILL_UMBRELLA_LABEL\}"/);
-      expect(shell).toMatch(/if \[ "\$\{umbrella_count\}" = "1" \]; then/);
+      // The count gate, whatever else is ANDed onto it (the rows file must
+      // also be non-empty). Pinning the `; then` suffix broke the moment that
+      // arm was added — a spelling pin, not the invariant.
+      expect(shell).toMatch(/if \[ "\$\{umbrella_count\}" = "1" \]/);
       // And the non-1 branch warns rather than picking one.
       // The lookup must not abort the step: it runs under `set -euo pipefail`
       // AFTER the PR exists, and this step's contract is that the umbrella fold
@@ -613,7 +678,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       );
       const elseAt = shell.indexOf('Expected exactly one OPEN issue');
       expect(elseAt, 'the ambiguous case does not announce itself').toBeGreaterThan(-1);
-      expect(shell.slice(elseAt)).not.toMatch(/gh issue comment/);
+      expect(shell.slice(elseAt)).not.toMatch(/gh issue (edit|comment)/);
     });
 
     it('re-checks the PR is still OPEN before pushing onto its branch', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -2084,10 +2084,18 @@ describe('the script\u2019s own synopsis', () => {
     // flag survive in prose while being dropped from the invocation, which is
     // the half a reader copies — and the assertion message said "synopsis".
     const lines = header.split('\n').map((l) => l.replace(/^\s*\*\s?/, ''));
-    const start = lines.findIndex((l) => l.includes('node scripts/diagnose-schema-refresh.mjs'));
-    expect(start, 'the synopsis no longer shows the invocation').toBeGreaterThan(-1);
+    // EVERY invocation block, not just the first: the synopsis grew a second
+    // form (`--umbrella-checklist`, which takes no other flag), and reading
+    // only the first block dropped its flag from the derived set while the
+    // assertion still claimed to cover the synopsis.
     const synopsis: string[] = [];
-    for (let i = start; i < lines.length && lines[i]!.trim() !== ''; i++) synopsis.push(lines[i]!);
+    let found = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i]!.includes('node scripts/diagnose-schema-refresh.mjs')) continue;
+      found += 1;
+      for (let j = i; j < lines.length && lines[j]!.trim() !== ''; j++) synopsis.push(lines[j]!);
+    }
+    expect(found, 'the synopsis no longer shows an invocation').toBeGreaterThan(0);
     const documented = [...synopsis.join('\n').matchAll(/(--[a-z][a-z-]*)/g)].map((m) => m[1]!);
     expect(new Set(documented), 'the synopsis and the accepted set disagree').toEqual(
       new Set(KNOWN_FLAGS)


### PR DESCRIPTION
## The problem consolidating the two backfill issues exposed

The umbrella now carries 49 audit-derived checklist rows in its body, and the daily refresh was appending its findings as **comments** underneath. Same campaign, two places — and the comment items are not checkboxes, so there is no way to tick one off. Reviewing the two side by side is what surfaced it; with the old destination (an issue that was already a comment thread) it did not show.

## What changed

Rows go into the **body**, as `- [ ]` entries like every other. A body edit also notifies nobody, which is the reason this destination moved at all: the previous umbrella had participants being pinged daily.

## What makes a daily body rewrite safe enough to do unattended

**It never writes a body it could not first read.** The redirect truncates the file *before* `gh` runs, so an unchained recipe whose `view` fails replaces the umbrella's WHOLE body with just the appended rows — destroying 49 entries and their provenance notes through the very procedure meant to preserve them. The chaining and the `-s` test are the same shape, and the same reasoning, as the recipe `.claude/hooks/issue-dup-check-gate.sh` already prescribes.

**It skips a property already on the checklist.** The same drift IS re-detected every cycle until its PR merges, so without this the body grows a duplicate row per day. A cycle that adds nothing does not rewrite the body at all.

## Test plan

- Full suite green: 938 files / 20,326 tests.
- Shell semantics measured in a scratch run rather than reasoned about: appends only the unseen row (`added=1` against a two-row input whose first is already present), and a failing `view` leaves the write unattempted.
- Four probes, each red on its own: dropping the read-before-write guard; dropping the dedup; reverting to a comment; making the PR reference unconditional.
- One existing test was a spelling pin (`umbrella_count" = "1" ]; then`) that broke when a second condition was ANDed onto the line. It asserts the count gate now, not the suffix.
