### PR TITLE
chore(hooks): refuse the Bash arm alone when the matcher will not load, so the gate cannot take away its own repair

### DIFF
--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -861,15 +861,20 @@ gate_segments_raw() {
           #
           # NO APOSTROPHE APPEARS IN THIS COMMENT. The whole awk program is ONE
           # single-quoted shell word, so one apostrophe ends that word and
-          # leaves the library unparseable -- which fails every gate CLOSED,
-          # including the one matching Edit and Write, so the ability to repair
-          # the file goes with it. That happened FIVE times while this branch
-          # was written, and the fifth was this very comment, in the draft that
-          # described the hazard. Do not read that as carelessness to be
-          # corrected by care: the hazard is structural, and go-to-k/cdkd#2717
-          # proposes the structural fix (the Edit and Write arms read
-          # tool_input.file_path and need no matcher, so only the Bash arm has
-          # any reason to fail closed on it).
+          # leaves the library unparseable -- which fails every gate CLOSED.
+          # That happened FIVE times while this branch was written, and the
+          # fifth was this very comment, in the draft that described the
+          # hazard. Do not read that as carelessness to be corrected by care:
+          # the hazard is structural.
+          #
+          # It no longer takes the ability to repair the file with it.
+          # go-to-k/cdkd#2717 SHIPPED the structural fix: main-tree-edit-gate --
+          # the one hook matching Edit and Write as well as Bash -- refuses only
+          # in its `Bash` arm, because the file-path arm reads the target from
+          # the payload (`tool_input.file_path`, or `notebook_path` for
+          # NotebookEdit) and needs no matcher at all. So a library you have
+          # just broken is still editable with the Edit and Write tools from a
+          # feature worktree.
           #
           # A retry stood here whose own comment said it repaired a backtick
           # body whose number-sign comment carries one apostrophe. It did the

--- a/.claude/hooks/main-tree-edit-gate.sh
+++ b/.claude/hooks/main-tree-edit-gate.sh
@@ -65,33 +65,50 @@ __hook_dir="${BASH_SOURCE[0]%/*}"
 # `%/*` leaves the string unchanged when the path has no slash (invoked as
 # `bash main-tree-edit-gate.sh` from inside the hooks dir).
 [ "$__hook_dir" = "${BASH_SOURCE[0]}" ] && __hook_dir="."
+__lib_loaded=1
 if ! . "$__hook_dir/lib/command-match.sh" 2>/dev/null \
   || ! declare -F gate_unquote_span >/dev/null \
   || ! declare -F gate_unquote >/dev/null \
   || ! declare -F gate_segments_marked >/dev/null; then
-  # FAIL CLOSED, as every other blocking gate does: a hook that cannot parse
-  # the command cannot say the edit is safe, and `|| exit 0` on an unloadable
-  # library is the shape that made twelve sibling gates inert
-  # (go-to-k/cdkd#2027).
+  __lib_loaded=0
+fi
+
+# The refusal is DEFERRED to the `Bash` arm, and that is the whole point of
+# separating these two statements.
+#
+# FAIL CLOSED is still right for `Bash`: a hook that cannot parse the command
+# cannot say the write is safe, and `|| exit 0` on an unloadable library is the
+# shape that made twelve sibling gates inert (go-to-k/cdkd#2027).
+#
+# But this hook's matcher is `Edit|Write|Bash`, and refusing at LOAD time
+# refused all three at once -- taking away the tools the library is repaired
+# with. That happened four times in one session (go-to-k/cdkd#2650), three of
+# them from a single apostrophe inside a comment in the library's awk program,
+# and each time the maintainer had to run the repair from their own shell. A
+# safety mechanism must not be able to remove the operator's means of repair.
+#
+# The asymmetry that makes the split sound: the `Edit|Write|MultiEdit` arm reads
+# `tool_input.file_path` through `jq` and calls NO library function -- the path
+# arrives already expanded, so there is no shell text to parse. Only the `Bash`
+# arm needs the matcher, so only the `Bash` arm fails closed on it. Everything
+# between here and the dispatch is variable assignments and function
+# definitions, so nothing runs against the missing functions in between.
+#
+# Refusing EVERY Bash call rather than only the ones it would have parsed is
+# deliberate: deciding which calls are safe is the parse it cannot do.
+__refuse_unloadable_library() {
   echo "Blocked: .claude/hooks/lib/command-match.sh is missing or unloadable," >&2
   echo "so main-tree-edit-gate cannot resolve the command's working directory." >&2
   echo "Restore the file; do not work around the gate." >&2
-  # THIS HOOK MATCHES Edit AND Write AS WELL AS Bash, so an unloadable library
-  # takes away the three tools an agent would repair it with. Fail-closed is
-  # still right -- a gate that cannot parse the command cannot bless the edit --
-  # but a refusal with no way out reads as a broken harness rather than a
-  # working gate, so it has to name the one route that does not weaken it: a
-  # human running the fix in their own shell. In Claude Code that is the `!`
-  # prefix in the prompt. Measured the hard way (go-to-k/cdkd#2650): an
-  # apostrophe inside a comment in the library's awk program closed the shell
-  # string, and the session that wrote it could not undo it.
   echo "" >&2
-  echo "If you are an agent and Edit/Write/Bash are all refused, you cannot fix" >&2
-  echo "this yourself -- that is by design. Ask the operator to run the repair" >&2
-  echo "from their own shell (in Claude Code, prefix the command with '!')." >&2
-  echo "Check it first with: bash -n .claude/hooks/lib/command-match.sh" >&2
+  echo "Only Bash is refused. This hook's Edit and Write arms read the target" >&2
+  echo "path directly and need no shell parsing, so they still work -- repair" >&2
+  echo "lib/command-match.sh with the Edit or Write tool. A Bash call that is" >&2
+  echo "no longer refused is the proof it loaded; until then run any syntax" >&2
+  echo "check as the operator ('!' prefixed, in Claude Code):" >&2
+  echo "  bash -n .claude/hooks/lib/command-match.sh" >&2
   exit 2
-fi
+}
 
 # Every `cd` target in the RAW command text becomes an additional base for every
 # candidate already collected. Used wherever the walk's own `cd` following is
@@ -327,6 +344,10 @@ case "$tool" in
     [[ -n "$fp" ]] && candidates+=("$fp")
     ;;
   Bash)
+    # Before anything is read off the command: without the matcher this arm
+    # cannot resolve a `cd`, and an unresolved `cd` is the difference between
+    # "the write is outside the repo" and "the write lands in the main tree".
+    [ "$__lib_loaded" = 1 ] || __refuse_unloadable_library
     cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
     [[ -z "$cmd" ]] && exit 0
     # AN ORDERED WALK OVER `gate_segments_marked`. Each segment either updates

--- a/.claude/hooks/main-tree-edit-gate.sh
+++ b/.claude/hooks/main-tree-edit-gate.sh
@@ -96,17 +96,28 @@ fi
 #
 # Refusing EVERY Bash call rather than only the ones it would have parsed is
 # deliberate: deciding which calls are safe is the parse it cannot do.
+#
+# ONE arm is neither of the two: a `tool_name` this hook cannot classify -- a
+# malformed payload, or `jq` missing as well -- falls through the `case` to `*)`
+# and exits 0, where the load-time refusal used to catch it. That is accepted
+# rather than overlooked. Refusing in `*)` means refusing a payload whose tool is
+# UNKNOWN, which puts Edit and Write back inside the refusal the moment `jq`
+# breaks too -- the lockout again, arriving by a second route. It costs nothing
+# real: the registered matcher is `Edit|Write|Bash`, so `*)` is unreachable for
+# any tool this hook is actually invoked on.
 __refuse_unloadable_library() {
   echo "Blocked: .claude/hooks/lib/command-match.sh is missing or unloadable," >&2
   echo "so main-tree-edit-gate cannot resolve the command's working directory." >&2
   echo "Restore the file; do not work around the gate." >&2
   echo "" >&2
   echo "Only Bash is refused. This hook's Edit and Write arms read the target" >&2
-  echo "path directly and need no shell parsing, so they still work -- repair" >&2
-  echo "lib/command-match.sh with the Edit or Write tool. A Bash call that is" >&2
-  echo "no longer refused is the proof it loaded; until then run any syntax" >&2
-  echo "check as the operator ('!' prefixed, in Claude Code):" >&2
+  echo "path directly and need no shell parsing, so FROM A FEATURE WORKTREE you" >&2
+  echo "can repair lib/command-match.sh with the Edit or Write tool." >&2
+  echo "In the main tree on main this gate refuses that edit as well -- for its" >&2
+  echo "own separate reason -- so there the repair is the operator's, run from" >&2
+  echo "their own shell ('!' prefixed, in Claude Code):" >&2
   echo "  bash -n .claude/hooks/lib/command-match.sh" >&2
+  echo "A Bash call that is no longer refused is the proof the library loaded." >&2
   exit 2
 }
 

--- a/.claude/hooks/main-tree-edit-gate.sh
+++ b/.claude/hooks/main-tree-edit-gate.sh
@@ -28,7 +28,11 @@
 #   sanctioned `.claude/worktrees/<branch>/` flow is never blocked.
 #
 # Candidate targets by tool:
-#   - Edit / Write: `tool_input.file_path` (reliable).
+#   - Edit / Write / MultiEdit / NotebookEdit: `tool_input.file_path`,
+#     falling back to `tool_input.notebook_path` (reliable). The last
+#     two reach this hook because a matcher is an UNANCHORED REGEX and
+#     `Edit|Write|Bash` matches the substring; NotebookEdit is the one
+#     that sends `notebook_path` instead of `file_path`.
 #   - Bash: best-effort scan of `tool_input.command` for LITERAL
 #     write targets — `> f`, `>> f`, `tee [-a] f`, `sed -i ... f`,
 #     `cp <src> f`, `mv <src> f`. Variable-indirected targets
@@ -87,8 +91,8 @@ fi
 # and each time the maintainer had to run the repair from their own shell. A
 # safety mechanism must not be able to remove the operator's means of repair.
 #
-# The asymmetry that makes the split sound: the `Edit|Write|MultiEdit` arm reads
-# `tool_input.file_path` through `jq` and calls NO library function -- the path
+# The asymmetry that makes the split sound: the file-path arm (all four labels)
+# reads its target through `jq` and calls NO library function -- the path
 # arrives already expanded, so there is no shell text to parse. Only the `Bash`
 # arm needs the matcher, so only the `Bash` arm fails closed on it. Everything
 # between here and the dispatch is variable assignments and function
@@ -122,10 +126,10 @@ __refuse_unloadable_library() {
   echo "" >&2
   echo "Only Bash is refused. This hook's Edit and Write arms read the target" >&2
   echo "path directly and need no shell parsing, so FROM A FEATURE WORKTREE you" >&2
-  echo "can repair it with the Edit or Write tool -- that route is still open." >&2
+  echo "can repair the library with the Edit or Write tool -- that route is open." >&2
   echo "In the main tree on main this gate refuses that edit too, for its own" >&2
   echo "separate reason, so there the repair belongs to the operator, made from" >&2
-  echo "their own shell. To inspect the file first ('!' prefixed, in Claude Code):" >&2
+  echo "their own shell ('!' prefixed, in Claude Code). To inspect it first:" >&2
   echo "  bash -n .claude/hooks/lib/command-match.sh" >&2
   echo "A Bash call that is no longer refused is the proof the library loaded." >&2
   exit 2
@@ -361,7 +365,14 @@ cand_bases=()
 
 case "$tool" in
   Edit|Write|MultiEdit|NotebookEdit)
-    fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+    # `notebook_path` is NOT a guess: it is the field `worktree-owner-gate.sh`
+    # has read for `NotebookEdit` all along, and NotebookEdit is the one tool in
+    # this pattern that does not send `file_path`. Reading only `file_path` made
+    # adding the label INERT for exactly the tool it was added for -- measured,
+    # a NotebookEdit of a TRACKED main-tree file collected no candidate and
+    # exited 0, while the same payload spelled with `file_path` exited 2. Cases
+    # written against the invented spelling passed throughout.
+    fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null || echo "")
     [[ -n "$fp" ]] && candidates+=("$fp")
     ;;
   Bash)

