### PR TITLE
chore(schemas): make the decision count in a refresh PR's title reachable from its body

### DIFF
--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -97,7 +97,11 @@ a typical cycle most additions are read-only.
 
 A refresh PR that needs one is **assigned to you, labelled `needs-decision`,
 titled with the count, and opened by a one-line verdict at the top of its
-body**. Of those, only the assignment sends a notification — it is applied
+body**. The verdict names a range — `D1`–`D5` — and every decision in the body
+carries its label, running straight through the sections. They are spread
+across sections because they arrive from different checks, so the labels are
+what let you reach the number in the title; each decision section also carries
+its own count in the heading. Of those, only the assignment sends a notification — it is applied
 first for that reason — while the label and the title suffix are what the PR
 list can still tell you afterwards, including that a PR was settled. The
 verdict line is rewritten every cycle, so it does not age the way the rest of

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1020,11 +1020,37 @@ export function renderDiagnosis(input) {
   } = input;
   const lines = ['## What changed, and what needs a decision', ''];
 
-  if (
-    countDecisions({ removed, divergences, nestedKeyUnparsed, failedChecks, unreadable }) === 0
-  ) {
+  const decisionTotal = countDecisions({
+    removed,
+    divergences,
+    nestedKeyUnparsed,
+    failedChecks,
+    unreadable,
+  });
+  if (decisionTotal === 0) {
     lines.push('Nothing in this refresh needs a decision — additions only.', '');
+  } else {
+    lines.push(
+      `**${decisionTotal} ${decisionTotal === 1 ? 'decision needs' : 'decisions need'} your ` +
+        `call**, labelled **D1**\u2013**D${decisionTotal}** below. They are spread across ` +
+        'sections because they arrive from different checks; the labels run straight through ' +
+        'so the count in the title can be reached from the body.',
+      ''
+    );
   }
+
+  // One running label per decision, ACROSS sections. Per-section numbering
+  // restarts and cannot be counted up to the total in the title, which is the
+  // only number a reader sees first — the PR that motivated this said
+  // "5 decisions needed" over four divergences and one failed check in two
+  // differently-shaped sections, and nothing in the body let a reader reach 5.
+  //
+  // Incremented at exactly the sites `countDecisions` counts, and the suite
+  // pins the last label against that total: a section that stops labelling, or
+  // one that labels something the count does not include, is a body that
+  // disagrees with its own title.
+  let decisionSeq = 0;
+  const D = () => `**D${++decisionSeq}.** `;
 
   if (autoTolerated.length > 0) {
     lines.push(
@@ -1066,7 +1092,7 @@ export function renderDiagnosis(input) {
 
   if (removed.length > 0) {
     lines.push(
-      '### Properties AWS removed — a decision is needed',
+      `### Properties AWS removed (${removed.length}) — a decision is needed`,
       '',
       'Each was in the previous snapshot, is not in this one, AND is declared by',
       'the provider — so the declaration is now bogus. Removals nothing declares',
@@ -1074,7 +1100,9 @@ export function renderDiagnosis(input) {
       ''
     );
     for (const entry of removed) {
-      lines.push(`- ${renderName(entry.resourceType)}`);
+      // One decision per TYPE, which is the unit `countDecisions` uses: a type
+      // losing three properties is settled by one judgement.
+      lines.push(`- ${D()}${renderName(entry.resourceType)}`);
       for (const property of entry.properties) {
         const candidates = entry.candidates[property] ?? [];
         const where =
@@ -1141,7 +1169,7 @@ export function renderDiagnosis(input) {
 
   if (divergences.length > 0) {
     lines.push(
-      '### Nested-key divergences — a decision is needed',
+      `### Nested-key divergences (${divergences.length}) — a decision is needed`,
       '',
       'Reported by the nested-key check, which reports divergences rather than',
       'staleness, so regenerating will not clear these.',
@@ -1150,7 +1178,7 @@ export function renderDiagnosis(input) {
     for (const d of divergences) {
       const detail = d.detail ? ` — ${renderDetail(d.detail)}` : '';
       lines.push(
-        `- ${renderName(d.resourceType)}: ${renderKey(d.nestedKey)} [${d.bucket}]${detail}`
+        `- ${D()}${renderName(d.resourceType)}: ${renderKey(d.nestedKey)} [${d.bucket}]${detail}`
       );
     }
     lines.push('', ...divergenceProcedure(divergences, sdkLag), '');
@@ -1162,7 +1190,7 @@ export function renderDiagnosis(input) {
     // is honest — both were tried, and the second is the exact silent-clean
     // verdict the whole job exists to prevent.
     lines.push(
-      '### The nested-key check reported something this report could not read',
+      `### ${D()}The nested-key check reported something this report could not read`,
       '',
       'It failed, or dropped findings, without printing lines this parser could',
       'read. That is one of its non-divergence refusals (a stale',
@@ -1188,7 +1216,7 @@ export function renderDiagnosis(input) {
     // `enrichment-coverage` — both fixture-driven, both CI-blocking, both
     // reachable by an ordinary schema ADDITION — reporting nothing. The next
     // one is a row in `CHECK_GUIDANCE` and a line in the workflow.
-    lines.push('### CI checks that FAILED — a decision is needed', '');
+    lines.push(`### CI checks that FAILED (${failedChecks.length}) — a decision is needed`, '');
     for (const check of failedChecks) {
       // `Object.hasOwn`, not a bare lookup: a plain object literal answers for
       // `constructor` / `toString` / `valueOf` with a FUNCTION, which the
@@ -1200,7 +1228,7 @@ export function renderDiagnosis(input) {
       // rejection placeholder — the section that exists to say WHICH check
       // failed naming none of them. Identical to the defect one section down,
       // one round earlier. `renderKey` adds its own backticks.
-      lines.push(`#### ${renderKey(check)}`, '');
+      lines.push(`#### ${D()}${renderKey(check)}`, '');
       lines.push(
         ...(guidance ?? [
           'This report carries no guidance for that check — read its job log.',
@@ -1270,7 +1298,7 @@ export function renderDiagnosis(input) {
       // which is also what every other section renders.
       ...unreadable.map(
         (/** @type {string} */ f) =>
-          `- ${renderName(f.replace(/\.json$/, '').replace(/-/g, '::'))}`
+          `- ${D()}${renderName(f.replace(/\.json$/, '').replace(/-/g, '::'))}`
       ),
       ''
     );

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -2459,7 +2459,7 @@ describe('--decision-count-out', () => {
       );
       expect(readFileSync(out, 'utf8').trim()).toBe('2');
       // And the report it was written beside agrees.
-      expect(md).toContain('### CI checks that FAILED — a decision is needed');
+      expect(md).toContain('### CI checks that FAILED (2) — a decision is needed');
       expect(md).not.toContain('Nothing in this refresh needs a decision');
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -3308,4 +3308,119 @@ describe('writeAutoTolerated', () => {
       ).toBe(true);
     }
   }, 60_000);
+});
+
+describe('the decision labels and the count cannot disagree', () => {
+  // The PR that motivated this said "5 decisions needed" in its title over
+  // four nested-key divergences and one failed check, rendered in two
+  // differently-shaped sections with no counts and no numbering — so the
+  // number a reader sees first could not be reached from the body at all.
+  //
+  // The labels run straight through the sections, and this is the fence that
+  // keeps them honest: a section that stops labelling, or one that labels
+  // something `countDecisions` does not count, is a body disagreeing with its
+  // own title. That is the exact class this file keeps finding elsewhere.
+  const REMOVED = {
+    resourceType: 'AWS::S3::Bucket',
+    properties: ['Gone', 'AlsoGone'],
+    candidates: {},
+    sdk: {},
+  };
+  const DIVERGENCE = {
+    resourceType: 'AWS::Glue::Connection',
+    nestedKey: 'OAuth2Credentials',
+    bucket: 'definition-member-missing',
+    detail: 'd',
+  };
+
+  /** Every `Dn` the report emits, in order. */
+  const labels = (md: string): number[] =>
+    [...md.matchAll(/\*\*D(\d+)\.\*\*/g)].map((m) => Number(m[1]));
+
+  const CASES: Array<[string, Record<string, unknown>]> = [
+    ['removed only', { removed: [REMOVED], divergences: [] }],
+    ['divergences only', { removed: [], divergences: [DIVERGENCE] }],
+    ['failed checks only', { removed: [], divergences: [], failedChecks: ['property-coverage'] }],
+    ['unparsed checker only', { removed: [], divergences: [], nestedKeyUnparsed: true }],
+    ['unreadable only', { removed: [], divergences: [], unreadable: ['AWS-S3-Bucket.json'] }],
+    [
+      'every kind at once',
+      {
+        removed: [REMOVED],
+        divergences: [DIVERGENCE, { ...DIVERGENCE, nestedKey: 'OtherKey' }],
+        failedChecks: ['property-coverage', 'audit:sdk-attr-coverage:check'],
+        nestedKeyUnparsed: true,
+        unreadable: ['AWS-S3-Bucket.json'],
+      },
+    ],
+    // The NON-decision sections, present so a stray label in one breaks the
+    // sequence. Without them a probe that numbered the auto-settled list — the
+    // direction where the body claims MORE decisions than the title — passed
+    // every case: the fence only saw sections that were already labelled.
+    [
+      'beside the sections that must NOT be labelled',
+      {
+        removed: [],
+        divergences: [DIVERGENCE],
+        autoTolerated: [
+          {
+            resourceType: 'AWS::Route53::RecordSet',
+            property: 'GeoProximityLocation',
+            rationale: 'settled by the job',
+          },
+        ],
+        autoEscalated: [
+          { resourceType: 'AWS::SQS::Queue', property: 'DelaySeconds', reason: 'could not tell' },
+        ],
+        writableAdded: [{ resourceType: 'AWS::S3::Bucket', properties: ['NewOne'] }],
+        skipped: ['AWS::Foo::Bar'],
+      },
+    ],
+  ];
+
+  for (const [name, extra] of CASES) {
+    it(`labels exactly as many decisions as it counts — ${name}`, () => {
+      const input = { writableAdded: [], skipped: [], ...extra };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const n = countDecisions(input as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const md = renderDiagnosis(input as any);
+      const seen = labels(md);
+      expect(n, `${name}: the case exercises no decision at all`).toBeGreaterThan(0);
+      expect(seen, `${name}: a section stopped labelling, or labelled twice`).toEqual(
+        Array.from({ length: n }, (_, i) => i + 1)
+      );
+      // And the index line a reader lands on first names the same range.
+      expect(md).toContain(`labelled **D1**–**D${n}**`);
+    });
+  }
+
+  it('says nothing about labels when there is nothing to decide', () => {
+    const md = renderDiagnosis({ removed: [], divergences: [], writableAdded: [], skipped: [] });
+    expect(md).toContain('Nothing in this refresh needs a decision');
+    expect(labels(md), 'a label was emitted with no decision behind it').toEqual([]);
+    expect(md).not.toContain('labelled **D1**');
+  });
+
+  it('gives every decision SECTION a count in its heading', () => {
+    // The settled and added sections already carried one; the decision ones did
+    // not, so the reader could not even total the sections up, let alone the
+    // items. Asserted as a property of the headings rather than a list, so a
+    // new decision section cannot ship without one.
+    const md = renderDiagnosis({
+      removed: [REMOVED],
+      divergences: [DIVERGENCE],
+      failedChecks: ['property-coverage'],
+      writableAdded: [],
+      skipped: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const decisionHeadings = md
+      .split('\n')
+      .filter((l) => l.startsWith('### ') && l.includes('a decision is needed'));
+    expect(decisionHeadings.length, 'no decision section rendered').toBeGreaterThan(0);
+    for (const h of decisionHeadings) {
+      expect(h, `decision section without a count: ${h}`).toMatch(/\(\d+\)/);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

PR go-to-k/cdkd#2784 landed titled `— 5 decisions needed` and the body did not support the number. The five were four `AWS::Glue::Connection` nested-key divergences and one failed check, rendered in two differently-shaped sections — bullets in one, `####` headings in the other — with **no counts on either heading and no numbering on any item**. The count is the first thing a reader sees, and nothing in the body let them reach it.

Every decision now carries a running label, `D1`…`Dn`, in the order it appears. The labels run **straight through** the sections rather than restarting: decisions arrive from five different checks in five different shapes, so a per-section number is not something anyone can add up. A line under the summary names the range, and each decision section carries its own count — which the settled and additions sections already had, so the inconsistency was that only the sections needing nothing were countable.

`nestedKeyUnparsed` and `unreadable` are labelled too. Neither renders a `### … a decision is needed` heading, which is exactly why a second, hand-written copy of this list would forget them.

## Before / after

```
before:  ### Nested-key divergences — a decision is needed
         - `AWS::Glue::Connection`: `OAuth2Credentials` [definition-member-missing] — …

after:   **5 decisions need your call**, labelled **D1**–**D5** below. …
         ### Nested-key divergences (4) — a decision is needed
         - **D1.** `AWS::Glue::Connection`: `OAuth2Credentials` [definition-member-missing] — …
```

## Test plan

- 941 files / 20,432 tests green; typecheck, `typecheck:test`, lint, format, build clean. No `src/` change.
- The labels are emitted at exactly the sites `countDecisions` counts, and a fence pins the emitted sequence against that total — for each kind of decision alone and for all five at once.
- Eight mutation probes over the labelling. **One survived and is worth naming**: numbering the auto-SETTLED list — which is not a decision, so the body would claim more than the title — passed, because every case the fence ran carried only sections that were already labelled. The fence now renders the non-decision sections beside them, and the same probe reds with `expected [ 1, 2 ] to deeply equal [ 1 ]`.
