### PR TITLE
docs(retry): state the DELETE path's real backoff grid, 5s/8s/8s rather than 3 x 5s

### DIFF
--- a/.claude/rules/layout-deployment.md
+++ b/.claude/rules/layout-deployment.md
@@ -424,9 +424,9 @@ Index of every area: [code-layout.md](code-layout.md).
     dense IAM grid, which needed its own ceiling).
   - All special grids apply ONLY on the default schedule: any explicit
     `maxRetries` / `initialDelayMs` / `maxDelayMs` / `isRetryable` means the
-    caller owns the cadence verbatim (the DELETE path's 3 retries from 5s —
-    5s/8s/8s, since it sets `initialDelayMs` and leaves `maxDelayMs` at the 8s
-    default — `describe-type.ts`'s throttle-only retry).
+    caller owns the cadence verbatim: the DELETE path's 3 retries from 5s
+    (5s/8s/8s, since it passes `initialDelayMs` and leaves `maxDelayMs` at the
+    8s default), and `describe-type.ts`'s throttle-only retry.
   - Dense-grid rationale: cdkd creates an IAM entity and consumes it ~1-3s
     later, so propagation resolves in single-digit seconds — the generic
     4s/8s steps overshoot (measured: ~10.2s of a 25.9s deploy burned in

--- a/.claude/rules/layout-deployment.md
+++ b/.claude/rules/layout-deployment.md
@@ -424,8 +424,9 @@ Index of every area: [code-layout.md](code-layout.md).
     dense IAM grid, which needed its own ceiling).
   - All special grids apply ONLY on the default schedule: any explicit
     `maxRetries` / `initialDelayMs` / `maxDelayMs` / `isRetryable` means the
-    caller owns the cadence verbatim (the DELETE path's 3 x 5s,
-    `describe-type.ts`'s throttle-only retry).
+    caller owns the cadence verbatim (the DELETE path's 3 retries from 5s —
+    5s/8s/8s, since it sets `initialDelayMs` and leaves `maxDelayMs` at the 8s
+    default — `describe-type.ts`'s throttle-only retry).
   - Dense-grid rationale: cdkd creates an IAM entity and consumes it ~1-3s
     later, so propagation resolves in single-digit seconds — the generic
     4s/8s steps overshoot (measured: ~10.2s of a 25.9s deploy burned in

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -150,7 +150,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-08T12:44:00Z	PASS	150	verify.sh	issue #2767 + #2802 broad-set arm after the fence review round; 9 deleted 0 errors
+lambda	2026-09-09T03:18:49Z	PASS	82	verify.sh	rc ok, 9 deleted 0 errors, orph clean
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -150,7 +150,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-09T03:18:49Z	PASS	82	verify.sh	rc ok, 9 deleted 0 errors, orph clean
+lambda	2026-09-09T03:18:49Z	PASS	82	verify.sh	issue #2785 gate refresh, 9 deleted 0 errors, orph clean
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans

--- a/src/deployment/retry.ts
+++ b/src/deployment/retry.ts
@@ -241,9 +241,10 @@ const defaultSleep = (ms: number): Promise<void> =>
  * 4s/8s steps overshoot it. The dense schedule applies ONLY when the caller
  * left the schedule at its defaults — a caller that passed its own
  * `maxRetries` / `initialDelayMs` / `maxDelayMs` / `isRetryable` picked that
- * schedule deliberately (e.g. the DELETE path's 3 x 5s, or the delete-then-
- * re-create sites' ~64s budget covering SQS's 60s name cooldown) and gets it
- * verbatim.
+ * schedule deliberately (e.g. the DELETE path's 3 retries from 5s — 5s/8s/8s,
+ * since it passes `initialDelayMs` but leaves `maxDelayMs` at the 8s default —
+ * or the delete-then-re-create sites' ~64s budget covering SQS's 60s name
+ * cooldown) and gets it verbatim.
  *
  * A THIRD class rides its own grid on the default schedule since issue
  * [#2116](https://github.com/go-to-k/cdkd/issues/2116): a NAME COOLDOWN (a


### PR DESCRIPTION
## Summary

Two comments described the DELETE path's retry backoff as **"3 x 5s"**, which
reads as 15s. The real grid is **5s / 8s / 8s = 21s**: the call site passes
`maxRetries: 3` and `initialDelayMs: 5_000` but never threads `maxDelayMs`, so
`withRetry`'s 8s default caps every step after the first.

- `src/deployment/retry.ts` — comment only.
- `.claude/rules/layout-deployment.md` — the one that matters. It is loaded
  into any session working on `src/deployment/**`, so the wrong figure is what
  a future session would size a DELETE budget against.

The figure was re-derived from the defaults rather than trusted from the issue
body, and review then found it was **already pinned by the repo's own test** —
`tests/unit/deployment/retry.test.ts:344` asserts `[5, 8, 8]`. The comments had
been contradicting a passing test.

## Two corrections to the issue's premise

- `docs/changelog-cdkd.md` is a **gitignored build artifact** assembled by
  `scripts/assemble-changelog.ts` (it was replaced by `changelog.d/` in
  go-to-k/cdkd#2811 while the issue sat open). The tracked third copy of
  "3 x 5s" is `changelog.d/_archive.md:933`, and it stays — the forward-only
  cutoff applies to it for the same reason the issue gave.
- The issue estimated `small (S) / ~15 min`. That was wrong: `retry.ts` is in
  both the `integ-destroy` and `integ-broad` gate scopes, which digest the file
  diff and cannot tell a comment from code, so a real-AWS integ run was
  required to make this mergeable. The right classification was `medium (M)`.

## Test plan

- `vp run check`, `vp run typecheck:test`, `vp run build` — pass.
- `vp test run` — 952 files, 20664 tests, pass.
- **Real-AWS integ**: `lambda` (broad set), 82s — 9 resources deployed and
  destroyed, **0 errors, 0 orphans**. Verified independently afterwards: no
  `state.json` anywhere in the bucket, and no IAM role / Lambda / DynamoDB /
  SQS / event-source-mapping matching the stack. Refreshes `integ-destroy` and
  `integ-broad`; recorded in the committed ledger.

## Review

Size alone was `inline` (3 files, 8 insertions). Raised to 1-reviewer because
`src/deployment/retry.ts` carries `fix:` in 3 of its last 3 commits — a trigger
the merge hook cannot see, since it reads the diff and not the file's history.

The reviewer confirmed the derivation independently from the call site and
`withRetry`'s defaults, and found one regression the edit itself introduced: a
closing em dash had replaced the list comma in `layout-deployment.md`, leaving
`describe-type.ts`'s throttle-only retry dangling off the aside instead of
reading as the second example. Fixed in the second commit, along with a
`sets`/`passes` inconsistency between the two files and a missing issue
attribution on the ledger row.

Closes #2785