--- a/.claude/hooks/main-tree-edit-gate.sh
+++ b/.claude/hooks/main-tree-edit-gate.sh
@@ -102,20 +102,30 @@ fi
 # and exits 0, where the load-time refusal used to catch it. That is accepted
 # rather than overlooked. Refusing in `*)` means refusing a payload whose tool is
 # UNKNOWN, which puts Edit and Write back inside the refusal the moment `jq`
-# breaks too -- the lockout again, arriving by a second route. It costs nothing
-# real: the registered matcher is `Edit|Write|Bash`, so `*)` is unreachable for
-# any tool this hook is actually invoked on.
+# breaks too -- the lockout again, arriving by a second route. It is pinned by a
+# case, because eight lines of argument for a behaviour nothing measures is how
+# the behaviour goes away in a later refactor.
+#
+# An earlier revision of this comment justified it with "the registered matcher
+# is `Edit|Write|Bash`, so `*)` is unreachable". That was FALSE, and the file
+# contradicted it two ways at once. Claude Code matchers are UNANCHORED REGEX:
+# `Edit|Write|Bash` matches `MultiEdit` and `NotebookEdit` on the substring
+# `Edit`, so both reach this hook. `MultiEdit` was already in the file-path arm
+# and `NotebookEdit` was not -- which meant a NotebookEdit of a tracked file in
+# the main tree on `main` fell to `*)` and was ALLOWED. That hole predates this
+# change and is closed here, in the same `case` label the comment is about; the
+# sibling `worktree-owner-gate` has listed `NotebookEdit` all along.
 __refuse_unloadable_library() {
   echo "Blocked: .claude/hooks/lib/command-match.sh is missing or unloadable," >&2
   echo "so main-tree-edit-gate cannot resolve the command's working directory." >&2
-  echo "Restore the file; do not work around the gate." >&2
+  echo "Restore that file; do not work around the gate." >&2
   echo "" >&2
   echo "Only Bash is refused. This hook's Edit and Write arms read the target" >&2
   echo "path directly and need no shell parsing, so FROM A FEATURE WORKTREE you" >&2
-  echo "can repair lib/command-match.sh with the Edit or Write tool." >&2
-  echo "In the main tree on main this gate refuses that edit as well -- for its" >&2
-  echo "own separate reason -- so there the repair is the operator's, run from" >&2
-  echo "their own shell ('!' prefixed, in Claude Code):" >&2
+  echo "can repair it with the Edit or Write tool -- that route is still open." >&2
+  echo "In the main tree on main this gate refuses that edit too, for its own" >&2
+  echo "separate reason, so there the repair belongs to the operator, made from" >&2
+  echo "their own shell. To inspect the file first ('!' prefixed, in Claude Code):" >&2
   echo "  bash -n .claude/hooks/lib/command-match.sh" >&2
   echo "A Bash call that is no longer refused is the proof the library loaded." >&2
   exit 2
@@ -350,7 +360,7 @@ candidates=()
 cand_bases=()
 
 case "$tool" in
-  Edit|Write|MultiEdit)
+  Edit|Write|MultiEdit|NotebookEdit)
     fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
     [[ -n "$fp" ]] && candidates+=("$fp")
     ;;

--- a/.claude/hooks/main-tree-edit-gate.sh
+++ b/.claude/hooks/main-tree-edit-gate.sh
@@ -124,7 +124,7 @@ __refuse_unloadable_library() {
   echo "so main-tree-edit-gate cannot resolve the command's working directory." >&2
   echo "Restore that file; do not work around the gate." >&2
   echo "" >&2
-  echo "Only Bash is refused. This hook's Edit and Write arms read the target" >&2
+  echo "Only Bash is refused. This hook's file-path arms read the target" >&2
   echo "path directly and need no shell parsing, so FROM A FEATURE WORKTREE you" >&2
   echo "can repair the library with the Edit or Write tool -- that route is open." >&2
   echo "In the main tree on main this gate refuses that edit too, for its own" >&2

--- a/.claude/hooks/main-tree-edit-gate.test.sh
+++ b/.claude/hooks/main-tree-edit-gate.test.sh
@@ -57,6 +57,13 @@ git -C "$OPTOUT" -c user.email=t@t -c user.name=t commit -q -m init
 WT="$MAIN/.claude/worktrees/feat"
 git -C "$MAIN" worktree add -q "$WT" -b feat/work 2>/dev/null
 mkdir -p "$WT/docs/_generated"
+# The library's own directory, in BOTH trees. `__norm_candidate` returns 1 when
+# a candidate's PARENT DIRECTORY does not exist, and the hook then exits 0
+# without ever asking which branch the tree is on -- so a case naming a path
+# under a directory nobody created passes for that reason and proves nothing
+# about the arm it was written for. Both are created so the WORKTREE case and
+# its MAIN-tree twin differ only in the tree, which is the thing under test.
+mkdir -p "$WT/.claude/hooks/lib" "$MAIN/.claude/hooks/lib"
 
 pass=0; fail=0
 # run_case <expected_exit> <desc> <json>
@@ -497,17 +504,38 @@ run_broken 2 "Restore the file" "an unloadable library refuses EVERY Bash call, 
   "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > /tmp/elsewhere.txt"}}')"
 
 # The refusal has to say what SURVIVES, or an agent reads it as a dead end and
-# starts working around the gate. Both needles are load-bearing: the first is
-# the repair route, the second is how to check it.
-run_broken 2 "Only Bash is refused" "the refusal names the arms that still work" \
-  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
-run_broken 2 "bash -n" "the refusal names the syntax check" \
-  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+# starts working around the gate. Every SENTENCE of that advice gets a needle,
+# not just the headline: a review found lines 100-108 of the hook individually
+# deletable with the suite green, which is the same "the text is load-bearing"
+# claim going unpinned that this PR objects to in the text it replaced.
+#
+# The worktree qualifier is the one that was WRONG before this round. "Repair it
+# with the Edit or Write tool" is false in the main tree on `main`, where the
+# tracked-file arm refuses that edit -- the very case pinned below.
+__refusal_payload="$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+run_broken 2 "Only Bash is refused" "the refusal names the arms that still work" "$__refusal_payload"
+run_broken 2 "FROM A FEATURE WORKTREE" "the refusal names WHERE the repair is possible" "$__refusal_payload"
+run_broken 2 "In the main tree on main this gate refuses" \
+  "the refusal names where it is NOT, instead of overstating the route" "$__refusal_payload"
+run_broken 2 "bash -n" "the refusal names the syntax check" "$__refusal_payload"
+run_broken 2 "no longer refused is the proof" "the refusal says how to tell the repair worked" "$__refusal_payload"
+
+# The refusal has to be the FIRST thing the arm does. Moving it below the
+# `[[ -z "$cmd" ]] && exit 0` on the next line survives every other case in this
+# file, and turns an empty or absent `command` under a broken library from 2
+# into 0. Nothing else in the suite reaches the arm with no command.
+run_broken 2 "Restore the file" "an EMPTY Bash command still hits the refusal (guard is above the -z bail)" \
+  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:""}}')"
 
 # THE LOCKOUT CASES. Each of these exits 2 against the pre-go-to-k/cdkd#2717
-# hook -- that is what "locked out" meant -- and 0 here. An Edit and a Write are
-# both asserted because the split is per-ARM in a `case` and dropping one label
-# from the pattern would be invisible to either case alone.
+# hook -- that is what "locked out" meant -- and 0 here.
+#
+# `Edit` and `Write` are asserted SEPARATELY, but not because dropping a label
+# from the `case` pattern would otherwise be invisible -- case 5 above (a Write
+# of a new `src/` file, expecting 2) already fences `Write`, and dropping the
+# label sends it to `*)` and 0. They are separate because an expect-0 case
+# proves nothing on its own about WHICH arm answered, so each needs the
+# same-tool ENFORCEMENT control below it.
 run_broken 0 - "Edit outside the repo is ALLOWED with an unloadable library" \
   "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
     '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
@@ -515,22 +543,39 @@ run_broken 0 - "Write outside the repo is ALLOWED with an unloadable library" \
   "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
     '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
 # The repair itself, in the tree where the library an agent actually edits
-# lives. It passes for the BRANCH reason -- a feature worktree always passes --
-# which is the point: pre-go-to-k/cdkd#2717 that reason was never reached,
-# because the arm never ran. The two cases above pass for a different reason
-# (outside any repo), so this one is not a third spelling of them.
+# lives. This one passes for the BRANCH reason -- a feature worktree always
+# passes -- where the two above pass for a different one (outside any repo).
+# The MAIN-tree twin immediately below is what makes that claim checkable: same
+# path shape, same broken library, same absent-or-present parent directory,
+# differing only in the tree. Without the twin the case was a THIRD spelling of
+# "a path the gate could not resolve" -- `$WT/.claude/hooks/lib` did not exist,
+# so it exited before the branch lookup and its MAIN-tree twin returned 0 too.
 run_broken 0 - "Write to the library in a FEATURE worktree survives an unloadable library" \
   "$(jq -nc --arg fp "$WT/.claude/hooks/lib/command-match.sh" --arg cwd "$WT" \
     '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 2 "Blocked by main-tree-edit-gate" \
+  "the same library path in the MAIN tree on main is refused (the twin)" \
+  "$(jq -nc --arg fp "$MAIN/.claude/hooks/lib/command-match.sh" --arg cwd "$MAIN" \
+    '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
 
-# ...and the control that keeps the three above from being fail-open. The
-# surviving arms must still ENFORCE: a tracked main-tree target is refused by
+# ...and the controls that keep the lockout cases from being fail-open. The
+# surviving arms must still ENFORCE: a protected main-tree target is refused by
 # the gate's OWN message, not by the load refusal. The needle discriminates
 # which of the two fired.
+#
+# ONE PER TOOL LABEL, and that is not symmetry for its own sake. With only the
+# `Edit` control, inserting `[ "$tool" = Write ] && [ "$__lib_loaded" != 1 ] &&
+# exit 0` into the dispatch survived the whole suite: the `Write` lockout case
+# asserts an exit code alone, so a fail-open there is indistinguishable from the
+# arm working. Measured on this suite before the `Write` control existed.
 run_broken 2 "Blocked by main-tree-edit-gate" \
   "Edit of a tracked main-tree file is still BLOCKED with an unloadable library" \
   "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
     '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 2 "Blocked by main-tree-edit-gate" \
+  "Write to a tracked main-tree file is still BLOCKED with an unloadable library" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
 # A library that LOADS CLEANLY but lacks the symbol. The broken-syntax fixture
 # above can never reach the `declare -F gate_segments_marked` clause -- it trips
 # the `. source` arm first -- so that clause was load-bearing and untested:
@@ -554,18 +599,47 @@ if [[ "$sl_rc" == 2 ]]; then
 else
   fail=$((fail + 1)); echo "not ok (exit $sl_rc, want 2) a loadable library without gate_segments_marked must fail CLOSED"
 fi
+# ...and the arm split holds on THIS arm too. The `declare -F` clause and the
+# `. source` clause are different code paths to the same flag, and only the
+# second had an Edit case -- so a split applied to one and not the other would
+# have been invisible here.
+printf '%s' \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')" \
+  | "$HOOK_RUNNER" "$STUBLIB/main-tree-edit-gate.sh" >/dev/null 2>&1
+sl_edit_rc=$?
+if [[ "$sl_edit_rc" == 0 ]]; then
+  pass=$((pass + 1)); echo "ok   (exit 0) an Edit survives a library missing gate_segments_marked"
+else
+  fail=$((fail + 1)); echo "not ok (exit $sl_edit_rc, want 0) an Edit must survive the declare -F arm too"
+fi
 
-# The same fixture with the library RESTORED is the control: it proves the two
-# assertions above came from the broken library and not from the copy itself.
-cp .claude/hooks/lib/command-match.sh "$BROKEN/lib/command-match.sh"
+# An IDENTICAL copy with a WORKING library is the control: it proves the
+# assertions above came from the broken library and not from the copying.
+#
+# It is a second copy rather than `$BROKEN` repaired in place. Repairing
+# `$BROKEN` here made every `run_broken` added BELOW this line silently run
+# against a healthy library -- an ordering hazard with no symptom, because such
+# a case does not fail, it just stops measuring anything. `$BROKEN` now stays
+# broken for the whole file, and the assertion after the control says so.
+BROKEN_CTL="$TMPDIR/broken-ctl"
+cp -R .claude/hooks "$BROKEN_CTL"
 printf '%s' \
   "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > /tmp/elsewhere.txt"}}')" \
-  | "$HOOK_RUNNER" "$BROKEN/main-tree-edit-gate.sh" >/dev/null 2>&1
+  | "$HOOK_RUNNER" "$BROKEN_CTL/main-tree-edit-gate.sh" >/dev/null 2>&1
 fc_ctl=$?
 if [[ "$fc_ctl" == 0 ]]; then
