### PR TITLE
chore(work-issues): floor the COMPARAND, not just the walk, and spell an injected defect the way its source does

### DIFF
--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -165,9 +165,14 @@ past drops orphans). Treat a large sweep as a **multi-session relay**:
   sweep'", and leave a project memory with the remaining list + findings.
 - The sweep is DONE only when `/pick-integ` shows no stale tests left; the
   committed ledger is the source of truth.
-- A `FAIL` that is fixture staleness (AWS retired an engine/instance tier the
-  fixture hardcodes) is NOT a cdkd bug — record it as such and queue a
-  fixture version-bump follow-up.
+- **A `FAIL` that never reached the fixture's assertions is not a cdkd bug** —
+  open the log before recording it. Two classes: fixture staleness (AWS
+  retired an engine/instance tier the fixture hardcodes), and a fixture whose
+  own previous run blocks the next, because it pins a name AWS holds a
+  cooldown on (`export` recreates one FIXED S3 bucket, so a second run inside
+  ~58 min dies at `OperationAborted` before phase 1 — go-to-k/cdkd#2796).
+  Record it as such, queue the fixture fix, and refresh the gate from a
+  SIBLING in the same set rather than re-running the blocked fixture.
 
 ## Important
 

--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -173,8 +173,8 @@ past drops orphans). Treat a large sweep as a **multi-session relay**:
   cooldown of UP TO ~58 min answers `OperationAborted` before phase 1 —
   measured at 10 min apart, go-to-k/cdkd#2796). Record it as such and queue
   the fixture fix. A gate needing a refresh takes a SIBLING from the broad
-  set above instead; the SWEEP does not — the blocked fixture still owes its
-  own ledger row, so re-schedule it after the window rather than counting it
+  set above instead; the SWEEP does not — the `FAIL` row keeps it a
+  candidate, so re-schedule it after the window rather than counting it
   covered.
 
 ## Important

--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -169,10 +169,13 @@ past drops orphans). Treat a large sweep as a **multi-session relay**:
   open the log before recording it. Two classes: fixture staleness (AWS
   retired an engine/instance tier the fixture hardcodes), and a fixture whose
   own previous run blocks the next, because it pins a name AWS holds a
