### PR TITLE
test(integ): pin the assume-role propagation window again, with a second deploy

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -284,7 +284,7 @@ stack-lock-renewal	2026-08-23T02:58:02Z	PASS	539	verify.sh	issue #2168 lock rene
 state-destroy	2026-08-13T06:35:09Z	PASS	95	standard	PR 1774 gate; state destroy exit-code path, 1 del 0 err, zero-skip run byte-identical (no skipped suffix), orph clean
 state-info-command	2026-08-02T05:07:05Z	PASS	31	verify.sh	new verify.sh (#1335): state info human+json, flag+env sources, 1 del/0 err, 0 orphans
 stepfunctions	2026-09-08T08:09:51Z	PASS	130	verify.sh	rc 0, ACTIVE w/ auto role, destroy 0 orphans (SFN arm for #2783)
-stepfunctions-logging	2026-09-08T09:12:07Z	PASS	195	verify.sh	rc 0; 3rd run of phase 1a: 10 log-destination retries, 0 assume-role (#2783)
+stepfunctions-logging	2026-09-09T03:19:48Z	PASS	300	verify.sh	rc 0; phase 1a 7 log-destination retries, phase 4a 5 assume-role retries (#2801); 2 destroys 0 errors
 stepfunctions-s3-definition	2026-07-26T19:45:58Z	PASS	43	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 synthetics-canary	2026-07-26T19:25:15Z	PASS	144	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 tags-propagation	2026-07-26T18:49:34Z	PASS	63	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -284,7 +284,7 @@ stack-lock-renewal	2026-08-23T02:58:02Z	PASS	539	verify.sh	issue #2168 lock rene
 state-destroy	2026-08-13T06:35:09Z	PASS	95	standard	PR 1774 gate; state destroy exit-code path, 1 del 0 err, zero-skip run byte-identical (no skipped suffix), orph clean
 state-info-command	2026-08-02T05:07:05Z	PASS	31	verify.sh	new verify.sh (#1335): state info human+json, flag+env sources, 1 del/0 err, 0 orphans
 stepfunctions	2026-09-08T08:09:51Z	PASS	130	verify.sh	rc 0, ACTIVE w/ auto role, destroy 0 orphans (SFN arm for #2783)
-stepfunctions-logging	2026-09-09T03:19:48Z	PASS	300	verify.sh	rc 0; phase 1a 7 log-destination retries, phase 4a 5 assume-role retries (#2801); 2 destroys 0 errors
+stepfunctions-logging	2026-09-09T03:36:24Z	PASS	310	verify.sh	rc 0; 1a 6 log-dest retries, 4a 5 assume-role (+1 log-dest tail); 2 destroys 0 errors (#2801)
 stepfunctions-s3-definition	2026-07-26T19:45:58Z	PASS	43	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 synthetics-canary	2026-07-26T19:25:15Z	PASS	144	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 tags-propagation	2026-07-26T18:49:34Z	PASS	63	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean

--- a/src/deployment/retryable-errors.ts
+++ b/src/deployment/retryable-errors.ts
@@ -181,12 +181,11 @@ export const IAM_PROPAGATION_ERROR_MESSAGE_PATTERNS: readonly string[] = [
   // before surfacing. CloudFormation tolerates this via deployment latency;
   // cdkd retries. Surfaced by a bug-hunt sweep deploying a canonical Express
   // state machine with LoggingConfiguration (StateMachine + fresh Role +
-  // DefaultPolicy). NOT pinned by an integ today: stepfunctions-logging used to
-  // exercise this window, but its Phase 0 now settles the trust policy on
-  // purpose so the log-destination window below is reachable at all — and the
-  // two are mutually exclusive. Restoring a live pin is issue
-  // https://github.com/go-to-k/cdkd/issues/2801; the unit test still pins the
-  // classification.
+  // DefaultPolicy); pinned by tests/integration/stepfunctions-logging Phase 4,
+  // which redeploys the whole stack from nothing after the destroy so the role
+  // is fresh again. That phase exists because the fixture's Phase 0 settles the
+  // trust policy on purpose to reach the log-destination window below, and the
+  // two windows are mutually exclusive — one deploy can only pin one of them.
   'authorized to assume the provided role',
   // Step Functions CreateStateMachine / UpdateStateMachine, SECOND rejection of
   // the same deploy — the one that surfaces once the trust policy HAS settled.

--- a/tests/integration/stepfunctions-logging/lib/stepfunctions-logging-stack.ts
+++ b/tests/integration/stepfunctions-logging/lib/stepfunctions-logging-stack.ts
@@ -32,7 +32,10 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 //
 // So a single-deploy fixture CANNOT exercise window 2, and asserting on it
 // "when it happens" would be a test that passes identically with the fix
-// reverted. STAGE 0 is what makes it deterministic: it deploys the LogGroup
+// reverted. It cannot exercise BOTH either, which is why verify.sh deploys
+// twice: Phase 4 redeploys this same template from nothing after the destroy,
+// so the role is fresh again and window 1 is the one still open (issue #2801).
+// STAGE 0 is what makes window 2 deterministic: it deploys the LogGroup
 // and the execution Role ALONE and lets the trust policy settle, so the next
 // deploy creates the DefaultPolicy grants ~1s before CreateStateMachine and
 // window 2 is the only race left open. Measured over two runs of this shape:

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -25,6 +25,14 @@
 # Each phase ASSERTS its retry fired, because a run that never reaches its
 # window would pass identically with the corresponding fix reverted.
 #
+# The two directions are NOT symmetric, and each assertion keys on its own
+# needle rather than on exclusivity for that reason. Phase 1 is pure by
+# construction -- Phase 0's settle closes window 1, measured 0 assume-role
+# rejections across runs. Phase 4 only LEADS with window 1: once the trust
+# policy settles mid-deploy the grants may still be propagating, so a
+# log-destination retry can follow in the same phase (measured: 5 then 1).
+# Both are absorbed and the deploy succeeds, which is the property under test.
+#
 # Also the integ coverage for SFN LoggingConfiguration + TracingConfiguration
 # removal-clear on UPDATE (issue #978): UpdateStateMachine is patch-style, so a
 # config removed from the template is silently kept unless cdkd sends the
@@ -188,7 +196,11 @@ dump_retry_evidence() {
   echo "      --- last propagation-retry lines seen (may be empty) ---" >&2
   grep -E 'Retrying|attempt [0-9]+/' "${DEPLOY_LOG:-/dev/null}" | tail -5 >&2 || true
   echo "      --- last AccessDenied / authorization lines seen ---" >&2
-  grep -iE 'accessdenied|not authorized' "${DEPLOY_LOG:-/dev/null}" | tail -5 >&2 || true
+  # `authorized to assume` is NOT redundant with `not authorized`: window 1's
+  # sentence reads "...nor the regional one IS authorized to assume the provided
+  # role", carrying neither "not authorized" nor "AccessDenied". Without it this
+  # digest prints empty on exactly the regression Phase 4 exists to catch.
+  grep -iE 'accessdenied|not authorized|authorized to assume' "${DEPLOY_LOG:-/dev/null}" | tail -5 >&2 || true
 }
 
 # Assert that cdkd RETRIED a propagation rejection, for ONE named phrase.
@@ -197,6 +209,8 @@ dump_retry_evidence() {
 # $2 label    what to call it in the output
 # $3 wrong-window hint, for the case where retries fired carrying some OTHER
 #             propagation phrase (each caller's neighbouring window differs)
+# $4 no-retry hint, for the case where nothing raced at all -- also per window,
+#             because the knob that would widen each gap is a different one
 #
 # The needle is AWS's text; the SENTINEL is cdkd's own propagation-retry line,
 # present whenever ANY propagation retry happened. Checking both distinguishes
@@ -208,7 +222,7 @@ dump_retry_evidence() {
 # checks assume-role first), so each phase closes one and asserts the other, and
 # a copy per phase is a copy that can drift away from the sentinel it shares.
 assert_propagation_retry() {
-  local needle="$1" label="$2" wrong_window_hint="$3"
+  local needle="$1" label="$2" wrong_window_hint="$3" no_retry_hint="$4"
   local hits propagation_hits
   hits="$(grep -cF "${needle}" "${DEPLOY_LOG}" || true)"
   propagation_hits="$(grep -cE 'attempt [0-9]+/26' "${DEPLOY_LOG}" || true)"
@@ -228,8 +242,62 @@ assert_propagation_retry() {
   echo "      proves nothing about the ${label} pattern. Either the retry debug line" >&2
   echo "      moved off --verbose (it is logger.debug, so --verbose is required), or" >&2
   echo "      IAM now propagates inside the gap cdkd leaves before the create." >&2
+  echo "      ${no_retry_hint}" >&2
   dump_retry_evidence
   exit 1
+}
+
+# Destroy the stack and assert it is really gone, for a named phase.
+#
+# $1 the state machine ARN captured BEFORE the destroy
+# $2 the phase label, for the failure messages
+#
+# ONE helper for both destroys, by the same argument as
+# assert_propagation_retry: Phase 5 began as a verbatim copy of Phase 3 and had
+# already lost one of its comments. A drifting copy here fails SILENTLY -- a
+# broken poll still exits 0 whenever the machine happens to be gone already.
+destroy_and_assert_gone() {
+  local sm_arn="$1" phase="$2"
+  node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
+
+  # SFN DeleteStateMachine is ASYNC: accept DELETING and poll until gone.
+  local sm_gone="" attempt status describe_rc
+  for attempt in $(seq 1 15); do
+    # The capture sits in the `if` CONDITION, not in a bare assignment: errexit
+    # does not apply there, so the status is readable without `|| true`
+    # swallowing it -- which also keeps "the describe FAILED" distinguishable
+    # from "the describe answered something unexpected", two cases the swallowed
+    # form conflated.
+    if status="$(aws stepfunctions describe-state-machine --state-machine-arn "${sm_arn}" \
+      --region "${REGION}" --query 'status' --output text 2>&1)"; then
+      describe_rc=0
+    else
+      describe_rc=$?
+    fi
+    if [ "${describe_rc}" != "0" ]; then
+      if echo "${status}" | grep -q "StateMachineDoesNotExist"; then
+        sm_gone="yes"
+        break
+      fi
+      # A describe that failed for any OTHER reason (throttle, network) is most
+      # likely transient — keep polling rather than hard-failing after a clean
+      # destroy; the 15-attempt bound terminates the loop either way.
+      echo "    describe failed (attempt ${attempt}/15, rc=${describe_rc}): ${status}"
+    elif [ "${status}" != "DELETING" ]; then
+      echo "    describe returned unexpected status (attempt ${attempt}/15): ${status}"
+    else
+      echo "    state machine still DELETING (attempt ${attempt}/15), waiting..."
+    fi
+    sleep 4
+  done
+  if [ -z "${sm_gone}" ]; then
+    echo "FAIL: state machine ${sm_arn} did not finish deleting within ~60s (${phase})" >&2
+    exit 1
+  fi
+  echo "    state machine deleted"
+
+  assert_gone "state file ${STATE_KEY} still exists after ${phase}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+  echo "    cdkd state removed"
 }
 
 # --- Phase 1: deploy baseline (logging level ALL + tracing enabled) ----
@@ -283,7 +351,8 @@ echo "==> Phase 1a: assert the log-destination propagation race was retried (#27
 assert_propagation_retry \
   'not authorized to access the Log Destination' \
   'log-destination' \
-  'window 1 is still open despite the Phase 0 settle (raise TRUST_SETTLE_S)'
+  'window 1 is still open despite the Phase 0 settle (raise TRUST_SETTLE_S)' \
+  'Raising TRUST_SETTLE_S does NOT help here -- it widens the TRUST-policy gap, not the grants gap this window races.'
 
 SM_ARN="$(sm_arn)"
 echo "    state machine: ${SM_ARN}"
@@ -343,35 +412,7 @@ fi
 
 # --- Phase 3: destroy ---------------------------------------------------
 echo "==> Phase 3: destroy"
-node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
-
-# SFN DeleteStateMachine is ASYNC: accept DELETING and poll until gone.
-sm_gone=""
-for attempt in $(seq 1 15); do
-  STATUS="$(aws stepfunctions describe-state-machine --state-machine-arn "${SM_ARN}" \
-    --region "${REGION}" --query 'status' --output text 2>&1 || true)"
-  if echo "${STATUS}" | grep -q "StateMachineDoesNotExist"; then
-    sm_gone="yes"
-    break
-  fi
-  # Anything other than DELETING / gone is most likely a transient describe
-  # error (throttle, network) — keep polling instead of hard-failing after a
-  # clean destroy; the 15-attempt bound terminates the loop either way.
-  if [ "${STATUS}" != "DELETING" ]; then
-    echo "    describe returned unexpected output (attempt ${attempt}/15): ${STATUS}"
-  else
-    echo "    state machine still DELETING (attempt ${attempt}/15), waiting..."
-  fi
-  sleep 4
-done
-if [ -z "${sm_gone}" ]; then
-  echo "FAIL: state machine ${SM_ARN} did not finish deleting within ~60s" >&2
-  exit 1
-fi
-echo "    state machine deleted"
-
-assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
-echo "    cdkd state removed"
+destroy_and_assert_gone "${SM_ARN}" "Phase 3"
 
 # --- Phase 4: the ORIGINAL shape, which pins the ASSUME-ROLE window -----
 # Phase 0 exists to CLOSE window 1 so window 2 is reachable, and the two are
@@ -407,34 +448,11 @@ echo "==> Phase 4a: assert the assume-role propagation race was retried"
 assert_propagation_retry \
   'authorized to assume the provided role' \
   'assume-role' \
-  'the role outlived Phase 3, so this deploy is not creating it fresh'
+  'the trust policy propagated inside this deploy, closing window 1 before the create' \
+  'Nothing to raise here: this phase opens window 1 by CREATING the role in the same deploy, and that gap is cdkd own DAG ordering.'
 
 echo "==> Phase 5: destroy again"
 SM_ARN_P4="$(sm_arn)"
-node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
-
-sm_gone_p4=""
-for attempt in $(seq 1 15); do
-  STATUS_P4="$(aws stepfunctions describe-state-machine --state-machine-arn "${SM_ARN_P4}" \
-    --region "${REGION}" --query 'status' --output text 2>&1 || true)"
-  if echo "${STATUS_P4}" | grep -q "StateMachineDoesNotExist"; then
-    sm_gone_p4="yes"
-    break
-  fi
-  if [ "${STATUS_P4}" != "DELETING" ]; then
-    echo "    describe returned unexpected output (attempt ${attempt}/15): ${STATUS_P4}"
-  else
-    echo "    state machine still DELETING (attempt ${attempt}/15), waiting..."
-  fi
-  sleep 4
-done
-if [ -z "${sm_gone_p4}" ]; then
-  echo "FAIL: state machine ${SM_ARN_P4} did not finish deleting within ~60s (Phase 5)" >&2
-  exit 1
-fi
-echo "    state machine deleted"
-
-assert_gone "state file ${STATE_KEY} still exists after Phase 5" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
-echo "    cdkd state removed"
+destroy_and_assert_gone "${SM_ARN_P4}" "Phase 5"
 
 echo "[verify] PASS — SFN Express + Logging/Tracing: log-destination propagation retry (#2783), assume-role propagation retry (#2801), removal-clear update (#978), destroy: all phases passed"

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -13,11 +13,17 @@
 # cdkd retries them on the dense cadence (src/deployment/retryable-errors.ts).
 #
 # Which race you get depends on the AGE GAP between the trust policy and the
-# grants, and window 1 MASKS window 2 (SFN checks assume-role first). Phase 0
-# exists to make window 2 deterministic — it deploys the role alone and lets it
-# settle, so the Phase 1 create races the log-delivery grants only. Phase 1a
-# then ASSERTS the retry happened, because a run that never reaches window 2
-# would pass identically with the #2783 fix reverted.
+# grants, and window 1 MASKS window 2 (SFN checks assume-role first). So ONE
+# deploy can only ever pin ONE of them, and this fixture pins both by deploying
+# twice from different starting states:
+#
+#   Phase 0-1a  role deployed ALONE and left to settle, so only the
+#               log-delivery grants are still propagating -> window 2 (#2783).
+#   Phase 4-4a  everything redeployed from nothing after Phase 3, so the role
+#               is fresh again -> window 1 (#2801).
+#
+# Each phase ASSERTS its retry fired, because a run that never reaches its
+# window would pass identically with the corresponding fix reverted.
 #
 # Also the integ coverage for SFN LoggingConfiguration + TracingConfiguration
 # removal-clear on UPDATE (issue #978): UpdateStateMachine is patch-style, so a
@@ -35,6 +41,10 @@
 #      template). Assert AWS now reports logging level OFF and tracing disabled
 #      (the removal actually reached AWS, not just cdkd state).
 #   3. Destroy + assert the state machine is gone and cdkd state is removed.
+#   4. Redeploy from scratch (role + policy + state machine together), so the
+#      assume-role window is the one still open.
+#   4a. Assert cdkd RETRIED the assume-role rejection (needle + sentinel).
+#   5. Destroy again + the same gone-probes.
 #
 # Required env vars:
 #   STATE_BUCKET — cdkd state bucket (e.g. cdkd-state-{accountId})
@@ -181,6 +191,47 @@ dump_retry_evidence() {
   grep -iE 'accessdenied|not authorized' "${DEPLOY_LOG:-/dev/null}" | tail -5 >&2 || true
 }
 
+# Assert that cdkd RETRIED a propagation rejection, for ONE named phrase.
+#
+# $1 needle   AWS's own sentence for the window under test
+# $2 label    what to call it in the output
+# $3 wrong-window hint, for the case where retries fired carrying some OTHER
+#             propagation phrase (each caller's neighbouring window differs)
+#
+# The needle is AWS's text; the SENTINEL is cdkd's own propagation-retry line,
+# present whenever ANY propagation retry happened. Checking both distinguishes
+# "the race did not occur" from "the retry line was reworded and this grep went
+# blind" -- a bare needle grep returning 0 cannot tell them apart
+# (.claude/rules/testing.md, "a fixture that greps cdkd's OWN output").
+#
+# ONE helper for both windows: they are mutually exclusive by construction (SFN
+# checks assume-role first), so each phase closes one and asserts the other, and
+# a copy per phase is a copy that can drift away from the sentinel it shares.
+assert_propagation_retry() {
+  local needle="$1" label="$2" wrong_window_hint="$3"
+  local hits propagation_hits
+  hits="$(grep -cF "${needle}" "${DEPLOY_LOG}" || true)"
+  propagation_hits="$(grep -cE 'attempt [0-9]+/26' "${DEPLOY_LOG}" || true)"
+  echo "    ${label} retries: ${hits}; propagation-retry lines: ${propagation_hits}"
+  if [ "${hits}" -gt 0 ]; then
+    echo "    OK: cdkd retried the ${label} rejection and the deploy still succeeded"
+    return 0
+  fi
+  if [ "${propagation_hits}" -gt 0 ]; then
+    echo "FAIL: propagation retries fired but none carried the ${label} phrase." >&2
+    echo "      Either AWS reworded the message (update the pattern in" >&2
+    echo "      src/deployment/retryable-errors.ts and this grep), or ${wrong_window_hint}." >&2
+    dump_retry_evidence
+    exit 1
+  fi
+  echo "FAIL: no propagation retry at all -- the deploy never raced IAM, so this run" >&2
+  echo "      proves nothing about the ${label} pattern. Either the retry debug line" >&2
+  echo "      moved off --verbose (it is logger.debug, so --verbose is required), or" >&2
+  echo "      IAM now propagates inside the gap cdkd leaves before the create." >&2
+  dump_retry_evidence
+  exit 1
+}
+
 # --- Phase 1: deploy baseline (logging level ALL + tracing enabled) ----
 echo "==> Phase 1: deploy Express state machine with logging level ALL + tracing enabled"
 # --verbose so the per-attempt propagation-retry lines reach the log; the
@@ -229,29 +280,10 @@ fi
 # this grep went blind" — a bare needle grep returning 0 cannot tell them apart
 # (.claude/rules/testing.md, "a fixture that greps cdkd's OWN output").
 echo "==> Phase 1a: assert the log-destination propagation race was retried (#2783)"
-LOG_DEST_HITS="$(grep -c 'not authorized to access the Log Destination' "${DEPLOY_LOG}" || true)"
-PROPAGATION_HITS="$(grep -cE 'attempt [0-9]+/26' "${DEPLOY_LOG}" || true)"
-echo "    log-destination retries: ${LOG_DEST_HITS}; propagation-retry lines: ${PROPAGATION_HITS}"
-if [ "${LOG_DEST_HITS}" -gt 0 ]; then
-  echo "    OK: cdkd retried the log-destination rejection and the deploy still succeeded"
-elif [ "${PROPAGATION_HITS}" -gt 0 ]; then
-  echo "FAIL: propagation retries fired but none carried the log-destination phrase." >&2
-  echo "      Either AWS reworded the message (update the pattern in" >&2
-  echo "      src/deployment/retryable-errors.ts and this grep), or window 1 is" >&2
-  echo "      still open despite the Phase 0 settle (raise TRUST_SETTLE_S)." >&2
-  dump_retry_evidence
-  exit 1
-else
-  echo "FAIL: no propagation retry at all -- the deploy never raced IAM, so this run" >&2
-  echo "      proves nothing about issue #2783. Either the retry debug line moved off" >&2
-  echo "      --verbose (it is logger.debug, so --verbose is required), or IAM now" >&2
-  echo "      propagates the log-delivery grants inside the ~1s cdkd leaves between" >&2
-  echo "      the DefaultPolicy CREATE and CreateStateMachine. Raising TRUST_SETTLE_S" >&2
-  echo "      does NOT help that second case -- it widens the TRUST-policy gap only." >&2
-  dump_retry_evidence
-  exit 1
-fi
-rm -f "${DEPLOY_LOG}"
+assert_propagation_retry \
+  'not authorized to access the Log Destination' \
+  'log-destination' \
+  'window 1 is still open despite the Phase 0 settle (raise TRUST_SETTLE_S)'
 
 SM_ARN="$(sm_arn)"
 echo "    state machine: ${SM_ARN}"
@@ -341,4 +373,68 @@ echo "    state machine deleted"
 assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
-echo "[verify] PASS — SFN Express + Logging/Tracing deploy (log-destination propagation retry, #2783), removal-clear update (#978), destroy: all phases passed"
+# --- Phase 4: the ORIGINAL shape, which pins the ASSUME-ROLE window -----
+# Phase 0 exists to CLOSE window 1 so window 2 is reachable, and the two are
+# mutually exclusive -- so the phases above can no longer exercise the
+# assume-role race at all. That left `authorized to assume the provided role`
+# with no live pin (issue #2801). This phase restores it by redeploying the
+# whole template from nothing: Phase 3 destroyed the role, so role, policy and
+# state machine are created together again and SFN's assume-role check -- which
+# runs FIRST -- is the window still open.
+#
+# No template change is needed for this; "everything at once" IS the default
+# stage. What makes it the other window is only that no role survives Phase 3.
+echo "==> Phase 4: redeploy from scratch (role + policy + state machine together)"
+set +e
+env -u CDKD_TEST_UPDATE -u CDKD_TEST_STAGE node "${LOCAL_DIST}" deploy "${STACK}" \
+  --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes --verbose 2>&1 |
+  tee "${DEPLOY_LOG}"
+PHASE4_RCS=("${PIPESTATUS[@]}")
+P4_DEPLOY_RC="${PHASE4_RCS[0]}"
+P4_TEE_RC="${PHASE4_RCS[1]}"
+set -e
+if [ "${P4_DEPLOY_RC}" != "0" ]; then
+  echo "FAIL: Phase 4 deploy exited ${P4_DEPLOY_RC}" >&2
+  dump_retry_evidence
+  exit "${P4_DEPLOY_RC}"
+fi
+if [ "${P4_TEE_RC}" != "0" ]; then
+  echo "FAIL: could not capture the Phase 4 deploy log (tee exited ${P4_TEE_RC})" >&2
+  exit 1
+fi
+
+echo "==> Phase 4a: assert the assume-role propagation race was retried"
+assert_propagation_retry \
+  'authorized to assume the provided role' \
+  'assume-role' \
+  'the role outlived Phase 3, so this deploy is not creating it fresh'
+
+echo "==> Phase 5: destroy again"
+SM_ARN_P4="$(sm_arn)"
+node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
+
+sm_gone_p4=""
+for attempt in $(seq 1 15); do
+  STATUS_P4="$(aws stepfunctions describe-state-machine --state-machine-arn "${SM_ARN_P4}" \
+    --region "${REGION}" --query 'status' --output text 2>&1 || true)"
+  if echo "${STATUS_P4}" | grep -q "StateMachineDoesNotExist"; then
+    sm_gone_p4="yes"
+    break
+  fi
+  if [ "${STATUS_P4}" != "DELETING" ]; then
+    echo "    describe returned unexpected output (attempt ${attempt}/15): ${STATUS_P4}"
+  else
+    echo "    state machine still DELETING (attempt ${attempt}/15), waiting..."
+  fi
+  sleep 4
+done
+if [ -z "${sm_gone_p4}" ]; then
+  echo "FAIL: state machine ${SM_ARN_P4} did not finish deleting within ~60s (Phase 5)" >&2
+  exit 1
+fi
+echo "    state machine deleted"
+
+assert_gone "state file ${STATE_KEY} still exists after Phase 5" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+echo "    cdkd state removed"
+
+echo "[verify] PASS — SFN Express + Logging/Tracing: log-destination propagation retry (#2783), assume-role propagation retry (#2801), removal-clear update (#978), destroy: all phases passed"


### PR DESCRIPTION
## Problem

`CreateStateMachine` can hit two different IAM-propagation windows, and Step
Functions checks them in a fixed order:

1. **assume-role** — `Neither the global service principal
   states.amazonaws.com, nor the regional one is authorized to assume the
   provided role.`
2. **log-destination** — `The state machine IAM Role is not authorized to
   access the Log Destination`

Window 1 MASKS window 2. PR (#2791) added a Phase 0 to `stepfunctions-logging`
that deploys the execution role alone and lets its trust policy settle, so the
Phase 1 create races the log-delivery grants only — which is what made window 2
reachable at all.

That necessarily made window 1 unreachable. Its retry pattern lost its live
pin, no other fixture exercised it, and the fixture's Phase 1a would actively
FAIL a run whose propagation retries carried the assume-role phrase. The
pattern's provenance comment still claimed the fixture pinned it.

## Fix

One deploy can only pin one window, so the fixture deploys twice from different
starting states:

| Phase | Starting state | Window pinned |
| --- | --- | --- |
| 0-1a | role deployed ALONE, trust policy settled | log-destination (#2783) |
| 4-4a | everything redeployed from nothing after Phase 3 | assume-role (#2801) |

**No template change was needed.** "Everything at once" is already the default
stage, and Phase 3 destroys the role — so redeploying the whole stack
reproduces the original pre-Phase-0 shape for free. Phase 5 then destroys again
with the same gone-probes Phase 3 uses.

The needle+sentinel assertion is now ONE helper taking the phrase, its label,
and a per-window hint for the "retries fired but carried the other phrase"
case. A copy per phase is a copy that can drift away from the sentinel it
shares.

## Verification

Two real-AWS runs of this shape. Each phase reaches its own window:

```
==> Phase 1a: assert the log-destination propagation race was retried (#2783)
    log-destination retries: 7; propagation-retry lines: 7
    OK: cdkd retried the log-destination rejection and the deploy still succeeded
...
==> Phase 4a: assert the assume-role propagation race was retried
    assume-role retries: 5; propagation-retry lines: 5
    OK: cdkd retried the assume-role rejection and the deploy still succeeded
```

The two directions are NOT symmetric, and the second run is what established
that — the first run's "zero contamination both ways" was a one-run number:

- **Phase 1 is pure by construction.** Phase 0's settle closes window 1, and
  both runs saw zero assume-role rejections there.
- **Phase 4 only LEADS with window 1.** Once the trust policy settles
  mid-deploy the grants may still be propagating, so a log-destination retry
  can follow in the same phase — run 2 measured 5 then 1.

Both are absorbed and the deploy succeeds, which is the property under test, so
each assertion keys on its OWN needle rather than on exclusivity. The fixture
comment states this rather than implying symmetry.

Both runs: all phases passed, both destroys clean (3 and 4 deleted, 0 errors),
no orphans, exit 0.

## Notes

- No changelog entry: this is tests plus a comment, with no behavior delta in
  the shipped binary.
- `src/deployment/retryable-errors.ts` is comment-only, so the `integ-broad`
  marker from this branch's cross-cutting scope still stands on its existing
  broad run.

Closes #2801