-  pass=$((pass + 1)); echo "ok   (exit 0) the same copy with the library restored allows an outside write"
+  pass=$((pass + 1)); echo "ok   (exit 0) an identical copy with a WORKING library allows an outside write"
 else
   fail=$((fail + 1)); echo "not ok (exit $fc_ctl, want 0) the copied hook must work when its library loads"
+fi
+# Every `run_broken` above asserted something only because `$BROKEN`'s library
+# was still unloadable when it ran. Nothing else says so, and the thing that
+# would break it -- repairing `$BROKEN` mid-file, as this control used to --
+# leaves those cases green while they measure nothing.
+if "$HOOK_RUNNER" -n "$BROKEN/lib/command-match.sh" 2>/dev/null; then
+  fail=$((fail + 1)); echo "not ok \$BROKEN's library PARSES -- every run_broken case above measured nothing"
+else
+  pass=$((pass + 1)); echo "ok   \$BROKEN's library is still unloadable at the end of the block"
 fi
 
 # A FLOOR, which this suite never had. Its sibling `command-match.test.sh`
@@ -896,7 +970,7 @@ else
   printf 'FAIL latency: a 300 KB command took %ss to refuse, budget 4s\n' "$__os_secs"
 fi
 
-CASE_FLOOR=108
+CASE_FLOOR=116
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'not ok case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/main-tree-edit-gate.test.sh
+++ b/.claude/hooks/main-tree-edit-gate.test.sh
@@ -495,12 +495,12 @@ run_broken() {
   fi
 }
 
-run_broken 2 "Restore the file" "a Bash call with an unloadable library fails CLOSED" \
+run_broken 2 "Restore that file" "a Bash call with an unloadable library fails CLOSED" \
   "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
 
 # The Bash refusal is unconditional within its arm -- a write to /tmp is refused
 # too, because deciding that it is safe is exactly the parse the hook cannot do.
-run_broken 2 "Restore the file" "an unloadable library refuses EVERY Bash call, not only in-tree writes" \
+run_broken 2 "Restore that file" "an unloadable library refuses EVERY Bash call, not only in-tree writes" \
   "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > /tmp/elsewhere.txt"}}')"
 
 # The refusal has to say what SURVIVES, or an agent reads it as a dead end and
@@ -513,18 +513,29 @@ run_broken 2 "Restore the file" "an unloadable library refuses EVERY Bash call, 
 # with the Edit or Write tool" is false in the main tree on `main`, where the
 # tracked-file arm refuses that edit -- the very case pinned below.
 __refusal_payload="$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+run_broken 2 "lib/command-match.sh is missing or unloadable" \
+  "the refusal names WHICH file, so 'Restore that file' has an antecedent" "$__refusal_payload"
+run_broken 2 "cannot resolve the command's working directory" \
+  "the refusal says what the missing file cost it" "$__refusal_payload"
+run_broken 2 "Restore that file" "the refusal says what to do" "$__refusal_payload"
 run_broken 2 "Only Bash is refused" "the refusal names the arms that still work" "$__refusal_payload"
 run_broken 2 "FROM A FEATURE WORKTREE" "the refusal names WHERE the repair is possible" "$__refusal_payload"
-run_broken 2 "In the main tree on main this gate refuses" \
+run_broken 2 "can repair it with the Edit or Write tool" \
+  "the refusal names the repair itself, not only the place it works" "$__refusal_payload"
+run_broken 2 "In the main tree on main this gate refuses that edit too" \
   "the refusal names where it is NOT, instead of overstating the route" "$__refusal_payload"
-run_broken 2 "bash -n" "the refusal names the syntax check" "$__refusal_payload"
+run_broken 2 "the repair belongs to the operator" \
+  "the refusal names WHO repairs it in the main tree" "$__refusal_payload"
+run_broken 2 "To inspect the file first" \
+  "the refusal labels bash -n as an INSPECTION, not as the repair" "$__refusal_payload"
+run_broken 2 "bash -n" "the refusal names the inspection command" "$__refusal_payload"
 run_broken 2 "no longer refused is the proof" "the refusal says how to tell the repair worked" "$__refusal_payload"
 
 # The refusal has to be the FIRST thing the arm does. Moving it below the
 # `[[ -z "$cmd" ]] && exit 0` on the next line survives every other case in this
 # file, and turns an empty or absent `command` under a broken library from 2
 # into 0. Nothing else in the suite reaches the arm with no command.
-run_broken 2 "Restore the file" "an EMPTY Bash command still hits the refusal (guard is above the -z bail)" \
+run_broken 2 "Restore that file" "an EMPTY Bash command still hits the refusal (guard is above the -z bail)" \
   "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:""}}')"
 
 # THE LOCKOUT CASES. Each of these exits 2 against the pre-go-to-k/cdkd#2717
@@ -576,6 +587,39 @@ run_broken 2 "Blocked by main-tree-edit-gate" \
   "Write to a tracked main-tree file is still BLOCKED with an unloadable library" \
   "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
     '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
+
+# THE OTHER TWO LABELS IN THE `case` PATTERN. A Claude Code matcher is an
+# UNANCHORED REGEX, so `Edit|Write|Bash` matches `MultiEdit` and `NotebookEdit`
+# on the substring `Edit` and this hook IS invoked for both. `MultiEdit` was in
+# the file-path arm with no case; `NotebookEdit` was in NEITHER, so a notebook
+# write to a tracked file in the main tree on `main` was allowed outright --
+# a hole that predates the load-refusal split and is closed with it.
+#
+# Both are pinned with the pair, like Edit and Write: the allow case alone
+# cannot tell the arm answering from `*)` answering.
+for __t in MultiEdit NotebookEdit; do
+  run_broken 2 "Blocked by main-tree-edit-gate" \
+    "$__t of a tracked main-tree file is BLOCKED with an unloadable library" \
+    "$(jq -nc --arg t "$__t" --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+      '{tool_name:$t, cwd:$cwd, tool_input:{file_path:$fp}}')"
+  run_broken 0 - "$__t outside the repo is ALLOWED with an unloadable library" \
+    "$(jq -nc --arg t "$__t" --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
+      '{tool_name:$t, cwd:$cwd, tool_input:{file_path:$fp}}')"
+done
+
+# THE `*)` ARM, which the hook spends a paragraph justifying and nothing
+# measured: replacing its `exit 0` with the refusal left the suite green. An
+# unclassifiable `tool_name` -- a malformed payload, or `jq` missing too -- must
+# PASS even with the library unloadable, because refusing there puts Edit and
+# Write back inside the refusal and re-creates the lockout by a second route.
+# The target is a tracked main-tree file, so this is the strongest form: even
+# there, an unknown tool is not this hook's business.
+run_broken 0 - "an unclassifiable tool_name falls to *) and PASSES (refusing there re-creates the lockout)" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"WebFetch", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 0 - "an ABSENT tool_name does the same" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{cwd:$cwd, tool_input:{file_path:$fp}}')"
 # A library that LOADS CLEANLY but lacks the symbol. The broken-syntax fixture
 # above can never reach the `declare -F gate_segments_marked` clause -- it trips
 # the `. source` arm first -- so that clause was load-bearing and untested:
@@ -603,15 +647,32 @@ fi
 # `. source` clause are different code paths to the same flag, and only the
 # second had an Edit case -- so a split applied to one and not the other would
 # have been invisible here.
-printf '%s' \
-  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')" \
-  | "$HOOK_RUNNER" "$STUBLIB/main-tree-edit-gate.sh" >/dev/null 2>&1
-sl_edit_rc=$?
-if [[ "$sl_edit_rc" == 0 ]]; then
-  pass=$((pass + 1)); echo "ok   (exit 0) an Edit survives a library missing gate_segments_marked"
-else
-  fail=$((fail + 1)); echo "not ok (exit $sl_edit_rc, want 0) an Edit must survive the declare -F arm too"
-fi
+#
+# IT IS A PAIR, for the same reason every other allow-case here is. With only
+# the allow half, a fail-open reachable in exactly this state --
+# `if declare -F gate_unquote && ! declare -F gate_segments_marked &&
+# [ "$tool" != Bash ]; then exit 0; fi` -- survived the whole suite: exit 0 from
+# the arm and exit 0 from a fail-open are the same byte.
+run_stublib() { # <expected> <needle|-> <desc> <json>
+  local expected="$1" needle="$2" desc="$3" json="$4" rc out ok_text
+  out=$(printf '%s' "$json" | "$HOOK_RUNNER" "$STUBLIB/main-tree-edit-gate.sh" 2>&1 >/dev/null); rc=$?
+  if [[ "$needle" == "-" || "$out" == *"$needle"* ]]; then ok_text=1; else ok_text=0; fi
+  if [[ "$rc" == "$expected" && "$ok_text" == 1 ]]; then
+    pass=$((pass + 1)); printf 'ok   (exit %s, stub lib) %s\n' "$rc" "$desc"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL (exit %s want %s; text %s) %s\n' "$rc" "$expected" \
+      "$([[ "$ok_text" == 1 ]] && echo ok || echo MISSING)" "$desc"
+    printf '     wanted text: %s\n     got: %s\n' "$needle" "$(printf '%s' "$out" | head -2)"
+  fi
+}
+run_stublib 0 - "an Edit survives a library missing gate_segments_marked" \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
+    '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_stublib 2 "Blocked by main-tree-edit-gate" \
+  "...and still ENFORCES on a tracked main-tree file (the control for it)" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
 
 # An IDENTICAL copy with a WORKING library is the control: it proves the
 # assertions above came from the broken library and not from the copying.
@@ -636,10 +697,18 @@ fi
 # was still unloadable when it ran. Nothing else says so, and the thing that
 # would break it -- repairing `$BROKEN` mid-file, as this control used to --
 # leaves those cases green while they measure nothing.
-if "$HOOK_RUNNER" -n "$BROKEN/lib/command-match.sh" 2>/dev/null; then
+# EXISTENCE IS CHECKED SEPARATELY. `bash -n <absent file>` exits 127, which is
+# non-zero and so read as "still broken" -- so `rm -f` on the fixture passed this
+# assertion. Deleting the library IS a broken library for the hook, but not for
+# the cases above: they assert the SOURCE arm's refusal, and a file that is gone
+# takes a different path to it. Both halves, or the guard has a hole where the
+# thing it guards against is one command away.
+if [[ ! -f "$BROKEN/lib/command-match.sh" ]]; then
+  fail=$((fail + 1)); echo "not ok \$BROKEN's library is GONE -- the run_broken cases did not exercise the syntax-error arm"
+elif "$HOOK_RUNNER" -n "$BROKEN/lib/command-match.sh" 2>/dev/null; then
   fail=$((fail + 1)); echo "not ok \$BROKEN's library PARSES -- every run_broken case above measured nothing"
 else