-  cooldown on (`export` recreates one FIXED S3 bucket, so a second run inside
-  ~58 min dies at `OperationAborted` before phase 1 — go-to-k/cdkd#2796).
-  Record it as such, queue the fixture fix, and refresh the gate from a
-  SIBLING in the same set rather than re-running the blocked fixture.
+  cooldown on (`export` recreates one FIXED S3 bucket, and S3's same-name
+  cooldown of UP TO ~58 min answers `OperationAborted` before phase 1 —
+  measured at 10 min apart, go-to-k/cdkd#2796). Record it as such and queue
+  the fixture fix. A gate needing a refresh takes a SIBLING from the broad
+  set above instead; the SWEEP does not — the blocked fixture still owes its
+  own ledger row, so re-schedule it after the window rather than counting it
+  covered.
 
 ## Important
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -16,11 +16,10 @@ Never edit in the main checkout (`main-tree-branch-gate` blocks branching
 there). Per lane:
 
 ```bash
-# MAIN-CHECKOUT mode only. IN-PLACE (launched inside a linked worktree) skips
-# these two and creates NO WORKTREE -- nesting dies with the outer workspace
-# (go-to-k/cdkd#2390). It DOES still take a branch, in place: see the branch
-# recipe below, which is unconditional. (The probe lives in
-# references/launch-mode.md, its only copy.)
+# MAIN-CHECKOUT mode only; CLAUDE.md holds this recipe and why IN-PLACE
+# (launched inside a linked worktree) creates NO worktree. IN-PLACE skips
+# these two and still takes a branch, by the unconditional recipe below.
+# (The mode probe lives in references/launch-mode.md, its only copy.)
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 cd .claude/worktrees/<branch>
 mise trust && mise install   # untrusted .mise.toml: vp / markgate will not resolve
@@ -282,11 +281,6 @@ applied literally that refuses every EMPTY bucket, so the third probe applied
 the issue's own prescription and one test went red. Write that control before
 writing the paragraph that explains why you did not do what was asked.
 
-**Choose the probe's INPUT to discriminate too** — a mask-before-stringify
-fix probed with a SCALAR secret came back green under its own motivating
-mutation; only a JSON-document secret makes the needle stop occurring. Ask
-what property of the INPUT the defect depends on.
-
 **A probe MATRIX that must recur is a SCRIPT, not a re-measured table** —
 §8-g's "delete the number" disposition. Re-measuring on the merge tree was
 already the rule and a table went stale TWICE in one lane anyway, a reviewer
@@ -310,12 +304,18 @@ and report the HIT's own line.
 **Calibration is HALF the measurement — follow it with probes against the
 real tree:**
 
-- **Write the defect in the spelling a PERSON would write**, not the easiest
-  to inject (a fence split on quote characters caught its own probe and
-  missed the spelling anybody would type — go-to-k/cdkd#2052).
-- **Write the defect in every spelling the language allows** (a scanner
-  matched `||` only while the tree used `??` at four sites; widening it
-  surfaced a real unfiled bug — go-to-k/cdkd#2111).
+- **Spell the injected defect the way its SOURCE would** — not the easiest to
+  inject, nor one you have proved you can see. Four wrong choices: the line
+  you just removed (a fence caught it, missing computed members,
+  `Object.assign`, a literal, a spread rebuild); the injectable spelling over
+  the one a PERSON types (go-to-k/cdkd#2052); one spelling where the language
+  allows several (`||` matched while four sites used `??`, and widening it
+  found a real bug — go-to-k/cdkd#2111); and, for GENERATED input, the
+  UPSTREAM form over the generator's output (go-to-k/cdkd#2788 injected
+  `/properties/X`, a prefix the generator strips, so the probe "proving" it
+  discriminated used a shape the repo never holds). Same for a probe's VALUE
+  input (a mask-before-stringify fix stayed green under its own mutation
+  until the secret was a JSON document, not a scalar).
 - **Delete the thing the fence REQUIRES and watch it fail.** An OR of
   whole-file substrings is satisfied by any one; a population derived from
   the DEFECT itself drops the subject out instead of failing (a gate-parity
@@ -324,14 +324,14 @@ real tree:**
   annotation, an explicit return type, `implements`) is derivable-around for
   free — derive from a relation the write CANNOT omit, and ask: what would
   this look like if the author did not write the optional part?
-- **Probe the fence with the evasions the DEFECT would use**, not the one you
-  just fixed — the removed line is the one spelling you have proved you can
-  see (a fence caught its own removed line and missed computed members,
-  `Object.assign`, an object literal and a spread rebuild).
 - **Watch the FLOOR for the same collapse** — a floor naming only the file
   the defect lives in is satisfied BY the collapse; a floor computed from the
   pool it guards is unfalsifiable (emptying the pool left it green). Write
-  the expected count as a LITERAL from a source the fence does not read.
+  the expected count as a LITERAL from a source the fence does not read. **A
+  RELATION also needs a floor on the COMPARAND** — walk floors count what you
+  ITERATED, and a set-vs-set claim is vacuously TRUE when the other operand
+  parses empty (go-to-k/cdkd#2788: 134 fixtures compared nothing under two
+  healthy walk floors, and the invariant read correctly was FALSE).
 - **Is anything RUNNING it?** (nine shell hook harnesses were invoked by no
   CI step and no task — exercised only by hand since written).
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -16,10 +16,10 @@ Never edit in the main checkout (`main-tree-branch-gate` blocks branching
 there). Per lane:
 
 ```bash
-# MAIN-CHECKOUT only; CLAUDE.md holds this recipe and why IN-PLACE (launched
-# inside a linked worktree) creates NO worktree. IN-PLACE skips these two and
-# still branches, by the unconditional recipe below. (The mode probe lives in
-# references/launch-mode.md, its only copy.)
+# MAIN-CHECKOUT only; CLAUDE.md holds this recipe and why IN-PLACE (in a
+# linked worktree) creates NO worktree. IN-PLACE skips these two and branches
+# by the unconditional recipe below. (Mode probe: references/launch-mode.md,
+# its only copy.)
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 cd .claude/worktrees/<branch>
 mise trust && mise install   # untrusted .mise.toml: vp / markgate will not resolve
@@ -305,12 +305,13 @@ and report the HIT's own line.
 real tree:**
 
 - **Spell the injected defect the way its SOURCE would** — not the easiest to
-  inject, nor one you have proved you can see. Every wrong spelling in turn:
-  the line you just removed (a fence caught that while missing computed
-  members, `Object.assign`, an object literal, a spread); the injectable
+  inject, nor one you have proved you can see. Four wrong choices: the line
+  you just removed (a fence caught that while missing computed members,
+  `Object.assign`, an object literal, a spread rebuild); the injectable
   spelling over the one a PERSON types (go-to-k/cdkd#2052); one spelling
-  where the language allows several (`||` matched while four sites used `??`;
-  widening it found a bug — go-to-k/cdkd#2111); and, for GENERATED input, the
+  where the language allows several — probe each (`||` matched while four
+  sites used `??`; widening it found a real unfiled bug —
+  go-to-k/cdkd#2111); and, for GENERATED input, the
   UPSTREAM form not the generator's output (go-to-k/cdkd#2788 injected
   `/properties/X`, a prefix the generator strips, so the probe "proving" it
   discriminated used a shape no fixture holds). It governs any probe's VALUE
@@ -332,7 +333,7 @@ real tree:**
   RELATION also needs a floor on the COMPARAND** — walk floors count what you
   ITERATED, and a set-vs-set claim is vacuously TRUE when the other operand
   parses empty (go-to-k/cdkd#2788: 134 fixtures compared nothing under two
-  healthy walk floors; the invariant was FALSE).
+  healthy walk floors; the invariant as stated was FALSE).
 - **Is anything RUNNING it?** (nine shell hook harnesses were invoked by no
   CI step and no task — exercised only by hand since written).
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -16,10 +16,10 @@ Never edit in the main checkout (`main-tree-branch-gate` blocks branching
 there). Per lane:
 
 ```bash
-# MAIN-CHECKOUT mode only; CLAUDE.md holds this recipe and why IN-PLACE
-# (launched inside a linked worktree) creates NO worktree. IN-PLACE skips
-# these two and still takes a branch, by the unconditional recipe below.
-# (The mode probe lives in references/launch-mode.md, its only copy.)
+# MAIN-CHECKOUT only; CLAUDE.md holds this recipe and why IN-PLACE (launched
+# inside a linked worktree) creates NO worktree. IN-PLACE skips these two and
+# still branches, by the unconditional recipe below. (The mode probe lives in
+# references/launch-mode.md, its only copy.)
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 cd .claude/worktrees/<branch>
 mise trust && mise install   # untrusted .mise.toml: vp / markgate will not resolve
@@ -305,17 +305,18 @@ and report the HIT's own line.
 real tree:**
 
 - **Spell the injected defect the way its SOURCE would** — not the easiest to
-  inject, nor one you have proved you can see. Four wrong choices: the line
-  you just removed (a fence caught it, missing computed members,
-  `Object.assign`, a literal, a spread rebuild); the injectable spelling over
-  the one a PERSON types (go-to-k/cdkd#2052); one spelling where the language
-  allows several (`||` matched while four sites used `??`, and widening it
-  found a real bug — go-to-k/cdkd#2111); and, for GENERATED input, the
-  UPSTREAM form over the generator's output (go-to-k/cdkd#2788 injected
+  inject, nor one you have proved you can see. Every wrong spelling in turn:
+  the line you just removed (a fence caught that while missing computed
+  members, `Object.assign`, an object literal, a spread); the injectable
+  spelling over the one a PERSON types (go-to-k/cdkd#2052); one spelling
+  where the language allows several (`||` matched while four sites used `??`;
+  widening it found a bug — go-to-k/cdkd#2111); and, for GENERATED input, the
+  UPSTREAM form not the generator's output (go-to-k/cdkd#2788 injected
   `/properties/X`, a prefix the generator strips, so the probe "proving" it
-  discriminated used a shape the repo never holds). Same for a probe's VALUE
-  input (a mask-before-stringify fix stayed green under its own mutation
-  until the secret was a JSON document, not a scalar).
+  discriminated used a shape no fixture holds). It governs any probe's VALUE
+  input too — ask what property of it the defect depends on (a
+  mask-before-stringify fix stayed green under its own mutation until the
+  secret was a JSON document, not a scalar).
 - **Delete the thing the fence REQUIRES and watch it fail.** An OR of
   whole-file substrings is satisfied by any one; a population derived from
   the DEFECT itself drops the subject out instead of failing (a gate-parity
@@ -331,7 +332,7 @@ real tree:**
   RELATION also needs a floor on the COMPARAND** — walk floors count what you
   ITERATED, and a set-vs-set claim is vacuously TRUE when the other operand
   parses empty (go-to-k/cdkd#2788: 134 fixtures compared nothing under two
-  healthy walk floors, and the invariant read correctly was FALSE).
+  healthy walk floors; the invariant was FALSE).
 - **Is anything RUNNING it?** (nine shell hook harnesses were invoked by no
   CI step and no task — exercised only by hand since written).
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -134,24 +134,28 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // 176,352 the floor below was derived against. Recorded rather than
     // re-deriving the floor each time: the margins stayed POSITIVE throughout
     // (479 largest-side, 252 binding), so only this measurement moved.
-    // 176,654 after the go-to-k/cdkd#2750 retro added two rules to
+    // 176,660 after the go-to-k/cdkd#2750 retro added two rules to
     // implement.md 5-f' -- the COMPARAND floor and the injected-defect
-    // spelling. Components: implement.md 28,743 -> 28,933 (+190); no other
-    // stage file touched, so the corpus moves by the same +190. Within the
-    // file, measured per hunk: the COMPARAND rule is +284 and the merged
-    // spelling bullet +241, against -276 for deleting 5-e's probe-INPUT
+    // spelling. Components: implement.md 28,743 -> 28,939 (+196); no other
+    // stage file touched, so the corpus moves by the same +196. Within the
+    // file, measured per hunk: the COMPARAND rule is +294 and the merged
+    // spelling bullet +269, against -276 for deleting 5-e's probe-INPUT
     // bullet (its rule moved into that merged bullet, which now folds THREE
-    // 5-f' bullets plus it into one) and -59 for the 5-a comment's
-    // restatement of the IN-PLACE rationale CLAUDE.md owns -- so 335 B of the
-    // 525 B added is paid, and the merge is what makes the pair cheaper than
+    // 5-f' bullets plus it into one) and -91 for the 5-a comment's
+    // restatement of the IN-PLACE rationale CLAUDE.md owns -- so 367 B of the
+    // 563 B added is paid, and the merge is what makes the pair cheaper than
     // two fresh bullets rather than a saving in itself. The floor below is
     // NOT raised: retro.md section 10-c forbids a retro buying room that way.
-    // Margins now 479 largest-side and 62 binding -- the thinnest this record
-    // has held, so the next edit to implement.md opens with a compression
-    // pass and not an addition; verify.md has 384 B before it overtakes as
-    // largest, and growth there does not move the binding margin at all.
-    corpusBytes: 176_654,
-    largest: { file: 'implement.md', bytes: 28_933 },
+    // Margins now 479 largest-side and 56 binding -- the thinnest since the
+    // floor was re-derived to 148,200, which that lane left at 364 and the
+    // entry above at 252. So the next edit to implement.md opens with a
+    // compression pass and not an addition. No crossover projection is stated
+    // here on purpose: a review round caught this comment quoting one that
+    // was stale by exactly this round's own delta, and the failure messages
+    // below already PRINT both live margins and the leader's cap headroom,
+    // which is the number to plan against.
+    corpusBytes: 176_660,
+    largest: { file: 'implement.md', bytes: 28_939 },
     runnerUp: { file: 'verify.md', bytes: 28_516 },
   },
 };

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -133,9 +133,17 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // 176,464 after two rounds of review reworded ship.md, on top of the
     // 176,352 the floor below was derived against. Recorded rather than
     // re-deriving the floor each time: the margins stayed POSITIVE throughout
-    // (now 479 largest-side, 252 binding), so only this measurement moved.
-    corpusBytes: 176_464,
-    largest: { file: 'implement.md', bytes: 28_743 },
+    // (479 largest-side, 252 binding), so only this measurement moved.
+    // 176,621 after the go-to-k/cdkd#2750 retro added two rules to
+    // implement.md 5-f' -- the COMPARAND floor and the injected-defect
+    // spelling. The floor below is NOT raised: retro.md section 10-c forbids a
+    // retro buying room that way, so the +157 B was paid for by merging four
+    // near-duplicate probe bullets into one (5-e's probe-INPUT bullet moved
+    // into 5-f''s list) and by cutting the worktree recipe CLAUDE.md already
+    // states verbatim. Margins now 479 largest-side and 95 binding -- thin, so
+    // the next round here opens by compressing rather than adding.
+    corpusBytes: 176_621,
+    largest: { file: 'implement.md', bytes: 28_900 },
     runnerUp: { file: 'verify.md', bytes: 28_516 },
   },
 };

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -134,16 +134,24 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // 176,352 the floor below was derived against. Recorded rather than
     // re-deriving the floor each time: the margins stayed POSITIVE throughout
     // (479 largest-side, 252 binding), so only this measurement moved.
-    // 176,621 after the go-to-k/cdkd#2750 retro added two rules to
+    // 176,654 after the go-to-k/cdkd#2750 retro added two rules to
     // implement.md 5-f' -- the COMPARAND floor and the injected-defect
-    // spelling. The floor below is NOT raised: retro.md section 10-c forbids a
-    // retro buying room that way, so the +157 B was paid for by merging four
-    // near-duplicate probe bullets into one (5-e's probe-INPUT bullet moved
-    // into 5-f''s list) and by cutting the worktree recipe CLAUDE.md already
-    // states verbatim. Margins now 479 largest-side and 95 binding -- thin, so
-    // the next round here opens by compressing rather than adding.
-    corpusBytes: 176_621,
-    largest: { file: 'implement.md', bytes: 28_900 },
+    // spelling. Components: implement.md 28,743 -> 28,933 (+190); no other
+    // stage file touched, so the corpus moves by the same +190. Within the
+    // file, measured per hunk: the COMPARAND rule is +284 and the merged
+    // spelling bullet +241, against -276 for deleting 5-e's probe-INPUT
+    // bullet (its rule moved into that merged bullet, which now folds THREE
+    // 5-f' bullets plus it into one) and -59 for the 5-a comment's
+    // restatement of the IN-PLACE rationale CLAUDE.md owns -- so 335 B of the
+    // 525 B added is paid, and the merge is what makes the pair cheaper than
+    // two fresh bullets rather than a saving in itself. The floor below is
+    // NOT raised: retro.md section 10-c forbids a retro buying room that way.
+    // Margins now 479 largest-side and 62 binding -- the thinnest this record
+    // has held, so the next edit to implement.md opens with a compression
+    // pass and not an addition; verify.md has 384 B before it overtakes as
+    // largest, and growth there does not move the binding margin at all.
+    corpusBytes: 176_654,
+    largest: { file: 'implement.md', bytes: 28_933 },
     runnerUp: { file: 'verify.md', bytes: 28_516 },
   },
 };


### PR DESCRIPTION
## Summary

`/work-issues` retrospective (§10) for the run that took go-to-k/cdkd#2750 end
to end and merged it as go-to-k/cdkd#2788. Two rules land in
`references/implement.md` section 5-f' — where a lane builds a repo-wide check
— and one in `/pick-integ`.

## The evidence

**A fence shipped VACUOUS and its own discrimination probe validated the wrong
thing.** `tests/unit/provisioning/silent-drop-guard-key-disjointness.test.ts`
asserted `silentDrop ∩ createOnlyProperties = ∅`, parsing the schema fixtures'
`createOnlyProperties` as `/properties/<Name>` pointers.
`scripts/refresh-cfn-schemas.mjs` already strips that prefix, so the comparand
was EMPTY for all 134 fixtures and the case compared nothing. Read correctly the
invariant is FALSE — 80 pairs over 24 types. The fence's two coverage floors
(`typesRead`, `dropsChecked`) were both healthy: they watched the WALK. The
violation injected to prove the case discriminated was itself `/properties/X`, a
shape no fixture holds. Two independent reviewers found it; no floor did.

**A broad-set integ could not run twice in an hour.** `export` pins one FIXED S3
bucket name, so the ~58 min same-name cooldown killed two attempts ten minutes
apart before their assertions (go-to-k/cdkd#2796). The ledger row reads `FAIL`,
which looks like a fix regression until the log is opened.

## What changed

- **`references/implement.md` 5-f' — a RELATION also needs a floor on the
  COMPARAND.** Walk floors count what you ITERATED; a set-vs-set claim is
  vacuously TRUE when the other operand parses empty. Added to the existing
  "Watch the FLOOR for the same collapse" bullet, which was about a floor
  derived from its own pool — a different collapse.
- **`references/implement.md` 5-f' — spell the injected defect the way its
  SOURCE would.** Four near-duplicate statements of one rule are now ONE bullet:
  not the line you just removed, not the injectable spelling over the one a
  person types, not one spelling where the language allows several, and — new —
  not the UPSTREAM form where the input is GENERATED. 5-e's "Choose the probe's
  INPUT to discriminate too" moved into it rather than sitting a section away
  saying the same thing.
- **`.claude/skills/pick-integ/SKILL.md`** — the `FAIL`-triage line now covers
  any FAIL that never reached the fixture's assertions, adds the
  self-cooldowning-fixture class with the `export` measurement, and says to
  refresh the gate from a SIBLING in the same set rather than re-running the
  blocked fixture.

## Paid for by compression, not by a raised bound

retro.md 10-c forbids a retro buying room by raising a cap or a corpus bound, and
the work-issues corpus floor had 252 B of binding margin. Net cost is **+196 B**,
all of it in implement.md; no other stage file is touched. Per hunk: the
COMPARAND rule +294 and the merged spelling bullet +269, against -276 for
deleting 5-e's probe-INPUT bullet (its rule moved into that merged bullet, which
folds three 5-f' bullets plus it into one) and -91 for the 5-a comment's
restatement of the IN-PLACE rationale CLAUDE.md owns (10-c: do not restate a rule
CLAUDE.md holds — it is injected into every context). So 367 B of the 563 B added
is paid; the merge is what makes the pair cheaper than two fresh bullets, not a
saving in itself.

`MIN_REFERENCE_CORPUS_BYTES` stays at 148,200. MEASURED is updated to corpus
176,660 / implement.md 28,939 / verify.md 28,516, and the new margins — 479
largest-side, **56 binding**, the thinnest since the floor was re-derived to
148,200 — are recorded beside it with the instruction that the next edit to
implement.md opens with a compression pass, not an addition. The entry states
no crossover projection: a review round caught one that had gone stale by
exactly its own round's delta, and the assertion's failure messages already
print both live margins.

## Deliberate non-changes

- **verify.md §8-a held.** Rounds 2 and 4 each found a blocker inside the
  previous round's fix, both in prose rather than code, and round 4 converged by
  making the message CLAIM LESS instead of gaining a fourth condition — which is
  what §8-a already prescribes. Adding a second citation to a bullet that worked
  is the appending pattern 10-c forbids.
- **gates-and-pr.md §6 held** on the gated-command preamble: a `git commit -F`
  refused because the heredoc writing the file shared the Bash call is the
  documented behaviour, down to "write the file in one call, run the gated
  command in the next".
- **ship.md's CUMULATIVE BUDGET paragraph is not extended.** The rules-corpus
  fence failed twice on the projection because a peer merged mid-run, and both
  times it was funded from this change's own prose. The missing disposition —
  measure `origin/main` alone before paying, because the overrun may not be
  yours — is the subject of open issue go-to-k/cdkd#2310, whose headline number
  is now stale: `origin/main` measures 995,881 B against a 996,000 B ceiling,
  119 B of headroom. Posted there as a comment rather than duplicated into a
  stage file already at its bound.
- **No `.claude/rules/**` edit.** The comparand rule's natural home is
  `.claude/rules/testing.md` → "A checker must prove it sees its input", which
  prescribes floors per input SHAPE and is silent on the comparand. With 119 B
  of corpus headroom it cannot hold a new rule, and funding it would mean
  trimming another entry — which the corpus FLOOR exists to forbid. The rule
  landed in the skill stage where it fires instead.

## Test plan

- `vp test run` — 945 files / 20,486 tests, 0 failures, no type errors; re-run
  in full after the review round (the short round skips `typecheck:test`).
- `skill-file-payload.test.ts`, `work-issues-launch-mode.test.ts`,
  `work-issues-skill-refs.test.ts`, `rule-file-payload.test.ts` — 428 tests,
  green. The launch-mode fences are the ones that could break on the 5-a
  compression: both mode tokens, the `ALWAYS, and WITHOUT leaving the tree` pin
  and the `git fetch origin && git switch -c <branch> origin/main` recipe are
  untouched.
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — clean, nothing
  regenerated.
- No `src/**` change, so no changelog entry (go-to-k/cdkd#2779) and no integ
  gate is in scope.

## Review

Two reviewers in parallel — a spec reviewer against retro.md 10-a/10-b/10-c/10-d
and a code reviewer on the numbers and the prose-vs-code claims. No blockers from
either; every factual claim was verified against the artifacts and the
rule-loss audit found nothing dropped by the four-into-one merge. Seven minor
items were taken, and the two that matter are corrections to THIS PR's own
record:

- the MEASURED comment's payment claim was false in both halves — the merge is
  +241 B rather than a saving, and the worktree recipe was not cut (the 5-a
  comment's restatement of the IN-PLACE rationale was). On the one file whose
  subject is comment claims going stale, that is the class it exists to catch;
- the entry carried no per-file COMPONENTS, which lines 386-393 of the same file
  mandate.

Also restored: the probe-INPUT rule's actionable close and its scope beyond
scanner work (it had narrowed by moving under 5-f''s heading), and `/pick-integ`
now says the S3 cooldown is UP TO ~58 min with the repro measured 10 min apart,
with separate answers for refreshing a GATE (take a broad-set sibling) and for
the staleness SWEEP (the `FAIL` row keeps the fixture a candidate).

A third round then reviewed the second, and found two blockers in the comment
the second had just corrected — a crossover projection stale by exactly that
round's own delta, and a "thinnest this record has held" superlative the file's
own history falsifies (31 B, 40 B, 52 B, 54 B). Both are the class this PR is
about, arriving in its own record; the projection is deleted rather than
corrected a second time. That round also restored four words earlier
compressions had dropped — `a real unfiled bug`, `a spread rebuild`, `the
invariant AS STATED was FALSE`, and the bullet's label, where "Every wrong
spelling in turn" headed a list of things NOT to do.

## Mirrors

10-c's default is landing a flow lesson in all three repos. This session could
not pay cdk-local's and cdk-real-drift's own gate cycles on top of cdkd's, and
the copy has to be re-derived against each repo's files rather than pasted, so
it took 10-c's filing fallback: go-to-k/cdk-local#715 and
go-to-k/cdk-real-drift#1896, each naming the other and this PR, both resolved
first against that repo's merged file, open PRs and open issues.