-  pass=$((pass + 1)); echo "ok   \$BROKEN's library is still unloadable at the end of the block"
+  pass=$((pass + 1)); echo "ok   \$BROKEN's library is present and still unparsable at the end of the block"
 fi
 
 # A FLOOR, which this suite never had. Its sibling `command-match.test.sh`
@@ -970,10 +1039,15 @@ else
   printf 'FAIL latency: a 300 KB command took %ss to refuse, budget 4s\n' "$__os_secs"
 fi
 
-CASE_FLOOR=116
-if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+CASE_FLOOR=129
+# `ran` is captured BEFORE the increment. Incrementing `fail` first and then
+# printing `$((pass + fail))` re-counted the floor's own failure as a case, so
+# one deleted case reported `only 129 cases ran, expected at least 129` -- a
+# message that reads like a bug in the check rather than the shrink it caught.
+__ran=$((pass + fail))
+if [ "$__ran" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
-  printf 'not ok case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+  printf 'not ok case floor: only %s cases ran, expected at least %s\n' "$__ran" "$CASE_FLOOR"
 fi
 echo "----"
 echo "passed=$pass failed=$fail"

--- a/.claude/hooks/main-tree-edit-gate.test.sh
+++ b/.claude/hooks/main-tree-edit-gate.test.sh
@@ -122,6 +122,35 @@ run_case 0 "Bash '> /tmp/scratch' " \
   "$(jq -nc --arg cmd "echo hi > /tmp/scratch.$$.log" --arg cwd "$MAIN" \
     '{tool_name:"Bash", cwd:$cwd, tool_input:{command:$cmd}}')"
 
+# 4b. MultiEdit and NotebookEdit, WITH A WORKING LIBRARY. These are the cases
+# that matter: the hole was that a notebook write to a tracked main-tree file
+# was allowed in an ORDINARY session, and every case for it originally sat in
+# the broken-library block. Measured there, `[ "$__lib_loaded" = 1 ] &&
+# [ "$tool" = NotebookEdit ] && exit 0` -- the hole, restored by one line --
+# left the suite fully green.
+#
+# Each tool is driven with the field it really sends. NotebookEdit sends
+# `notebook_path`; a case built with `file_path` passes while the hook ignores
+# notebooks entirely, which is exactly how the label shipped inert once.
+run_case 2 "MultiEdit tracked ledger in main tree on main" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"MultiEdit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_case 2 "NotebookEdit {notebook_path} tracked ledger in main tree on main" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"NotebookEdit", cwd:$cwd, tool_input:{notebook_path:$fp}}')"
+# The WIDENING side: adding a label to a blocking gate can only be safe if it
+# still passes where the gate always passed. Both were verified to exit 0 before
+# these cases existed -- correct, but unmeasured.
+run_case 0 "NotebookEdit {notebook_path} inside a feature worktree" \
+  "$(jq -nc --arg fp "$WT/docs/_generated/ledger.tsv" --arg cwd "$WT" \
+    '{tool_name:"NotebookEdit", cwd:$cwd, tool_input:{notebook_path:$fp}}')"
+run_case 0 "NotebookEdit {notebook_path} in a repo with no .markgate.yml" \
+  "$(jq -nc --arg fp "$OPTOUT/article.md" --arg cwd "$OPTOUT" \
+    '{tool_name:"NotebookEdit", cwd:$cwd, tool_input:{notebook_path:$fp}}')"
+run_case 0 "MultiEdit inside a feature worktree" \
+  "$(jq -nc --arg fp "$WT/docs/_generated/ledger.tsv" --arg cwd "$WT" \
+    '{tool_name:"MultiEdit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+
 # 5. Write a NEW source file under src/ in main tree on main -> BLOCK (2).
 run_case 2 "Write new src/ file in main tree on main" \
   "$(jq -nc --arg fp "$MAIN/src/brandnew.ts" --arg cwd "$MAIN" \
@@ -520,13 +549,15 @@ run_broken 2 "cannot resolve the command's working directory" \
 run_broken 2 "Restore that file" "the refusal says what to do" "$__refusal_payload"
 run_broken 2 "Only Bash is refused" "the refusal names the arms that still work" "$__refusal_payload"
 run_broken 2 "FROM A FEATURE WORKTREE" "the refusal names WHERE the repair is possible" "$__refusal_payload"
-run_broken 2 "can repair it with the Edit or Write tool" \
+run_broken 2 "can repair the library with the Edit or Write tool" \
   "the refusal names the repair itself, not only the place it works" "$__refusal_payload"
 run_broken 2 "In the main tree on main this gate refuses that edit too" \
   "the refusal names where it is NOT, instead of overstating the route" "$__refusal_payload"
 run_broken 2 "the repair belongs to the operator" \
   "the refusal names WHO repairs it in the main tree" "$__refusal_payload"
-run_broken 2 "To inspect the file first" \
+run_broken 2 "'!' prefixed" \
+  "the refusal keeps the how-to on the OPERATOR's line, where the repair is" "$__refusal_payload"
+run_broken 2 "To inspect it first" \
   "the refusal labels bash -n as an INSPECTION, not as the repair" "$__refusal_payload"
 run_broken 2 "bash -n" "the refusal names the inspection command" "$__refusal_payload"
 run_broken 2 "no longer refused is the proof" "the refusal says how to tell the repair worked" "$__refusal_payload"
@@ -588,24 +619,30 @@ run_broken 2 "Blocked by main-tree-edit-gate" \
   "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
     '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
 
-# THE OTHER TWO LABELS IN THE `case` PATTERN. A Claude Code matcher is an
-# UNANCHORED REGEX, so `Edit|Write|Bash` matches `MultiEdit` and `NotebookEdit`
-# on the substring `Edit` and this hook IS invoked for both. `MultiEdit` was in
-# the file-path arm with no case; `NotebookEdit` was in NEITHER, so a notebook
-# write to a tracked file in the main tree on `main` was allowed outright --
-# a hole that predates the load-refusal split and is closed with it.
+# THE OTHER TWO LABELS IN THE `case` PATTERN, under a broken library. The
+# HEALTHY-state cases are further down and are the load-bearing ones; these only
+# say the load split treats all four labels alike.
 #
-# Both are pinned with the pair, like Edit and Write: the allow case alone
-# cannot tell the arm answering from `*)` answering.
-for __t in MultiEdit NotebookEdit; do
-  run_broken 2 "Blocked by main-tree-edit-gate" \
-    "$__t of a tracked main-tree file is BLOCKED with an unloadable library" \
-    "$(jq -nc --arg t "$__t" --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
-      '{tool_name:$t, cwd:$cwd, tool_input:{file_path:$fp}}')"
-  run_broken 0 - "$__t outside the repo is ALLOWED with an unloadable library" \
-    "$(jq -nc --arg t "$__t" --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
-      '{tool_name:$t, cwd:$cwd, tool_input:{file_path:$fp}}')"
-done
+# `NotebookEdit` sends `notebook_path`, NOT `file_path` -- the field
+# `worktree-owner-gate.sh` has read for it all along. Building these payloads
+# with `file_path` is what let the label ship INERT: measured, a NotebookEdit of
+# a tracked main-tree file spelled the real way collected no candidate and
+# exited 0, while the invented spelling exited 2 and every case passed. Each
+# tool is driven with the field it actually sends.
+run_broken 2 "Blocked by main-tree-edit-gate" \
+  "MultiEdit of a tracked main-tree file is BLOCKED with an unloadable library" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"MultiEdit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 0 - "MultiEdit outside the repo is ALLOWED with an unloadable library" \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
+    '{tool_name:"MultiEdit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 2 "Blocked by main-tree-edit-gate" \
+  "NotebookEdit {notebook_path} of a tracked main-tree file is BLOCKED with an unloadable library" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"NotebookEdit", cwd:$cwd, tool_input:{notebook_path:$fp}}')"
+run_broken 0 - "NotebookEdit {notebook_path} outside the repo is ALLOWED with an unloadable library" \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.ipynb" --arg cwd "$MAIN" \
+    '{tool_name:"NotebookEdit", cwd:$cwd, tool_input:{notebook_path:$fp}}')"
 
 # THE `*)` ARM, which the hook spends a paragraph justifying and nothing
 # measured: replacing its `exit 0` with the refusal left the suite green. An
@@ -1039,10 +1076,10 @@ else
   printf 'FAIL latency: a 300 KB command took %ss to refuse, budget 4s\n' "$__os_secs"
 fi
 
-CASE_FLOOR=129
+CASE_FLOOR=135
 # `ran` is captured BEFORE the increment. Incrementing `fail` first and then
 # printing `$((pass + fail))` re-counted the floor's own failure as a case, so
-# one deleted case reported `only 129 cases ran, expected at least 129` -- a
+# one deleted case reported `only 135 cases ran, expected at least 135` -- a
 # message that reads like a bug in the check rather than the shrink it caught.
 __ran=$((pass + fail))
 if [ "$__ran" -lt "$CASE_FLOOR" ]; then

--- a/.claude/hooks/main-tree-edit-gate.test.sh
+++ b/.claude/hooks/main-tree-edit-gate.test.sh
@@ -453,29 +453,84 @@ run_case 0 "Bash PAST the byte bound: a write OUTSIDE the repo still passes" \
 # --- THE FAIL-CLOSED LOAD PATH, which had no case at all (go-to-k/cdkd#2650) -
 # The guard has been here since the hook started sourcing the shared matcher,
 # and nothing ran it. It matters more than an ordinary arm because this hook's
-# matcher is `Edit|Write|Bash`: an unloadable library takes away every tool an
-# agent would repair it with, which is by design and therefore has to SAY so.
-# Measured the hard way -- an apostrophe inside a comment in the library's awk
-# program closed the shell string, and the session that wrote it was locked out
-# of its own repo. Asserted: the refusal fires (exit 2, never 0), and it names
-# the operator route out. A refusal with no way out reads as a broken harness.
+# matcher is `Edit|Write|Bash`: an unloadable library used to take away every
+# tool an agent would repair it with. Measured the hard way -- an apostrophe
+# inside a comment in the library's awk program closed the shell string, and the
+# session that wrote it was locked out of its own repo, four times in one
+# session.
+#
+# go-to-k/cdkd#2717 SPLIT that: `Bash` still fails closed, `Edit` and `Write` do
+# not, because those two arms read `tool_input.file_path` and call no library
+# function. The cases below assert BOTH halves against the same broken fixture
+# -- the refusal and the surviving arms -- because either one alone is
+# satisfiable by the bug it replaces: refusing everything passes the first, and
+# passing everything passes the second.
 BROKEN="$TMPDIR/broken"
 cp -R .claude/hooks "$BROKEN"
 echo 'this is not shell(' > "$BROKEN/lib/command-match.sh"
-fc_out=$(printf '%s' \
-  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')" \
-  | "$HOOK_RUNNER" "$BROKEN/main-tree-edit-gate.sh" 2>&1)
-fc_rc=$?
-if [[ "$fc_rc" == 2 ]]; then
-  pass=$((pass + 1)); echo "ok   (exit 2) an unloadable library fails CLOSED"
-else
-  fail=$((fail + 1)); echo "not ok (exit $fc_rc, want 2) an unloadable library must fail CLOSED"
-fi
-if [[ "$fc_out" == *"prefix the command with"* && "$fc_out" == *"bash -n"* ]]; then
-  pass=$((pass + 1)); echo "ok   the fail-closed refusal names the operator route out"
-else
-  fail=$((fail + 1)); echo "not ok the fail-closed refusal must name a route out; got: $fc_out"
-fi
+
+# run_broken <expected_exit> <needle|-> <desc> <json>
+# `-` as the needle asserts the exit code alone. Runs the BROKEN copy, not
+# `$HOOK`, so it cannot use `run_case` / `run_case_text`.
+run_broken() {
+  local expected="$1" needle="$2" desc="$3" json="$4" rc out ok_text
+  out=$(printf '%s' "$json" | "$HOOK_RUNNER" "$BROKEN/main-tree-edit-gate.sh" 2>&1 >/dev/null); rc=$?
+  if [[ "$needle" == "-" ]]; then ok_text=1
+  elif [[ "$out" == *"$needle"* ]]; then ok_text=1
+  else ok_text=0; fi
+  if [[ "$rc" == "$expected" && "$ok_text" == 1 ]]; then
+    pass=$((pass + 1)); printf 'ok   (exit %s, broken lib) %s\n' "$rc" "$desc"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL (exit %s want %s; text %s) %s\n' "$rc" "$expected" \
+      "$([[ "$ok_text" == 1 ]] && echo ok || echo MISSING)" "$desc"
+    printf '     wanted text: %s\n     got: %s\n' "$needle" "$(printf '%s' "$out" | head -2)"
+  fi
+}
+
+run_broken 2 "Restore the file" "a Bash call with an unloadable library fails CLOSED" \
+  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+
+# The Bash refusal is unconditional within its arm -- a write to /tmp is refused
+# too, because deciding that it is safe is exactly the parse the hook cannot do.
+run_broken 2 "Restore the file" "an unloadable library refuses EVERY Bash call, not only in-tree writes" \
+  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > /tmp/elsewhere.txt"}}')"
+
+# The refusal has to say what SURVIVES, or an agent reads it as a dead end and
+# starts working around the gate. Both needles are load-bearing: the first is
+# the repair route, the second is how to check it.
+run_broken 2 "Only Bash is refused" "the refusal names the arms that still work" \
+  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+run_broken 2 "bash -n" "the refusal names the syntax check" \
+  "$(jq -nc --arg cwd "$MAIN" '{tool_name:"Bash", cwd:$cwd, tool_input:{command:"echo hi > docs/_generated/ledger.tsv"}}')"
+
+# THE LOCKOUT CASES. Each of these exits 2 against the pre-go-to-k/cdkd#2717
+# hook -- that is what "locked out" meant -- and 0 here. An Edit and a Write are
+# both asserted because the split is per-ARM in a `case` and dropping one label
+# from the pattern would be invisible to either case alone.
+run_broken 0 - "Edit outside the repo is ALLOWED with an unloadable library" \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
+    '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
+run_broken 0 - "Write outside the repo is ALLOWED with an unloadable library" \
+  "$(jq -nc --arg fp "$TMPDIR/scratch.txt" --arg cwd "$MAIN" \
+    '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
+# The repair itself, in the tree where the library an agent actually edits
+# lives. It passes for the BRANCH reason -- a feature worktree always passes --
+# which is the point: pre-go-to-k/cdkd#2717 that reason was never reached,
+# because the arm never ran. The two cases above pass for a different reason
+# (outside any repo), so this one is not a third spelling of them.
+run_broken 0 - "Write to the library in a FEATURE worktree survives an unloadable library" \
+  "$(jq -nc --arg fp "$WT/.claude/hooks/lib/command-match.sh" --arg cwd "$WT" \
+    '{tool_name:"Write", cwd:$cwd, tool_input:{file_path:$fp}}')"
+
+# ...and the control that keeps the three above from being fail-open. The
+# surviving arms must still ENFORCE: a tracked main-tree target is refused by
+# the gate's OWN message, not by the load refusal. The needle discriminates
+# which of the two fired.
+run_broken 2 "Blocked by main-tree-edit-gate" \
+  "Edit of a tracked main-tree file is still BLOCKED with an unloadable library" \
+  "$(jq -nc --arg fp "$MAIN/docs/_generated/ledger.tsv" --arg cwd "$MAIN" \
+    '{tool_name:"Edit", cwd:$cwd, tool_input:{file_path:$fp}}')"
 # A library that LOADS CLEANLY but lacks the symbol. The broken-syntax fixture
 # above can never reach the `declare -F gate_segments_marked` clause -- it trips
 # the `. source` arm first -- so that clause was load-bearing and untested:
@@ -841,7 +896,7 @@ else
   printf 'FAIL latency: a 300 KB command took %ss to refuse, budget 4s\n' "$__os_secs"
 fi
 
-CASE_FLOOR=102
+CASE_FLOOR=108
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'not ok case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/rules/hooks-main-tree-edit.md
+++ b/.claude/rules/hooks-main-tree-edit.md
@@ -83,14 +83,38 @@ toll only on a session actually touching these two hooks.
   is the parse the hook just failed to do.
 
   **The surviving arms still ENFORCE**, which is the half a fail-open would also
-  satisfy: with the library broken, an `Edit` of a tracked main-tree file is
-  still refused, by the gate's OWN message rather than the load refusal. Both
-  halves are cases. Measured against `origin/main`'s hook under the same broken
+  satisfy: with the library broken, an `Edit` or `Write` of a protected
+  main-tree file is still refused, by the gate's OWN message rather than the
+  load refusal. Measured against `origin/main`'s hook under the same broken
   library and the same payloads: `Edit` 2 → 0, `Write` 2 → 0, `Bash` 2 → 2, with
-  the library restored giving 0 on the old hook as the control. The refusal TEXT
-  is a case too — it has to say that Edit and Write survive, since a refusal
-  that misstates what is available is what sends an agent looking for a way
-  around the gate.
+  a working-library copy giving 0 on the old hook as the control.
+
+  **There is ONE enforcement control per tool label, and the reason is a
+  measured survivor, not symmetry.** With only the `Edit` control, injecting
+  `[ "$tool" = Write ] && [ "$__lib_loaded" != 1 ] && exit 0` into the dispatch
+  survived the whole suite: an expect-0 lockout case asserts a bare exit code,
+  so a fail-open in that arm is indistinguishable from the arm working. The same
+  shape sank the worktree-repair case, which named a path under a directory the
+  fixture never created — `__norm_candidate` returns 1 on an absent parent
+  directory, so it exited before the branch lookup and its MAIN-tree twin
+  answered 0 as well. **Every expect-0 case here is paired with a case that must
+  answer 2 for the same tool**, and the pairs differ only in the thing under
+  test.
+
+  The refusal TEXT is a case too, one needle per SENTENCE. It has to say that
+  Edit and Write survive **and where** — `FROM A FEATURE WORKTREE`; in the main
+  tree on `main` the gate refuses that edit as well, for its own separate
+  reason, and there the repair is the operator's. The first revision said only
+  the first half, which is the same overstatement in the other direction as the
+  text it replaced: a refusal that misstates what is available is what sends an
+  agent looking for a way around the gate.
+
+  **An unclassifiable `tool_name` now exits 0 where the load-time refusal caught
+  it** — a malformed payload, or `jq` missing as well, falls through the `case`
+  to `*)`. Accepted, not overlooked: refusing there puts Edit and Write back
+  inside the refusal the moment `jq` breaks too, which is the lockout arriving
+  by a second route, and the registered matcher is `Edit|Write|Bash`, so `*)` is
+  unreachable for any tool this hook is invoked on.
 
   **This is the fifth resolution strategy the gate has carried, and the first
   that is neither anchored nor hand-rolled.** The four before it each fixed

--- a/.claude/rules/hooks-main-tree-edit.md
+++ b/.claude/rules/hooks-main-tree-edit.md
@@ -35,8 +35,10 @@ toll only on a session actually touching these two hooks.
   `main`/`master` AND the file is tracked (or is a NEW file under `src/` /
   `tests/` / `docs/` / `scripts/` / `.claude/`, excluding
   `.claude/worktrees/*`). Edit / Write / MultiEdit / NotebookEdit read
-  `tool_input.file_path` (reliable) — the last two reach this hook because a
-  matcher is an unanchored regex and `Edit|Write|Bash` matches the substring;
+  `tool_input.file_path`, falling back to `tool_input.notebook_path` (reliable)
+  — the last two reach this hook because a matcher is an unanchored regex and
+  `Edit|Write|Bash` matches the substring, and NotebookEdit is the one that
+  sends `notebook_path`;
   Bash best-effort-scans for LITERAL write targets (`> f`, `>> f`,
   `tee [-a] f`, `sed -i ... f`). **Known gap**: a variable-indirected target
   (`mv "$tmp" "$LEDGER"`) cannot be resolved statically — the next bullet,
@@ -73,45 +75,36 @@ toll only on a session actually touching these two hooks.
   comment in its awk program, each needing the maintainer's own shell. A safety
   mechanism must not remove the operator's means of repair.
 
-  Sound because the file-path arm reads `tool_input.file_path` through `jq` and
-  calls NO library function: the path arrives expanded, so there is no shell text
-  to parse, and everything between load and dispatch is assignments and function
-  definitions. Only `Bash` needs the matcher, and there the refusal is
-  UNCONDITIONAL — a `/tmp` write is refused too, since deciding it is safe is the
-  parse that just failed. Measured, same broken library: `Edit` 2 → 0, `Write`
-  2 → 0, `Bash` 2 → 2, working-library copy 0 on the old hook as control.
+  Sound because the file-path arm calls NO library function; the hook's own
+  header carries that argument and the `*)` one, so they are not repeated here.
+  Measured **against `origin/main`'s hook**, same broken library and payloads:
+  `Edit` 2 → 0, `Write` 2 → 0, `Bash` 2 → 2, working-library copy 0 on the old
+  hook as control. Keep the comparand — a compression dropped it once, and
+  `2 → 0` alone reads as THIS hook going block to allow, the opposite of the
+  claim. Surviving arms refuse **by the gate's OWN message**, the only way to
+  tell enforcement from lockout.
 
-  **Every expect-0 case is paired with an expect-2 case on the SAME tool label
-  and the SAME broken-library arm.** Both qualifiers were learned by being
-  wrong. With only the `Edit` control, `[ "$tool" = Write ] &&
-  [ "$__lib_loaded" != 1 ] && exit 0` survived the whole suite — an expect-0 case
-  asserts a bare exit code, so a fail-open reads identically to the arm working;
-  the `declare -F` arm then repeated it once the `. source` arm had its pair. The
-  same shape sank the worktree-repair case, which named a path under a directory
-  the fixture never created: `__norm_candidate` returns 1 on an absent parent
-  dir, so it never reached the branch lookup and its MAIN-tree twin answered 0
-  too.
+  Three test properties, each bought by a measured survivor rather than by
+  taste. **Every expect-0 case is paired with an expect-2 case on the SAME tool
+  label AND the SAME library state** — a bare exit code cannot tell a fail-open
+  from the arm working, so `Write`, the `declare -F` arm, and the healthy-library
+  state each shipped a hole once the others had pairs. **One needle per
+  refusal SENTENCE**, measured by deleting each line. **A case must reach the
+  branch it names**: the worktree-repair case sat under a directory the fixture
+  never created, so `__norm_candidate` returned 1 and its MAIN-tree twin
+  answered 0 too.
 
-  The refusal TEXT is cases too, **one needle per SENTENCE**, measured by
-  deleting each line and requiring a red. It says Edit and Write survive **and
-  where** — `FROM A FEATURE WORKTREE`; in the main tree on `main` the gate
-  refuses that edit too, and there the repair belongs to the operator. `bash -n`
-  is labelled an INSPECTION: dropping the label left the colon binding it to
-  "the repair", which it is not.
-
-  **An unclassifiable `tool_name` exits 0** where the load-time refusal caught
-  it — a malformed payload, or `jq` gone too, falls to `*)`. Accepted: refusing
-  there puts Edit and Write back inside the refusal the moment `jq` breaks,
-  the lockout by a second route. PINNED by a case, because replacing that
-  `exit 0` with the refusal left the suite green until one existed.
-
-  **A matcher is an UNANCHORED REGEX**, which is what an earlier draft of that
-  paragraph got wrong ("`Edit|Write|Bash`, so `*)` is unreachable"). It matches
-  `MultiEdit` and `NotebookEdit` on the substring, so both reach this hook.
-  `MultiEdit` sat in the file-path arm with no case; **`NotebookEdit` was in
-  neither, so a notebook write to a tracked main-tree file was allowed
-  outright** — a hole predating this change, closed with it in the same `case`
-  label. The sibling `worktree-owner-gate` has listed it all along.
+  **A matcher is an UNANCHORED REGEX** — an earlier draft asserted the opposite
+  ("`Edit|Write|Bash`, so `*)` is unreachable"). It matches `MultiEdit` and
+  `NotebookEdit` on the substring, so both reach this hook. `MultiEdit` sat in
+  the file-path arm with no case; **`NotebookEdit` was in neither, so a notebook
+  write to a tracked main-tree file was allowed outright** — a hole predating
+  this change. Closing it took TWO edits: the label, and the FIELD. NotebookEdit
+  sends `notebook_path`, so the label alone was inert for the only tool it was
+  added for — measured, exit 0 with the label in place, 2 for the same payload
+  spelled `file_path`, every case green. `tests/unit/scripts/settings-bash-matcher-coverage.test.ts`
+  now fails if that matcher is anchored, which the hook's own suite cannot see:
+  it feeds the hook payloads directly and never reads the matcher.
 
   **This is the fifth resolution strategy the gate has carried, and the first
   that is neither anchored nor hand-rolled.** The four before it each fixed

--- a/.claude/rules/hooks-main-tree-edit.md
+++ b/.claude/rules/hooks-main-tree-edit.md
@@ -62,7 +62,35 @@ toll only on a session actually touching these two hooks.
   published as eleven, then fourteen, then twenty-eight, and a reviewer
   re-measuring got fourteen against a different comparand: four attempts, no
   two agreeing. Apply the `odd-trailing-bs` mutant and read the differential's
-  own undeclared-cell list. Load fails CLOSED.
+  own undeclared-cell list.
+
+  **Load fails CLOSED for `Bash` ONLY, and the asymmetry is the point**
+  (go-to-k/cdkd#2717). Every other gate on the shared matcher refuses outright
+  when the library will not load; this one matches `Edit|Write|Bash`, so
+  refusing at LOAD time took away the three tools the library is repaired with.
+  It happened four times in one session (go-to-k/cdkd#2650), three of them from
+  a single apostrophe inside a comment in the library's awk program, and each
+  time the maintainer ran the repair from their own shell. A safety mechanism
+  must not be able to remove the operator's means of repair.
+
+  What makes the split sound rather than a relaxation: the
+  `Edit|Write|MultiEdit` arm reads `tool_input.file_path` through `jq` and calls
+  no library function — the path arrives already expanded, so there is no shell
+  text to parse. Only the `Bash` arm needs the matcher. Everything between the
+  load and the dispatch is assignments and function definitions, so nothing runs
+  against the missing symbols in between. Inside the `Bash` arm the refusal is
+  UNCONDITIONAL — a write to `/tmp` is refused too, because deciding it is safe
+  is the parse the hook just failed to do.
+
+  **The surviving arms still ENFORCE**, which is the half a fail-open would also
+  satisfy: with the library broken, an `Edit` of a tracked main-tree file is
+  still refused, by the gate's OWN message rather than the load refusal. Both
+  halves are cases. Measured against `origin/main`'s hook under the same broken
+  library and the same payloads: `Edit` 2 → 0, `Write` 2 → 0, `Bash` 2 → 2, with
+  the library restored giving 0 on the old hook as the control. The refusal TEXT
+  is a case too — it has to say that Edit and Write survive, since a refusal
+  that misstates what is available is what sends an agent looking for a way
+  around the gate.
 
   **This is the fifth resolution strategy the gate has carried, and the first
   that is neither anchored nor hand-rolled.** The four before it each fixed

--- a/.claude/rules/hooks-main-tree-edit.md
+++ b/.claude/rules/hooks-main-tree-edit.md
@@ -34,7 +34,9 @@ toll only on a session actually touching these two hooks.
   the user's `git pull --ff-only`. Fires only when the target's branch is
   `main`/`master` AND the file is tracked (or is a NEW file under `src/` /
   `tests/` / `docs/` / `scripts/` / `.claude/`, excluding
-  `.claude/worktrees/*`). Edit/Write read `tool_input.file_path` (reliable);
+  `.claude/worktrees/*`). Edit / Write / MultiEdit / NotebookEdit read
+  `tool_input.file_path` (reliable) — the last two reach this hook because a
+  matcher is an unanchored regex and `Edit|Write|Bash` matches the substring;
   Bash best-effort-scans for LITERAL write targets (`> f`, `>> f`,
   `tee [-a] f`, `sed -i ... f`). **Known gap**: a variable-indirected target
   (`mv "$tmp" "$LEDGER"`) cannot be resolved statically — the next bullet,
@@ -64,57 +66,52 @@ toll only on a session actually touching these two hooks.
   two agreeing. Apply the `odd-trailing-bs` mutant and read the differential's
   own undeclared-cell list.
 
-  **Load fails CLOSED for `Bash` ONLY, and the asymmetry is the point**
-  (go-to-k/cdkd#2717). Every other gate on the shared matcher refuses outright
-  when the library will not load; this one matches `Edit|Write|Bash`, so
-  refusing at LOAD time took away the three tools the library is repaired with.
-  It happened four times in one session (go-to-k/cdkd#2650), three of them from
-  a single apostrophe inside a comment in the library's awk program, and each
-  time the maintainer ran the repair from their own shell. A safety mechanism
-  must not be able to remove the operator's means of repair.
+  **Load fails CLOSED for `Bash` ONLY** (go-to-k/cdkd#2717). Every other gate on
+  the shared matcher refuses outright; this one also matches Edit and Write, so
+  refusing at LOAD time took away the tools the library is repaired with — four
+  times in one session (go-to-k/cdkd#2650), three from one apostrophe in a
+  comment in its awk program, each needing the maintainer's own shell. A safety
+  mechanism must not remove the operator's means of repair.
 
-  What makes the split sound rather than a relaxation: the
-  `Edit|Write|MultiEdit` arm reads `tool_input.file_path` through `jq` and calls
-  no library function — the path arrives already expanded, so there is no shell
-  text to parse. Only the `Bash` arm needs the matcher. Everything between the
-  load and the dispatch is assignments and function definitions, so nothing runs
-  against the missing symbols in between. Inside the `Bash` arm the refusal is
-  UNCONDITIONAL — a write to `/tmp` is refused too, because deciding it is safe
-  is the parse the hook just failed to do.
+  Sound because the file-path arm reads `tool_input.file_path` through `jq` and
+  calls NO library function: the path arrives expanded, so there is no shell text
+  to parse, and everything between load and dispatch is assignments and function
+  definitions. Only `Bash` needs the matcher, and there the refusal is
+  UNCONDITIONAL — a `/tmp` write is refused too, since deciding it is safe is the
+  parse that just failed. Measured, same broken library: `Edit` 2 → 0, `Write`
+  2 → 0, `Bash` 2 → 2, working-library copy 0 on the old hook as control.
 
-  **The surviving arms still ENFORCE**, which is the half a fail-open would also
-  satisfy: with the library broken, an `Edit` or `Write` of a protected
-  main-tree file is still refused, by the gate's OWN message rather than the
-  load refusal. Measured against `origin/main`'s hook under the same broken
-  library and the same payloads: `Edit` 2 → 0, `Write` 2 → 0, `Bash` 2 → 2, with
-  a working-library copy giving 0 on the old hook as the control.
+  **Every expect-0 case is paired with an expect-2 case on the SAME tool label
+  and the SAME broken-library arm.** Both qualifiers were learned by being
+  wrong. With only the `Edit` control, `[ "$tool" = Write ] &&
+  [ "$__lib_loaded" != 1 ] && exit 0` survived the whole suite — an expect-0 case
+  asserts a bare exit code, so a fail-open reads identically to the arm working;
+  the `declare -F` arm then repeated it once the `. source` arm had its pair. The
+  same shape sank the worktree-repair case, which named a path under a directory
+  the fixture never created: `__norm_candidate` returns 1 on an absent parent
+  dir, so it never reached the branch lookup and its MAIN-tree twin answered 0
+  too.
 
-  **There is ONE enforcement control per tool label, and the reason is a
-  measured survivor, not symmetry.** With only the `Edit` control, injecting
-  `[ "$tool" = Write ] && [ "$__lib_loaded" != 1 ] && exit 0` into the dispatch
-  survived the whole suite: an expect-0 lockout case asserts a bare exit code,
-  so a fail-open in that arm is indistinguishable from the arm working. The same
-  shape sank the worktree-repair case, which named a path under a directory the
-  fixture never created — `__norm_candidate` returns 1 on an absent parent
-  directory, so it exited before the branch lookup and its MAIN-tree twin
-  answered 0 as well. **Every expect-0 case here is paired with a case that must
-  answer 2 for the same tool**, and the pairs differ only in the thing under
-  test.
+  The refusal TEXT is cases too, **one needle per SENTENCE**, measured by
+  deleting each line and requiring a red. It says Edit and Write survive **and
+  where** — `FROM A FEATURE WORKTREE`; in the main tree on `main` the gate
+  refuses that edit too, and there the repair belongs to the operator. `bash -n`
+  is labelled an INSPECTION: dropping the label left the colon binding it to
+  "the repair", which it is not.
 
-  The refusal TEXT is a case too, one needle per SENTENCE. It has to say that
-  Edit and Write survive **and where** — `FROM A FEATURE WORKTREE`; in the main
-  tree on `main` the gate refuses that edit as well, for its own separate
-  reason, and there the repair is the operator's. The first revision said only
-  the first half, which is the same overstatement in the other direction as the
-  text it replaced: a refusal that misstates what is available is what sends an
-  agent looking for a way around the gate.
+  **An unclassifiable `tool_name` exits 0** where the load-time refusal caught
+  it — a malformed payload, or `jq` gone too, falls to `*)`. Accepted: refusing
+  there puts Edit and Write back inside the refusal the moment `jq` breaks,
+  the lockout by a second route. PINNED by a case, because replacing that
+  `exit 0` with the refusal left the suite green until one existed.
 
-  **An unclassifiable `tool_name` now exits 0 where the load-time refusal caught
-  it** — a malformed payload, or `jq` missing as well, falls through the `case`
-  to `*)`. Accepted, not overlooked: refusing there puts Edit and Write back
-  inside the refusal the moment `jq` breaks too, which is the lockout arriving
-  by a second route, and the registered matcher is `Edit|Write|Bash`, so `*)` is
-  unreachable for any tool this hook is invoked on.
+  **A matcher is an UNANCHORED REGEX**, which is what an earlier draft of that
+  paragraph got wrong ("`Edit|Write|Bash`, so `*)` is unreachable"). It matches
+  `MultiEdit` and `NotebookEdit` on the substring, so both reach this hook.
+  `MultiEdit` sat in the file-path arm with no case; **`NotebookEdit` was in
+  neither, so a notebook write to a tracked main-tree file was allowed
+  outright** — a hole predating this change, closed with it in the same `case`
+  label. The sibling `worktree-owner-gate` has listed it all along.
 
   **This is the fifth resolution strategy the gate has carried, and the first
   that is neither anchored nor hand-rolled.** The four before it each fixed

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -901,7 +901,13 @@ CLOSED when it cannot load** (`exit 2`, with a `declare -F gate_matches`
 check for a truncated file — the liveness check covers all three exported
 functions); the three non-blocking detectors skip instead (a missed backup /
 reminder / warning is a smaller harm than refusing an operation they only
-observe). The path is derived with pure-bash `${BASH_SOURCE[0]%/*}` rather
+observe). **One gate fails closed for `Bash` and not for its other arms**:
+`main-tree-edit-gate` matches `Edit|Write|Bash`, and refusing at LOAD time took
+away the three tools the library is repaired with — go-to-k/cdkd#2717 moved the
+refusal inside the `Bash` arm, which is the only arm that parses command text.
+It is a carve-out for a MATCHER, not a softening of the rule: any gate matching
+Bash alone still refuses outright, and the `Bash` arm here still does.
+The path is derived with pure-bash `${BASH_SOURCE[0]%/*}` rather
 than `dirname` (no PATH lookup), `.` fallback for the no-slash case. Count
 the sharing hooks with
 `grep -l 'lib/command-match.sh' .claude/hooks/*.sh | grep -v test | wc -l`

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -901,12 +901,12 @@ CLOSED when it cannot load** (`exit 2`, with a `declare -F gate_matches`
 check for a truncated file — the liveness check covers all three exported
 functions); the three non-blocking detectors skip instead (a missed backup /
 reminder / warning is a smaller harm than refusing an operation they only
-observe). **One gate fails closed for `Bash` and not for its other arms**:
-`main-tree-edit-gate` matches `Edit|Write|Bash`, and refusing at LOAD time took
-away the three tools the library is repaired with — go-to-k/cdkd#2717 moved the
-refusal inside the `Bash` arm, which is the only arm that parses command text.
-It is a carve-out for a MATCHER, not a softening of the rule: any gate matching
-Bash alone still refuses outright, and the `Bash` arm here still does.
+observe). **One gate fails closed for `Bash` and not for its other arms** —
+`main-tree-edit-gate`, whose matcher also takes Edit and Write, so a LOAD-time
+refusal took away the tools the library is repaired with (go-to-k/cdkd#2717;
+[hooks-main-tree-edit.md](hooks-main-tree-edit.md) has it). A carve-out for a
+MATCHER, not a softening: a Bash-only gate still refuses outright, and so does
+that gate's `Bash` arm.
 The path is derived with pure-bash `${BASH_SOURCE[0]%/*}` rather
 than `dirname` (no PATH lookup), `.` fallback for the no-slash case. Count
 the sharing hooks with

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -526,11 +526,20 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // 109 B of headroom left after two parallel lanes had spent the rest.
   // Representative path for the satellite (its four globs are the two hooks
   // and their suites, per the REACH_FLOORS entry above). Payload is hooks.md +
-  // hooks-main-tree-edit.md. The FLOOR is ~12% under the measurement, this
-  // file's convention -- the first draft said 40_000, 51% under, and a floor
-  // that loose cannot notice the satellite going dark, because hooks.md alone
-  // is 78,437 B and satisfies it unaided.
-  ['.claude/hooks/main-tree-edit-gate.sh', 56_000, 95_000], // measured 68_626 on 2026-09-07
+  // hooks-main-tree-edit.md + hooks-authoring.md -- THREE files, not the two an
+  // earlier revision of this comment named; `hooks-authoring.md`'s glob covers
+  // every hook, so it has been in this payload since it split out. The FLOOR is
+  // ~35% under the measurement -- the first draft said 40_000, and a floor that
+  // loose cannot notice the satellite going dark, because hooks.md alone
+  // satisfies it unaided.
+  //
+  // The figure below was `68_626` until 2026-09-08, which is `86_662` with two
+  // digit pairs swapped and was never a payload this row could have measured:
+  // hooks.md alone exceeded it. Re-derive it from the assertion itself (drop the
+  // cap to 1 and read `pulls in N B` off the failure), not by hand -- a
+  // hand-summed answer has to reproduce `globToRegExp`, and the obvious
+  // approximation gets a different set of files.
+  ['.claude/hooks/main-tree-edit-gate.sh', 56_000, 95_000], // measured 86_662 on 2026-09-08
   // main-tree-branch-gate's entry moved out of hooks.md on 2026-09-01, when the
   // argument-parse rewrite's measured before/after table pushed that file to
   // 122,862 B -- past the same 120,000 B per-file cap, and one line past the

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -545,9 +545,13 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   //
   // The figure below was `68_626` until 2026-09-08, and it was CORRECT when
   // written: at go-to-k/cdkd#2731 the three files measured 59,133 + 5,692 +
-  // 3,801 = 68,626 exactly. It went stale by growth, not by error -- hooks.md
-  // 59,133 -> 70,168 and this satellite 5,692 -> 12,693 across #2711, #2766 and
-  // go-to-k/cdkd#2717's own commits.
+  // 3,801 = 68,626 exactly. It went stale by GROWTH, not by error. Derived per
+  // commit rather than recalled -- hooks.md 59,133 -> 70,168 is #2738 +4,736,
+  // #2766 +3,935, #2711 +1,016, #2760 +943 and this branch +405; the satellite
+  // 5,692 -> 12,693 is #2711 +4,189 and this branch +2,812. An earlier revision
+  // of this paragraph named three PRs from memory and omitted the two largest
+  // contributors to hooks.md, in a comment whose whole subject is checking the
+  // history instead of recalling it.
   //
   // Recorded because the first attempt to update it asserted the opposite: that
   // `68_626` was `86_662` with two digit pairs transposed and had never been a

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -528,18 +528,36 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // and their suites, per the REACH_FLOORS entry above). Payload is hooks.md +
   // hooks-main-tree-edit.md + hooks-authoring.md -- THREE files, not the two an
   // earlier revision of this comment named; `hooks-authoring.md`'s glob covers
-  // every hook, so it has been in this payload since it split out. The FLOOR is
-  // ~35% under the measurement -- the first draft said 40_000, and a floor that
-  // loose cannot notice the satellite going dark, because hooks.md alone
-  // satisfies it unaided.
+  // every hook, so it has been in this payload since it split out.
   //
-  // The figure below was `68_626` until 2026-09-08, which is `86_662` with two
-  // digit pairs swapped and was never a payload this row could have measured:
-  // hooks.md alone exceeded it. Re-derive it from the assertion itself (drop the
-  // cap to 1 and read `pulls in N B` off the failure), not by hand -- a
-  // hand-summed answer has to reproduce `globToRegExp`, and the obvious
-  // approximation gets a different set of files.
-  ['.claude/hooks/main-tree-edit-gate.sh', 56_000, 95_000], // measured 86_662 on 2026-09-08
+  // THE FLOOR IS DERIVED, not a percentage. It was 56_000 and fenced nothing:
+  // its own comment claimed a looser floor "cannot notice the satellite going
+  // dark, because hooks.md alone satisfies it unaided", which was true of 56_000
+  // too -- hooks.md is 70,168 B, so BOTH satellites could go dark and the row
+  // still passed. A floor here has exactly one job, so it has to sit above the
+  // largest payload that job would let through: hooks.md alone (70,168). At
+  // 78_000, hooks-main-tree-edit.md going dark leaves 73,969 and reds.
+  //
+  // The residual is named rather than papered over: hooks-authoring.md going
+  // dark alone leaves 82,861 and still passes. It is 3,801 B against a 12,693 B
+  // sibling, so no floor catches it without false-firing on ordinary edits to
+  // the other two; that one is covered by its own REACH_FLOORS row.
+  //
+  // The figure below was `68_626` until 2026-09-08, and it was CORRECT when
+  // written: at go-to-k/cdkd#2731 the three files measured 59,133 + 5,692 +
+  // 3,801 = 68,626 exactly. It went stale by growth, not by error -- hooks.md
+  // 59,133 -> 70,168 and this satellite 5,692 -> 12,693 across #2711, #2766 and
+  // go-to-k/cdkd#2717's own commits.
+  //
+  // Recorded because the first attempt to update it asserted the opposite: that
+  // `68_626` was `86_662` with two digit pairs transposed and had never been a
+  // payload this row could measure. That was invented to fit a digit
+  // coincidence, and `git log -S'68_626'` refutes it in one command. Re-derive
+  // the number from the assertion itself (drop the cap to 1 and read
+  // `pulls in N B` off the failure) and check the HISTORY before explaining why
+  // an old figure differs -- a hand-summed answer also has to reproduce
+  // `globToRegExp`, and the obvious approximation picks a different file set.
+  ['.claude/hooks/main-tree-edit-gate.sh', 78_000, 95_000], // measured 86_662 on 2026-09-08
   // main-tree-branch-gate's entry moved out of hooks.md on 2026-09-01, when the
   // argument-parse rewrite's measured before/after table pushed that file to
   // 122,862 B -- past the same 120,000 B per-file cap, and one line past the

--- a/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
+++ b/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
@@ -202,12 +202,30 @@ describe('.claude/settings.json PreToolUse gate reachability', () => {
     );
     expect(entries, 'main-tree-edit-gate must be registered at PreToolUse').toHaveLength(1);
 
-    const matcher = entries[0]?.matcher ?? '';
+    const matcher = entries[0]?.matcher;
+    // WITHOUT THIS, the assertion below is satisfiable by an ABSENT matcher: the
+    // `?? ''` an earlier revision used makes `new RegExp('')` match every tool,
+    // so a settings schema change that dropped the key entirely went green. A
+    // fence whose subject can vanish is the shape this whole PR exists to fix.
+    expect(
+      typeof matcher === 'string' && matcher.length > 0,
+      `main-tree-edit-gate's entry has no \`matcher\` (got ${JSON.stringify(matcher)}). An absent or empty matcher makes every assertion below vacuous, because an empty pattern matches everything.`,
+    ).toBe(true);
+    // A legal Claude Code wildcard (`*`) is not a legal JS RegExp and would throw
+    // a raw SyntaxError here instead of this test's message. Fail with the reason.
+    let re: RegExp;
+    try {
+      re = new RegExp(matcher as string);
+    } catch {
+      throw new Error(
+        `main-tree-edit-gate's matcher ${JSON.stringify(matcher)} is not a JS RegExp, so this fence cannot evaluate the reach it exists to protect. If the matcher moved to a wildcard or glob form, re-derive how the harness matches and rewrite this assertion -- do not delete it.`,
+      );
+    }
     // The floor is that a substring match still happens, not the exact string:
     // `Edit|Write|Bash` and `Write|Edit|Bash` are both fine, `^Edit$|...` is not.
     for (const tool of ['Edit', 'Write', 'MultiEdit', 'NotebookEdit']) {
       expect(
-        new RegExp(matcher).test(tool),
+        re.test(tool),
         [
           `main-tree-edit-gate's matcher ${JSON.stringify(matcher)} no longer routes ${tool}.`,
           'MultiEdit and NotebookEdit reach this gate only by unanchored substring',

--- a/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
+++ b/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
@@ -203,27 +203,48 @@ describe('.claude/settings.json PreToolUse gate reachability', () => {
     expect(entries, 'main-tree-edit-gate must be registered at PreToolUse').toHaveLength(1);
 
     const matcher = entries[0]?.matcher;
-    // WITHOUT THIS, the assertion below is satisfiable by an ABSENT matcher: the
-    // `?? ''` an earlier revision used makes `new RegExp('')` match every tool,
-    // so a settings schema change that dropped the key entirely went green. A
-    // fence whose subject can vanish is the shape this whole PR exists to fix.
-    expect(
-      typeof matcher === 'string' && matcher.length > 0,
-      `main-tree-edit-gate's entry has no \`matcher\` (got ${JSON.stringify(matcher)}). An absent or empty matcher makes every assertion below vacuous, because an empty pattern matches everything.`,
-    ).toBe(true);
+    // A NARROWING GUARD, not an `expect`. Both uses below need `matcher` to be a
+    // non-empty string, and an `expect` leaves that to runtime: written as
+    // `new RegExp(matcher as string)` the cast is load-bearing, so deleting or
+    // reordering the check compiles clean and `new RegExp(undefined)` yields
+    // `/(?:)/`, which matches all four tools. That is the vacuity this whole PR
+    // is about, one refactor away and invisible to the type checker. Narrowing
+    // instead means TS refuses the reordering.
+    if (typeof matcher !== 'string' || matcher.length === 0) {
+      throw new Error(
+        `main-tree-edit-gate's entry has no \`matcher\` (got ${JSON.stringify(matcher)}). An absent or empty matcher makes every assertion below vacuous, because an empty pattern matches everything.`,
+      );
+    }
     // A legal Claude Code wildcard (`*`) is not a legal JS RegExp and would throw
     // a raw SyntaxError here instead of this test's message. Fail with the reason.
     let re: RegExp;
     try {
-      re = new RegExp(matcher as string);
+      re = new RegExp(matcher);
     } catch {
       throw new Error(
         `main-tree-edit-gate's matcher ${JSON.stringify(matcher)} is not a JS RegExp, so this fence cannot evaluate the reach it exists to protect. If the matcher moved to a wildcard or glob form, re-derive how the harness matches and rewrite this assertion -- do not delete it.`,
       );
     }
+    // The tool list is DERIVED from the hook's own `case` label, not hand-written
+    // here. A hand list catches a label REMOVAL (so does the hook's suite) and
+    // catches nothing when a label is ADDED: the new tool would reach the hook by
+    // substring, be handled by the arm, and have no assertion that the matcher
+    // still routes it. Reading the label ties the two halves together.
+    const armLabel = /^\s*(Edit\|[A-Za-z|]+)\)\s*$/m.exec(
+      readFileSync(join(repoRoot, '.claude', 'hooks', 'main-tree-edit-gate.sh'), 'utf8'),
+    )?.[1];
+    expect(
+      armLabel,
+      "could not find main-tree-edit-gate's file-path `case` label; this fence derives its tool list from it, so a parse failure here would silently assert nothing",
+    ).toBeTruthy();
+    const tools = (armLabel ?? '').split('|').filter(Boolean);
+    // Floor: the label must still carry the two substring-reached tools this
+    // fence exists for, so a label rewritten down to `Edit|Write` cannot quietly
+    // shrink the list the loop below iterates.
+    expect(tools).toEqual(expect.arrayContaining(['MultiEdit', 'NotebookEdit']));
     // The floor is that a substring match still happens, not the exact string:
     // `Edit|Write|Bash` and `Write|Edit|Bash` are both fine, `^Edit$|...` is not.
-    for (const tool of ['Edit', 'Write', 'MultiEdit', 'NotebookEdit']) {
+    for (const tool of tools) {
       expect(
         re.test(tool),
         [

--- a/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
+++ b/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
@@ -183,4 +183,40 @@ describe('.claude/settings.json PreToolUse gate reachability', () => {
       );
     }
   });
+
+  // A matcher is an UNANCHORED REGEX, and `main-tree-edit-gate` depends on that
+  // rather than merely tolerating it: its registered matcher is
+  // `Edit|Write|Bash`, and `MultiEdit` / `NotebookEdit` reach it ONLY because
+  // `Edit` matches as a substring. Both are handled in its file-path `case`
+  // label, and a NotebookEdit of a tracked file in the main tree on `main` is
+  // refused there (go-to-k/cdkd#2717).
+  //
+  // So anchoring that matcher -- `^(Edit|Write|Bash)$`, or splitting it into
+  // exact alternatives -- would silently stop routing notebook writes to the
+  // gate and reopen the hole, with the hook's own suite still green: that suite
+  // feeds payloads to the hook directly and never consults the matcher. This is
+  // the only place the two halves meet.
+  it('keeps main-tree-edit-gate reachable for the Edit-substring tools', () => {
+    const entries = preToolUseEntries().filter((e) =>
+      (e.hooks ?? []).some((spec) => gateName(spec) === 'main-tree-edit-gate'),
+    );
+    expect(entries, 'main-tree-edit-gate must be registered at PreToolUse').toHaveLength(1);
+
+    const matcher = entries[0]?.matcher ?? '';
+    // The floor is that a substring match still happens, not the exact string:
+    // `Edit|Write|Bash` and `Write|Edit|Bash` are both fine, `^Edit$|...` is not.
+    for (const tool of ['Edit', 'Write', 'MultiEdit', 'NotebookEdit']) {
+      expect(
+        new RegExp(matcher).test(tool),
+        [
+          `main-tree-edit-gate's matcher ${JSON.stringify(matcher)} no longer routes ${tool}.`,
+          'MultiEdit and NotebookEdit reach this gate only by unanchored substring',
+          'match on `Edit`. Anchoring the matcher, or listing exact tool names,',
+          'stops notebook and multi-edit writes from being gated at all -- and the',
+          "hook's own suite cannot see it, because it feeds the hook payloads",
+          'directly and never reads the matcher. Keep the matcher unanchored.',
+        ].join(' '),
+      ).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`main-tree-edit-gate` was the only hook in the repo that could take away the
ability to repair it. Its matcher is `Edit|Write|Bash`, and it refused at LOAD
time — before the tool was even read — whenever `lib/command-match.sh` would not
source. All three tools went at once, including the two an agent repairs the
library with.

That is not hypothetical: it happened four times in one session
(go-to-k/cdkd#2650), three of them from a single apostrophe inside a comment in
the library's awk program, and each time the maintainer had to run the repair
from their own shell. go-to-k/cdkd#2717 calls it `severity: high` for exactly
this reason — **a safety mechanism must not be able to remove the operator's
means of repair.**

This takes option 1 from that issue (move the refusal into the `Bash` arm)
rather than option 2 (split the hook in two).

## What makes this a split and not a relaxation

The file-path arm reads its target through `jq` and calls **no library
function** — the path arrives already expanded, so there is no shell text to
parse, and everything between the load and the dispatch is assignments and
function definitions. Only the `Bash` arm needs the matcher, and there the
refusal stays **unconditional**: a write to `/tmp` is refused too, because
deciding it is safe is exactly the parse the hook just failed to do.

Measured against `origin/main`'s hook, same broken library and payloads:

```
arm  tool   rc
old  Edit   2      new  Edit   0
old  Write  2      new  Write  0
old  Bash   2      new  Bash   2
CONTROL: old hook, library restored, Edit -> 0
```

The control is what says the three refusals came from the broken library and not
from the copied fixture.

## A pre-existing hole, found while defending a claim in this PR

Round 2 added a comment justifying the `*)` arm with *"the registered matcher is
`Edit|Write|Bash`, so `*)` is unreachable."* **False.** Claude Code matchers are
unanchored regex, so `Edit|Write|Bash` matches `MultiEdit` and `NotebookEdit` on
the substring and this hook is invoked for both. `MultiEdit` was already in the
file-path arm; `NotebookEdit` was in neither:

> **A `NotebookEdit` of a tracked file in the main tree on `main` was allowed
> outright.** That is on `main` today.

It is closed here rather than deferred: it is the same `case` label this change
edits, the comment beside it was asserting the opposite, and the sibling
`worktree-owner-gate` has listed `NotebookEdit` all along.

**Closing it took two edits, and the label alone was inert.** NotebookEdit sends
`notebook_path`, not `file_path`. The first attempt added only the label, and
every case for it passed — because the cases were built with `file_path`, a
payload shape NotebookEdit never sends:

```
NotebookEdit {notebook_path}   rc=0   <- the real shape; hole still open
NotebookEdit {file_path}       rc=2   <- the shape the cases invented
Edit {file_path}               rc=2   <- control
```

The arm now reads `.tool_input.file_path // .tool_input.notebook_path // ""`,
the field list `worktree-owner-gate.sh:56` has used all along.

The matcher itself is now fenced. Anchoring it would silently stop routing
notebook writes **with the hook's own suite still green** — that suite feeds the
hook payloads directly and never reads the matcher — so
`settings-bash-matcher-coverage.test.ts` asserts the reach. Probed by anchoring
to `^(Edit|Write|Bash)$`, which fails it with the reason.

## Test plan

`main-tree-edit-gate.test.sh`: **135 pass / 0 fail** under bash 5.3.9 and macOS
system bash 3.2, `CASE_FLOOR` 102 -> 135. Every behaviour this PR argues for is
pinned by a mutation that was watched going red:

| Mutation | Result |
|---|---|
| jq reverted to `file_path` only | 133/135 |
| the NotebookEdit hole restored in the **healthy** state | 134/135 |
| `NotebookEdit` / `MultiEdit` dropped from the arm | 133/135 each |
| `*)` refuses instead of passing | 127/135 |
| `Write`-arm fail-open under a broken library | 133/135 |
| Edit/Write fail-open on the `declare -F` arm | 134/135 |
| each of the 11 refusal lines, deleted singly | 134/135 — all 11 |
| refusal moved below the empty-command bail | 134/135 |
| `$BROKEN`'s library deleted, or repaired, mid-file | 134/135 each |
| the fixture `mkdir` removed | 134/135 |
| the matcher anchored to `^(Edit\|Write\|Bash)$` | the new fence fails |

Three properties the cases hold to, each bought by a measured survivor rather
than by taste:

- **Every expect-0 case is paired with an expect-2 case on the same tool label
  AND the same library state.** A bare exit code cannot tell a fail-open from
  the arm working, so `Write`, the `declare -F` arm, and the healthy-library
  state each shipped a hole once the others had pairs.
- **One needle per refusal sentence**, measured by deleting each line.
- **A case must reach the branch it names.** The worktree-repair case originally
  sat under a directory the fixture never created, so `__norm_candidate`
  returned 1 and its MAIN-tree twin answered 0 too.

Also green: `main-tree-edit-oracle.test.sh` (0 fail-opens, 0 false-blocks over
207 executed commands), the full hook suite under both bashes (80 suite-runs,
0 failures), and 946 files / 20,534 unit tests on the rebased base.

## Docs

- `.claude/rules/hooks-main-tree-edit.md` — the `Bash`-only fail-closed, why the
  split is sound, the measured table, the three test properties, and the
  unanchored-matcher fact.
- `.claude/rules/hooks.md` — the class paragraph *"Every gate that sources the
  helper fails CLOSED"* now carries the carve-out, stated as an exception for a
  MATCHER rather than a softening.
- `rule-file-payload.test.ts` — the row's annotation was re-derived from the
  assertion itself (`86_662`), and its comment corrected: the payload is three
  files, not the two it named. See the retraction below for the figure's real
  history.

## Two fences in this diff were passing vacuously

Both are the same shape as the bug the PR fixes — a check whose subject can
vanish — and both were found by review, not by a failing test:

- The payload FLOOR on this row was `56_000`, while its own comment claimed a
  looser floor "cannot notice the satellite going dark, because hooks.md alone
  satisfies it unaided". That was true of `56_000` too: `hooks.md` is 70,168 B,
  so **both** satellites could go dark and the row still passed. Now `78_000` —
  measured, blanking `hooks-main-tree-edit.md` leaves 74,860 and reds, naming
  the file. The residual is stated in the comment rather than papered over.
- The matcher fence I added read `entries[0]?.matcher ?? ''`, and
  `new RegExp('')` matches every tool — so an **absent** matcher satisfied every
  assertion under it. It now requires a non-empty string, and a matcher that is
  not a legal JS RegExp (a `*` wildcard) fails with the reason instead of a raw
  `SyntaxError`. Both probed.

One annotation in this diff is a RETRACTION: an earlier commit claimed
`68_626` was `86_662` with digits transposed. `git log -S'68_626'` finds
go-to-k/cdkd#2731, where the three files measured 59,133 + 5,692 + 3,801 =
68,626 exactly. It was correct when written and went stale by growth — much of
it this branch's. The comment now records that, and says to check the history
before explaining why a figure differs.

## Follow-up filed

go-to-k/cdkd#2794 — `worktree-owner-gate.test.sh` builds every payload with
`file_path` and never sets `tool_name`, so the `notebook_path` fallback this
change learned the field name from is unfenced in its own suite. `severity:low`,
`effort:small`.

Refs go-to-k/cdkd#2717 — the first of its two remaining items. The
`issue-deferral-criteria-gate` deletion follows in its own PR and closes the
issue.
