### PR TITLE
test(scripts): fence the /new-integ scaffold aws-cdk-lib floor against the fixture corpus

### DIFF
--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -62,8 +62,11 @@
  * worth stating because they look symmetric and are not:
  *
  *  - A directory with no `package.json` (not a fixture) increments NEITHER
- *    counter, so the `fixtures === declaringFixtures` pin cannot see it. Only
- *    `FLOORS.fixtures` catches a walk that stopped finding manifests.
+ *    counter, so the `fixtures === declaringFixtures` pin cannot see it. A walk
+ *    that stopped finding manifests is caught by the `fixtures === 0` violation
+ *    below when it stops entirely, and by the test's independent
+ *    `fixtures >= 280` assertion when it merely shrinks. `FLOORS.fixtures` is
+ *    the CLI's own guard and is never consulted by the library or the suite.
  *  - A manifest declaring no `aws-cdk-lib` (not a member of this population)
  *    increments `fixtures` but not `declaringFixtures`, so it IS visible to
  *    that pin — which is what makes a reader silently losing one dependency
@@ -264,7 +267,7 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
       manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
     } catch (error) {
       refusals.push({
-        where: join(INTEG_ROOT_REL, fixture, 'package.json'),
+        where: join(integRoot, fixture, 'package.json'),
         reason: `manifest does not parse: ${String(error)}`,
       });
       continue;
@@ -278,7 +281,7 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
     const floor = parseFloor(spec);
     if (floor === null) {
       refusals.push({
-        where: join(INTEG_ROOT_REL, fixture, 'package.json'),
+        where: join(integRoot, fixture, 'package.json'),
         reason: `aws-cdk-lib spec "${spec}" has no decidable floor (accepted: ^X.Y.Z, ~X.Y.Z, X.Y.Z)`,
       });
       continue;
@@ -322,21 +325,28 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
     // hardcoded label pointed the reader at a directory that was never read.
     violations.push(`${integRoot}: no fixture manifest found — the corpus was not read`);
   } else if (minFloor === null) {
-    // `fixtures === 0` implies `minFloor === null`, so this arm is only ever
-    // reached with manifests present. Distinguish "they parsed and declared
-    // nothing" from "none of them parsed" — the refusals carry the detail, but
-    // the summary line should not assert the wrong one of the two.
-    const detail =
-      refusals.length === fixtures
-        ? `none of them readable (see the ${refusals.length} refusals above)`
-        : 'none declaring a decidable aws-cdk-lib floor';
-    violations.push(`${integRoot}: ${fixtures} fixture manifests read, ${detail}`);
+    // Deliberately states only what it KNOWS, and infers no cause.
+    //
+    // Two rounds of review were spent on a conditional here that tried to say
+    // WHY no floor was found -- "none of them parsed" versus "none declared
+    // one". Every version was wrong for some input, because the counts it
+    // branched on (`refusals.length` against `fixtures`) are different
+    // populations: `refusals` also holds the TEMPLATE refusal and
+    // undecidable-spec failures, neither of which is an unreadable manifest.
+    // The per-file truth is already in `refusals`, and every refusal is
+    // already emitted as its own violation above. So the summary reports the
+    // fact and points at them, rather than re-deriving a cause it cannot see.
+    violations.push(
+      `${integRoot}: ${fixtures} fixture manifests read, none yielded a decidable ` +
+        `aws-cdk-lib floor` +
+        (refusals.length > 0 ? ` (see the ${refusals.length} refusal(s) above for why)` : ''),
+    );
   }
   if (minFloor !== null && templateFloor !== null && compareFloors(templateFloor, minFloor) < 0) {
     const lowest = sorted[0];
     violations.push(
       `${TEMPLATE_REL} emits aws-cdk-lib "${templateFloor.raw}", below the lowest floor in the ` +
-        `fixture corpus ("${lowest.spec}", ${INTEG_ROOT_REL}/${lowest.fixture}). A new fixture ` +
+        `fixture corpus ("${lowest.spec}", ${join(integRoot, lowest.fixture)}). A new fixture ` +
         `scaffolded from this template would start behind the corpus — raise the template.`,
     );
   }

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -1,0 +1,436 @@
+/**
+ * Fence for the `/new-integ` scaffold template's `aws-cdk-lib` floor
+ * (issue #2839).
+ *
+ * WHAT IT ENFORCES
+ *
+ * The floor emitted by `.claude/skills/new-integ/SKILL.md`'s `package.json`
+ * template must not be LOWER than the lowest floor present in the integ-fixture
+ * corpus (`tests/integration/<fixture>/package.json`).
+ *
+ * WHY THAT RULE AND NOT "ALL FLOORS ARE EQUAL"
+ *
+ * Before go-to-k/cdkd#2838 the 292 fixtures carried FOUR different floors
+ * (`^2.169.0` x172, `^2.172.0` x91, `^2.176.0` x15, `^2.257.0` x6). The
+ * systematic source was this template: it emitted a hardcoded `^2.169.0` for
+ * every fixture ever scaffolded, while dependabot moved individual fixtures
+ * forward around it.
+ *
+ * The obvious fence — "every fixture floor is identical" — is WRONG for this
+ * repo, and would have been worse than nothing. Dependabot bumps `aws-cdk-lib`
+ * ONE DIRECTORY AT A TIME (go-to-k/cdkd#2487, #2488, #2834 are each a single
+ * fixture), so the corpus is legitimately non-uniform between such merges, and
+ * an equality fence would red-flag every one of those PRs. A fence that fires
+ * on correct, routine, bot-authored changes gets disabled, not obeyed.
+ *
+ * So the subject is the GENERATOR, not the corpus. The corpus is allowed to
+ * spread; the template is not allowed to fall behind the back of it.
+ *
+ * WHAT IT DOES NOT CLAIM
+ *
+ *  - It does NOT keep the corpus uniform. A fixture hand-authored with an old
+ *    floor lowers the minimum and the template still passes. That is the
+ *    deliberate cost of being dependabot-safe.
+ *  - It says nothing about the RESOLVED version. These are `^` floors and the
+ *    fixtures install with `pnpm install --ignore-workspace`, so what actually
+ *    resolves depends on the registry and the local store at run time.
+ *  - `assets/demo-gif/` is deliberately OUT of scope. It is not an integ
+ *    fixture, it has its own TRACKED `pnpm-lock.yaml`, and raising its floor
+ *    without regenerating that lockfile recreates the specifier mismatch
+ *    go-to-k/cdkd#2838 removed.
+ *
+ * REFUSALS ARE NOT PASSES
+ *
+ * Every input this cannot read is a hard failure, never a skip. The two
+ * fail-open shapes that would otherwise make a broken run look clean:
+ *
+ *  - The template floor failing to extract (a markdown edit moving the block,
+ *    a renamed skill). Reporting `null` as "nothing to compare" would make the
+ *    checker permanently, silently green — the exact failure mode it exists to
+ *    prevent, one level up.
+ *  - A fixture manifest that does not parse, or declares a spec whose floor is
+ *    not decidable (`*`, `latest`, a `||` range). Skipping it removes it from
+ *    the minimum, which can only ever LOOSEN the verdict.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Repo-relative path of the scaffold template this fences. */
+export const TEMPLATE_REL = join('.claude', 'skills', 'new-integ', 'SKILL.md');
+
+/** Repo-relative root of the integ-fixture corpus. */
+export const INTEG_ROOT_REL = join('tests', 'integration');
+
+/**
+ * Collapse floors. Every one of these is satisfiable by a run that inspected
+ * NOTHING, which is why they exist and why the unit test pins them to literals
+ * AND separately asserts the real magnitudes against independent literals — an
+ * assertion of the form `report.fixtures > FLOORS.fixtures` is circular and
+ * stays green with every floor zeroed.
+ *
+ * Measured 2026-09-09, immediately after go-to-k/cdkd#2838: 292 fixture
+ * directories, 292 declaring `aws-cdk-lib`, 1 distinct floor.
+ */
+export const FLOORS = {
+  /** Fixture directories with a readable `package.json`. */
+  fixtures: 250,
+  /** Of those, ones declaring `aws-cdk-lib`. */
+  declaringFixtures: 250,
+} as const;
+
+export type FloorOperator = '^' | '~' | '=';
+
+export interface ParsedFloor {
+  operator: FloorOperator;
+  major: number;
+  minor: number;
+  patch: number;
+  /** The spec exactly as written in the manifest. */
+  raw: string;
+}
+
+export interface FixtureFloor {
+  fixture: string;
+  spec: string;
+  floor: ParsedFloor;
+}
+
+export interface Refusal {
+  /** Repo-relative path, or the fixture name for a corpus refusal. */
+  where: string;
+  reason: string;
+}
+
+export interface FloorReport {
+  /** Fixture dirs carrying a readable `package.json`. */
+  fixtures: number;
+  /** Fixtures declaring `aws-cdk-lib` with a decidable floor. */
+  declaringFixtures: number;
+  /** Every distinct floor spec in the corpus, ascending. */
+  distinctFloors: string[];
+  /** The lowest corpus floor, or null when the corpus yielded none. */
+  minFloor: ParsedFloor | null;
+  /** The floor the scaffold template emits, or null when it did not extract. */
+  templateFloor: ParsedFloor | null;
+  /**
+   * Inputs that could not be read or decided. NON-EMPTY IS A FAILURE — see the
+   * header. Kept as a list rather than a count so the message names the file.
+   */
+  refusals: Refusal[];
+  /** Human-readable failures. Empty means the check passed. */
+  violations: string[];
+}
+
+/**
+ * Parse a dependency spec into the lowest version it admits.
+ *
+ * Accepts only the three shapes whose floor is decidable from the spec alone:
+ * `^X.Y.Z`, `~X.Y.Z` and a bare `X.Y.Z`. Everything else returns null and
+ * becomes a REFUSAL at the call site, never a skip: `*` / `latest` / `>=X` /
+ * an `||` union either have no floor or have one that a future registry state
+ * can change, and a spec this cannot decide must not be silently dropped out
+ * of the minimum.
+ *
+ * A prerelease or build suffix is refused too. None exist in the corpus, and
+ * accepting one would require prerelease ordering rules that buy nothing here.
+ */
+export function parseFloor(spec: string): ParsedFloor | null {
+  const m = /^([\^~]?)(\d+)\.(\d+)\.(\d+)$/.exec(spec.trim());
+  if (!m) return null;
+  return {
+    operator: (m[1] || '=') as FloorOperator,
+    major: Number(m[2]),
+    minor: Number(m[3]),
+    patch: Number(m[4]),
+    raw: spec.trim(),
+  };
+}
+
+/** Negative when `a` is lower than `b`. Compares the FLOOR, not the range. */
+export function compareFloors(a: ParsedFloor, b: ParsedFloor): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * Extract the `aws-cdk-lib` floor the scaffold template emits.
+ *
+ * Deliberately NOT a JSON parse: the template lives inside a fenced block in
+ * prose, indented, and is not a standalone document. It is matched by the
+ * quoted key so a reworded surrounding sentence cannot move it, and the whole
+ * file is searched rather than a located fence — the fence's language tag and
+ * indentation have both changed in this file's history.
+ *
+ * Returns null when the key is absent OR appears more than once. Two
+ * occurrences mean the template grew a second manifest (or an example of the
+ * wrong thing), and picking the first would silently fence whichever one
+ * happened to come first in the file.
+ */
+export function extractTemplateFloor(markdown: string): ParsedFloor | null {
+  const matches = [...markdown.matchAll(/"aws-cdk-lib"\s*:\s*"([^"]+)"/g)];
+  if (matches.length !== 1) return null;
+  return parseFloor(matches[0][1]);
+}
+
+/** Read `aws-cdk-lib` out of a manifest's dependencies or devDependencies. */
+function declaredSpec(manifest: unknown): string | null {
+  if (typeof manifest !== 'object' || manifest === null) return null;
+  const m = manifest as Record<string, unknown>;
+  for (const bucket of ['dependencies', 'devDependencies']) {
+    const deps = m[bucket];
+    if (typeof deps !== 'object' || deps === null) continue;
+    const spec = (deps as Record<string, unknown>)['aws-cdk-lib'];
+    if (typeof spec === 'string') return spec;
+  }
+  return null;
+}
+
+export interface CheckOptions {
+  /** Absolute path to the integ-fixture root. */
+  integRoot: string;
+  /** Absolute path to the scaffold template markdown. */
+  templatePath: string;
+}
+
+export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
+  const { integRoot, templatePath } = options;
+  const refusals: Refusal[] = [];
+  const floors: FixtureFloor[] = [];
+  let fixtures = 0;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(integRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch (error) {
+    // An unreadable corpus root is the loudest possible collapse: every count
+    // is zero and every floor is trivially satisfied.
+    return {
+      fixtures: 0,
+      declaringFixtures: 0,
+      distinctFloors: [],
+      minFloor: null,
+      templateFloor: null,
+      refusals: [{ where: integRoot, reason: `integ root unreadable: ${String(error)}` }],
+      violations: [`integ root unreadable: ${integRoot}`],
+    };
+  }
+
+  for (const fixture of entries) {
+    const manifestPath = join(integRoot, fixture, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+    fixtures += 1;
+
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    } catch (error) {
+      refusals.push({
+        where: join(INTEG_ROOT_REL, fixture, 'package.json'),
+        reason: `manifest does not parse: ${String(error)}`,
+      });
+      continue;
+    }
+
+    const spec = declaredSpec(manifest);
+    // A fixture that declares no aws-cdk-lib at all is not a refusal — it is
+    // simply not a member of this population.
+    if (spec === null) continue;
+
+    const floor = parseFloor(spec);
+    if (floor === null) {
+      refusals.push({
+        where: join(INTEG_ROOT_REL, fixture, 'package.json'),
+        reason: `aws-cdk-lib spec "${spec}" has no decidable floor (accepted: ^X.Y.Z, ~X.Y.Z, X.Y.Z)`,
+      });
+      continue;
+    }
+    floors.push({ fixture, spec, floor });
+  }
+
+  let templateFloor: ParsedFloor | null = null;
+  try {
+    templateFloor = extractTemplateFloor(readFileSync(templatePath, 'utf8'));
+    if (templateFloor === null) {
+      refusals.push({
+        where: TEMPLATE_REL,
+        reason:
+          'could not extract exactly one `"aws-cdk-lib": "<spec>"` with a decidable floor from the scaffold template',
+      });
+    }
+  } catch (error) {
+    refusals.push({ where: TEMPLATE_REL, reason: `template unreadable: ${String(error)}` });
+  }
+
+  const sorted = [...floors].sort((a, b) => compareFloors(a.floor, b.floor));
+  const minFloor = sorted.length > 0 ? sorted[0].floor : null;
+  const distinctFloors = [...new Set(sorted.map((f) => f.spec))];
+
+  const violations: string[] = [];
+  for (const refusal of refusals) {
+    violations.push(`${refusal.where}: ${refusal.reason}`);
+  }
+  if (minFloor !== null && templateFloor !== null && compareFloors(templateFloor, minFloor) < 0) {
+    const lowest = sorted[0];
+    violations.push(
+      `${TEMPLATE_REL} emits aws-cdk-lib "${templateFloor.raw}", below the lowest floor in the ` +
+        `fixture corpus ("${lowest.spec}", ${INTEG_ROOT_REL}/${lowest.fixture}). A new fixture ` +
+        `scaffolded from this template would start behind the corpus — raise the template.`,
+    );
+  }
+
+  return {
+    fixtures,
+    declaringFixtures: floors.length,
+    distinctFloors,
+    minFloor,
+    templateFloor,
+    refusals,
+    violations,
+  };
+}
+
+/**
+ * Fixed inputs with known verdicts, analyzed BEFORE the real tree is read.
+ *
+ * The floors above catch a run that collapsed toward zero. These catch the
+ * opposite and more dangerous collapse: a predicate that stopped discriminating
+ * leaves every count byte-identical, so nothing else in this file would notice.
+ * The set is majority-NEGATIVE for that reason, and each REFUSAL case names a
+ * substring of its own arm — a bare "refused" verdict cannot tell the arms
+ * apart.
+ */
+export const SELF_PROBE_CASES: ReadonlyArray<{
+  label: string;
+  spec: string;
+  expected: 'parsed' | 'refused';
+  floor?: [number, number, number];
+}> = [
+  { label: 'caret', spec: '^2.260.0', expected: 'parsed', floor: [2, 260, 0] },
+  { label: 'tilde', spec: '~2.257.0', expected: 'parsed', floor: [2, 257, 0] },
+  { label: 'exact', spec: '2.169.0', expected: 'parsed', floor: [2, 169, 0] },
+  { label: 'padded', spec: '  ^2.260.0  ', expected: 'parsed', floor: [2, 260, 0] },
+  { label: 'wildcard', spec: '*', expected: 'refused' },
+  { label: 'latest', spec: 'latest', expected: 'refused' },
+  { label: 'x-range', spec: '^2.x', expected: 'refused' },
+  { label: 'gte-range', spec: '>=2.260.0', expected: 'refused' },
+  { label: 'union-range', spec: '^2.260.0 || ^3.0.0', expected: 'refused' },
+  { label: 'prerelease', spec: '^2.260.0-alpha.0', expected: 'refused' },
+  { label: 'two-segment', spec: '^2.260', expected: 'refused' },
+  { label: 'empty', spec: '', expected: 'refused' },
+];
+
+export interface SelfProbeFailure {
+  label: string;
+  detail: string;
+}
+
+/** Run `SELF_PROBE_CASES`; a non-empty result must abort the run. */
+export function runSelfProbe(): SelfProbeFailure[] {
+  const failures: SelfProbeFailure[] = [];
+  // Test seam: proves the SPAWNED binary still consults the probe. Without it,
+  // `main()` dropping the `runSelfProbe()` call is unobservable from outside.
+  if (process.env['CDKD_SELF_PROBE_FORCE_FAIL'] === '1') {
+    return [{ label: 'forced', detail: 'CDKD_SELF_PROBE_FORCE_FAIL=1' }];
+  }
+  for (const testCase of SELF_PROBE_CASES) {
+    const got = parseFloor(testCase.spec);
+    if (testCase.expected === 'refused') {
+      if (got !== null) {
+        failures.push({ label: testCase.label, detail: `expected refusal, parsed ${got.raw}` });
+      }
+      continue;
+    }
+    if (got === null) {
+      failures.push({ label: testCase.label, detail: 'expected a parse, got a refusal' });
+      continue;
+    }
+    const [major, minor, patch] = testCase.floor ?? [-1, -1, -1];
+    if (got.major !== major || got.minor !== minor || got.patch !== patch) {
+      failures.push({
+        label: testCase.label,
+        detail: `expected ${major}.${minor}.${patch}, got ${got.major}.${got.minor}.${got.patch}`,
+      });
+    }
+  }
+  return failures;
+}
+
+function parseArgs(argv: string[]): { repoRoot: string; integRoot?: string; template?: string; json: boolean } {
+  let repoRoot = join(import.meta.dirname, '..');
+  let integRoot: string | undefined;
+  let template: string | undefined;
+  let json = false;
+  for (const arg of argv) {
+    if (arg === '--json') {
+      json = true;
+    } else if (arg.startsWith('--integ-root=')) {
+      const value = arg.slice('--integ-root='.length);
+      // An EMPTY value is refused rather than defaulted: `--integ-root=$DIR`
+      // with DIR unset would report a green for a corpus nobody named.
+      if (!value) throw new Error('--integ-root= requires a non-empty value');
+      integRoot = value;
+    } else if (arg.startsWith('--template=')) {
+      const value = arg.slice('--template='.length);
+      if (!value) throw new Error('--template= requires a non-empty value');
+      template = value;
+    } else if (arg.startsWith('--repo-root=')) {
+      const value = arg.slice('--repo-root='.length);
+      if (!value) throw new Error('--repo-root= requires a non-empty value');
+      repoRoot = value;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { repoRoot, integRoot, template, json };
+}
+
+function main(): void {
+  const { repoRoot, integRoot, template, json } = parseArgs(process.argv.slice(2));
+
+  const probeFailures = runSelfProbe();
+  if (probeFailures.length > 0) {
+    console.error('check-integ-cdk-lib-floor: SELF-PROBE FAILED — the classifier is broken:');
+    for (const f of probeFailures) console.error(`  ${f.label}: ${f.detail}`);
+    process.exit(1);
+  }
+
+  const report = checkIntegCdkLibFloor({
+    integRoot: integRoot ?? join(repoRoot, INTEG_ROOT_REL),
+    templatePath: template ?? join(repoRoot, TEMPLATE_REL),
+  });
+
+  if (json) {
+    // stdout is a DATA channel under --json; the human summary goes to stderr.
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  const floorViolations: string[] = [];
+  if (report.fixtures < FLOORS.fixtures) {
+    floorViolations.push(`only ${report.fixtures} fixtures read (floor ${FLOORS.fixtures})`);
+  }
+  if (report.declaringFixtures < FLOORS.declaringFixtures) {
+    floorViolations.push(
+      `only ${report.declaringFixtures} fixtures declared aws-cdk-lib (floor ${FLOORS.declaringFixtures})`,
+    );
+  }
+
+  const all = [...floorViolations, ...report.violations];
+  if (all.length > 0) {
+    console.error('check-integ-cdk-lib-floor: FAILED');
+    for (const v of all) console.error(`  ${v}`);
+    process.exit(1);
+  }
+
+  console.error(
+    `check-integ-cdk-lib-floor: OK — template ${report.templateFloor?.raw}, ` +
+      `${report.declaringFixtures}/${report.fixtures} fixtures, ` +
+      `lowest corpus floor ${report.minFloor?.raw}, ${report.distinctFloors.length} distinct.`,
+  );
+}
+
+if (process.argv[1] && import.meta.filename === process.argv[1]) {
+  main();
+}

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -41,8 +41,8 @@
  *
  * REFUSALS ARE NOT PASSES
  *
- * Every input this cannot read is a hard failure, never a skip. The two
- * fail-open shapes that would otherwise make a broken run look clean:
+ * Every input this cannot read is a hard failure, never a skip. The fail-open
+ * shapes that would otherwise make a broken run look clean:
  *
  *  - The template floor failing to extract (a markdown edit moving the block,
  *    a renamed skill). Reporting `null` as "nothing to compare" would make the
@@ -58,11 +58,16 @@
  *    not only in the CLI.
  *
  * Two skips are deliberate and are NOT refusals, because neither can loosen the
- * verdict by hiding a floor: a directory with no `package.json` at all (not a
- * fixture), and a manifest that declares no `aws-cdk-lib` (not a member of this
- * population). Both are counted — `fixtures` and `declaringFixtures` — and the
- * test pins them EQUAL, so a reader that silently stopped seeing one dependency
- * bucket shows up as a gap rather than as a smaller minimum.
+ * verdict by hiding a floor. They are pinned by DIFFERENT instruments, which is
+ * worth stating because they look symmetric and are not:
+ *
+ *  - A directory with no `package.json` (not a fixture) increments NEITHER
+ *    counter, so the `fixtures === declaringFixtures` pin cannot see it. Only
+ *    `FLOORS.fixtures` catches a walk that stopped finding manifests.
+ *  - A manifest declaring no `aws-cdk-lib` (not a member of this population)
+ *    increments `fixtures` but not `declaringFixtures`, so it IS visible to
+ *    that pin — which is what makes a reader silently losing one dependency
+ *    bucket show up as a gap rather than as a smaller minimum.
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
@@ -313,11 +318,19 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
   // existing-but-empty root previously produced a fully clean report, and a
   // caller reaching for the exported function gets no `FLOORS` check.
   if (fixtures === 0) {
-    violations.push(`${INTEG_ROOT_REL}: no fixture manifest found — the corpus was not read`);
+    // `integRoot`, not INTEG_ROOT_REL: under the `--integ-root=` seam the
+    // hardcoded label pointed the reader at a directory that was never read.
+    violations.push(`${integRoot}: no fixture manifest found — the corpus was not read`);
   } else if (minFloor === null) {
-    violations.push(
-      `${INTEG_ROOT_REL}: ${fixtures} fixture manifests read, none declaring a decidable aws-cdk-lib floor`,
-    );
+    // `fixtures === 0` implies `minFloor === null`, so this arm is only ever
+    // reached with manifests present. Distinguish "they parsed and declared
+    // nothing" from "none of them parsed" — the refusals carry the detail, but
+    // the summary line should not assert the wrong one of the two.
+    const detail =
+      refusals.length === fixtures
+        ? `none of them readable (see the ${refusals.length} refusals above)`
+        : 'none declaring a decidable aws-cdk-lib floor';
+    violations.push(`${integRoot}: ${fixtures} fixture manifests read, ${detail}`);
   }
   if (minFloor !== null && templateFloor !== null && compareFloors(templateFloor, minFloor) < 0) {
     const lowest = sorted[0];

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -211,17 +211,42 @@ export function extractTemplateFloorDetailed(markdown: string): TemplateExtracti
   return { floor: parseFloor(spec), matches: 1, spec };
 }
 
-/** Read `aws-cdk-lib` out of a manifest's dependencies or devDependencies. */
-function declaredSpec(manifest: unknown): string | null {
-  if (typeof manifest !== 'object' || manifest === null) return null;
+export type DeclaredSpec =
+  /** Declares `aws-cdk-lib` with a string spec. */
+  | { kind: 'found'; spec: string }
+  /** Declares no `aws-cdk-lib` — not a member of this population. */
+  | { kind: 'absent' }
+  /** Shaped in a way this cannot read. A REFUSAL, never a skip. */
+  | { kind: 'malformed'; why: string };
+
+/**
+ * Read `aws-cdk-lib` out of a manifest's dependencies or devDependencies.
+ *
+ * The three outcomes are distinguished because two of them used to collapse
+ * into one silent `continue`: a manifest parsing to a non-object, a non-object
+ * dependency bucket, and a non-string spec all read as "declares nothing" and
+ * dropped the fixture out of the minimum. Dropping a fixture can only ever
+ * LOOSEN the verdict, which the header calls a refusal — so they are refusals.
+ */
+export function declaredSpec(manifest: unknown): DeclaredSpec {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    return { kind: 'malformed', why: `manifest is not a JSON object (got ${typeof manifest})` };
+  }
   const m = manifest as Record<string, unknown>;
   for (const bucket of ['dependencies', 'devDependencies']) {
+    if (!(bucket in m)) continue;
     const deps = m[bucket];
-    if (typeof deps !== 'object' || deps === null) continue;
+    if (typeof deps !== 'object' || deps === null || Array.isArray(deps)) {
+      return { kind: 'malformed', why: `"${bucket}" is not a JSON object` };
+    }
+    if (!('aws-cdk-lib' in (deps as Record<string, unknown>))) continue;
     const spec = (deps as Record<string, unknown>)['aws-cdk-lib'];
-    if (typeof spec === 'string') return spec;
+    if (typeof spec !== 'string') {
+      return { kind: 'malformed', why: `"${bucket}"."aws-cdk-lib" is not a string` };
+    }
+    return { kind: 'found', spec };
   }
-  return null;
+  return { kind: 'absent' };
 }
 
 export interface CheckOptions {
@@ -309,10 +334,18 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
       continue;
     }
 
-    const spec = declaredSpec(manifest);
+    const declared = declaredSpec(manifest);
+    if (declared.kind === 'malformed') {
+      refusals.push({
+        where: at(join(integRoot, fixture, 'package.json')),
+        reason: declared.why,
+      });
+      continue;
+    }
     // A fixture that declares no aws-cdk-lib at all is not a refusal — it is
     // simply not a member of this population.
-    if (spec === null) continue;
+    if (declared.kind === 'absent') continue;
+    const spec = declared.spec;
 
     const floor = parseFloor(spec);
     if (floor === null) {

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -51,6 +51,18 @@
  *  - A fixture manifest that does not parse, or declares a spec whose floor is
  *    not decidable (`*`, `latest`, a `||` range). Skipping it removes it from
  *    the minimum, which can only ever LOOSEN the verdict.
+ *  - A corpus that yielded NO fixture, or no floor at all. `FLOORS` catches
+ *    that in `main()`, but the exported function is what a future caller
+ *    reaches for, and it used to return a fully clean report for an
+ *    existing-but-empty root — so the emptiness is a violation in the LIBRARY,
+ *    not only in the CLI.
+ *
+ * Two skips are deliberate and are NOT refusals, because neither can loosen the
+ * verdict by hiding a floor: a directory with no `package.json` at all (not a
+ * fixture), and a manifest that declares no `aws-cdk-lib` (not a member of this
+ * population). Both are counted — `fixtures` and `declaringFixtures` — and the
+ * test pins them EQUAL, so a reader that silently stopped seeing one dependency
+ * bucket shows up as a gap rather than as a smaller minimum.
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
@@ -167,9 +179,28 @@ export function compareFloors(a: ParsedFloor, b: ParsedFloor): number {
  * happened to come first in the file.
  */
 export function extractTemplateFloor(markdown: string): ParsedFloor | null {
+  return extractTemplateFloorDetailed(markdown).floor;
+}
+
+export interface TemplateExtraction {
+  floor: ParsedFloor | null;
+  /** How many `"aws-cdk-lib": "..."` declarations the template carries. */
+  matches: number;
+  /** The single matched spec, when there was exactly one. */
+  spec: string | null;
+}
+
+/**
+ * The counting form. `extractTemplateFloor` collapses all three failures to
+ * null, which made one refusal message cover "found none", "found several" and
+ * "found one I cannot decide" — so the day someone adds a second example
+ * manifest to the skill, the error did not say it had found two.
+ */
+export function extractTemplateFloorDetailed(markdown: string): TemplateExtraction {
   const matches = [...markdown.matchAll(/"aws-cdk-lib"\s*:\s*"([^"]+)"/g)];
-  if (matches.length !== 1) return null;
-  return parseFloor(matches[0][1]);
+  if (matches.length !== 1) return { floor: null, matches: matches.length, spec: null };
+  const spec = matches[0][1];
+  return { floor: parseFloor(spec), matches: 1, spec };
 }
 
 /** Read `aws-cdk-lib` out of a manifest's dependencies or devDependencies. */
@@ -252,13 +283,19 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
 
   let templateFloor: ParsedFloor | null = null;
   try {
-    templateFloor = extractTemplateFloor(readFileSync(templatePath, 'utf8'));
+    const extraction = extractTemplateFloorDetailed(readFileSync(templatePath, 'utf8'));
+    templateFloor = extraction.floor;
     if (templateFloor === null) {
-      refusals.push({
-        where: TEMPLATE_REL,
-        reason:
-          'could not extract exactly one `"aws-cdk-lib": "<spec>"` with a decidable floor from the scaffold template',
-      });
+      // Name WHICH of the three failures happened. One string for all three
+      // left "someone added a second example manifest" reading as "the key is
+      // gone", which points the fix at the wrong edit.
+      const reason =
+        extraction.matches === 0
+          ? 'found no `"aws-cdk-lib": "<spec>"` declaration in the scaffold template'
+          : extraction.matches > 1
+            ? `found ${extraction.matches} \`"aws-cdk-lib": "<spec>"\` declarations in the scaffold template; expected exactly 1 (which one is the template?)`
+            : `scaffold template spec "${extraction.spec}" has no decidable floor (accepted: ^X.Y.Z, ~X.Y.Z, X.Y.Z)`;
+      refusals.push({ where: TEMPLATE_REL, reason });
     }
   } catch (error) {
     refusals.push({ where: TEMPLATE_REL, reason: `template unreadable: ${String(error)}` });
@@ -271,6 +308,16 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
   const violations: string[] = [];
   for (const refusal of refusals) {
     violations.push(`${refusal.where}: ${refusal.reason}`);
+  }
+  // Emptiness is a LIBRARY-level violation, not only a CLI floor: an
+  // existing-but-empty root previously produced a fully clean report, and a
+  // caller reaching for the exported function gets no `FLOORS` check.
+  if (fixtures === 0) {
+    violations.push(`${INTEG_ROOT_REL}: no fixture manifest found — the corpus was not read`);
+  } else if (minFloor === null) {
+    violations.push(
+      `${INTEG_ROOT_REL}: ${fixtures} fixture manifests read, none declaring a decidable aws-cdk-lib floor`,
+    );
   }
   if (minFloor !== null && templateFloor !== null && compareFloors(templateFloor, minFloor) < 0) {
     const lowest = sorted[0];

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -229,23 +229,43 @@ export type DeclaredSpec =
  * LOOSEN the verdict, which the header calls a refusal — so they are refusals.
  */
 export function declaredSpec(manifest: unknown): DeclaredSpec {
-  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+  // `typeof null` and `typeof []` are both 'object', so a single
+  // "not a JSON object (got ${typeof manifest})" message named neither shape
+  // and contradicted itself. Each arm names its own.
+  if (manifest === null) return { kind: 'malformed', why: 'manifest is null' };
+  if (Array.isArray(manifest)) return { kind: 'malformed', why: 'manifest is a JSON array' };
+  if (typeof manifest !== 'object') {
     return { kind: 'malformed', why: `manifest is not a JSON object (got ${typeof manifest})` };
   }
+
   const m = manifest as Record<string, unknown>;
+  // A malformed bucket must NOT short-circuit a later valid one. Returning on
+  // the first bad bucket made `{dependencies: null, devDependencies: {...}}` --
+  // legal JSON, and previously `found` -- refuse: a decidable manifest
+  // rejected, the exact mirror of the loosening this function exists to stop.
+  // So the reasons are collected and only reported when NO bucket answered.
+  const problems: string[] = [];
   for (const bucket of ['dependencies', 'devDependencies']) {
     if (!(bucket in m)) continue;
     const deps = m[bucket];
     if (typeof deps !== 'object' || deps === null || Array.isArray(deps)) {
-      return { kind: 'malformed', why: `"${bucket}" is not a JSON object` };
+      problems.push(`"${bucket}" is not a JSON object`);
+      continue;
     }
     if (!('aws-cdk-lib' in (deps as Record<string, unknown>))) continue;
     const spec = (deps as Record<string, unknown>)['aws-cdk-lib'];
     if (typeof spec !== 'string') {
-      return { kind: 'malformed', why: `"${bucket}"."aws-cdk-lib" is not a string` };
+      problems.push(`"${bucket}"."aws-cdk-lib" is not a string`);
+      continue;
     }
     return { kind: 'found', spec };
   }
+  if (problems.length > 0) return { kind: 'malformed', why: problems.join('; ') };
+  // NOTE: only `dependencies` and `devDependencies` are the population.
+  // `peerDependencies` / `optionalDependencies` are NOT consulted -- an integ
+  // fixture is an app, not a library, so declaring aws-cdk-lib there would be
+  // the mistake rather than a floor to honour. Pinned by a test so the choice
+  // is visible rather than an accident of this loop's bucket list.
   return { kind: 'absent' };
 }
 

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -240,11 +240,18 @@ export interface CheckOptions {
 /**
  * Render a path for a message.
  *
- * EVERY printed path goes through this. Three rounds of review found the same
- * defect at six different sites: a hardcoded `INTEG_ROOT_REL` / `TEMPLATE_REL`
- * label, which under the `--integ-root=` / `--template=` seams names a file the
- * run never read. Hardcoding was the bug, so nothing here may hardcode; the
- * label is always DERIVED from the path actually used.
+ * Every path this file FORMATS goes through this. Four rounds of review found
+ * the same defect at seven different sites: a hardcoded `INTEG_ROOT_REL` /
+ * `TEMPLATE_REL` label, which under the `--integ-root=` / `--template=` seams
+ * names a file the run never read. Hardcoding was the bug, so nothing here may
+ * hardcode; the label is always DERIVED from the path actually used.
+ *
+ * EXEMPT, deliberately: the absolute path Node embeds in an errno message,
+ * which reaches a `reason` through `String(error)`. It is not a label this file
+ * composes, and the errno text is the diagnostic — stripping it to keep one
+ * line internally consistent would trade real information for tidiness. So a
+ * refusal line can legitimately carry a labelled path AND a raw absolute one.
+ * Do not "fix" that by reformatting the error.
  *
  * Relative when the path is inside `repoRoot` (the house convention — see
  * `scripts/check-local-reachability.ts`), absolute otherwise, so a seam path in

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -74,7 +74,7 @@
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join, relative, isAbsolute } from 'node:path';
+import { join, relative, isAbsolute, sep } from 'node:path';
 
 /** Repo-relative path of the scaffold template this fences. */
 export const TEMPLATE_REL = join('.claude', 'skills', 'new-integ', 'SKILL.md');
@@ -117,7 +117,7 @@ export interface FixtureFloor {
 }
 
 export interface Refusal {
-  /** Repo-relative path, or the fixture name for a corpus refusal. */
+  /** The path, as `label()` renders it: repo-relative inside the repo, absolute outside. */
   where: string;
   reason: string;
 }
@@ -252,7 +252,10 @@ export interface CheckOptions {
  */
 function label(repoRoot: string, path: string): string {
   const rel = relative(repoRoot, path);
-  return rel && !rel.startsWith('..') && !isAbsolute(rel) ? rel : path;
+  // `!rel.startsWith('..')` alone cannot tell `../x` (escaping) from `..x` (a
+  // legitimate in-repo name), so the separator is part of the test.
+  const escapes = rel === '..' || rel.startsWith(`..${sep}`);
+  return rel && !escapes && !isAbsolute(rel) ? rel : path;
 }
 
 export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
@@ -278,8 +281,8 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
       distinctFloors: [],
       minFloor: null,
       templateFloor: null,
-      refusals: [{ where: integRoot, reason: `integ root unreadable: ${String(error)}` }],
-      violations: [`integ root unreadable: ${integRoot}`],
+      refusals: [{ where: at(integRoot), reason: `integ root unreadable: ${String(error)}` }],
+      violations: [`integ root unreadable: ${at(integRoot)}`],
     };
   }
 

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -74,7 +74,7 @@
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative, isAbsolute } from 'node:path';
 
 /** Repo-relative path of the scaffold template this fences. */
 export const TEMPLATE_REL = join('.claude', 'skills', 'new-integ', 'SKILL.md');
@@ -229,10 +229,36 @@ export interface CheckOptions {
   integRoot: string;
   /** Absolute path to the scaffold template markdown. */
   templatePath: string;
+  /**
+   * Root the printed paths are rendered relative to. Defaults to this repo, so
+   * the ordinary invocation prints `tests/integration/basic/package.json`
+   * rather than an absolute path.
+   */
+  repoRoot?: string;
+}
+
+/**
+ * Render a path for a message.
+ *
+ * EVERY printed path goes through this. Three rounds of review found the same
+ * defect at six different sites: a hardcoded `INTEG_ROOT_REL` / `TEMPLATE_REL`
+ * label, which under the `--integ-root=` / `--template=` seams names a file the
+ * run never read. Hardcoding was the bug, so nothing here may hardcode; the
+ * label is always DERIVED from the path actually used.
+ *
+ * Relative when the path is inside `repoRoot` (the house convention — see
+ * `scripts/check-local-reachability.ts`), absolute otherwise, so a seam path in
+ * a temp dir cannot be mistaken for a repo file.
+ */
+function label(repoRoot: string, path: string): string {
+  const rel = relative(repoRoot, path);
+  return rel && !rel.startsWith('..') && !isAbsolute(rel) ? rel : path;
 }
 
 export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
   const { integRoot, templatePath } = options;
+  const repoRoot = options.repoRoot ?? join(import.meta.dirname, '..');
+  const at = (p: string) => label(repoRoot, p);
   const refusals: Refusal[] = [];
   const floors: FixtureFloor[] = [];
   let fixtures = 0;
@@ -267,7 +293,7 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
       manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
     } catch (error) {
       refusals.push({
-        where: join(integRoot, fixture, 'package.json'),
+        where: at(join(integRoot, fixture, 'package.json')),
         reason: `manifest does not parse: ${String(error)}`,
       });
       continue;
@@ -281,7 +307,7 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
     const floor = parseFloor(spec);
     if (floor === null) {
       refusals.push({
-        where: join(integRoot, fixture, 'package.json'),
+        where: at(join(integRoot, fixture, 'package.json')),
         reason: `aws-cdk-lib spec "${spec}" has no decidable floor (accepted: ^X.Y.Z, ~X.Y.Z, X.Y.Z)`,
       });
       continue;
@@ -303,10 +329,10 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
           : extraction.matches > 1
             ? `found ${extraction.matches} \`"aws-cdk-lib": "<spec>"\` declarations in the scaffold template; expected exactly 1 (which one is the template?)`
             : `scaffold template spec "${extraction.spec}" has no decidable floor (accepted: ^X.Y.Z, ~X.Y.Z, X.Y.Z)`;
-      refusals.push({ where: TEMPLATE_REL, reason });
+      refusals.push({ where: at(templatePath), reason });
     }
   } catch (error) {
-    refusals.push({ where: TEMPLATE_REL, reason: `template unreadable: ${String(error)}` });
+    refusals.push({ where: at(templatePath), reason: `template unreadable: ${String(error)}` });
   }
 
   const sorted = [...floors].sort((a, b) => compareFloors(a.floor, b.floor));
@@ -321,9 +347,7 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
   // existing-but-empty root previously produced a fully clean report, and a
   // caller reaching for the exported function gets no `FLOORS` check.
   if (fixtures === 0) {
-    // `integRoot`, not INTEG_ROOT_REL: under the `--integ-root=` seam the
-    // hardcoded label pointed the reader at a directory that was never read.
-    violations.push(`${integRoot}: no fixture manifest found — the corpus was not read`);
+    violations.push(`${at(integRoot)}: no fixture manifest found — the corpus was not read`);
   } else if (minFloor === null) {
     // Deliberately states only what it KNOWS, and infers no cause.
     //
@@ -337,16 +361,14 @@ export function checkIntegCdkLibFloor(options: CheckOptions): FloorReport {
     // already emitted as its own violation above. So the summary reports the
     // fact and points at them, rather than re-deriving a cause it cannot see.
     violations.push(
-      `${integRoot}: ${fixtures} fixture manifests read, none yielded a decidable ` +
-        `aws-cdk-lib floor` +
-        (refusals.length > 0 ? ` (see the ${refusals.length} refusal(s) above for why)` : ''),
+      `${at(integRoot)}: ${fixtures} fixture manifests read, none yielded a decidable aws-cdk-lib floor`,
     );
   }
   if (minFloor !== null && templateFloor !== null && compareFloors(templateFloor, minFloor) < 0) {
     const lowest = sorted[0];
     violations.push(
-      `${TEMPLATE_REL} emits aws-cdk-lib "${templateFloor.raw}", below the lowest floor in the ` +
-        `fixture corpus ("${lowest.spec}", ${join(integRoot, lowest.fixture)}). A new fixture ` +
+      `${at(templatePath)} emits aws-cdk-lib "${templateFloor.raw}", below the lowest floor in the ` +
+        `fixture corpus ("${lowest.spec}", ${at(join(integRoot, lowest.fixture))}). A new fixture ` +
         `scaffolded from this template would start behind the corpus — raise the template.`,
     );
   }
@@ -468,6 +490,7 @@ function main(): void {
   }
 
   const report = checkIntegCdkLibFloor({
+    repoRoot,
     integRoot: integRoot ?? join(repoRoot, INTEG_ROOT_REL),
     templatePath: template ?? join(repoRoot, TEMPLATE_REL),
   });

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -223,20 +223,56 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
     expect(report.fixtures).toBe(1);
     expect(report.declaringFixtures).toBe(0);
-    expect(report.violations.join('\n')).toContain('none declaring a decidable aws-cdk-lib floor');
+    expect(report.violations.join('\n')).toContain('none yielded a decidable aws-cdk-lib floor');
   });
 
-  // The two ways `minFloor` can be null read identically in a summary line, and
-  // only one of them is true at a time. The refusals carry the detail; the
-  // summary must not assert the wrong one.
-  it('says NONE WERE READABLE when every manifest failed to parse', () => {
-    const dir = scratch('cdkd-floor-unparseable-');
+  // The summary INFERS NO CAUSE. Two review rounds went into a conditional
+  // trying to say why no floor was found; every version was wrong for some
+  // input because it branched on `refusals.length` against `fixtures`, which
+  // are different populations (`refusals` also holds the TEMPLATE refusal).
+  // These cases pin the replacement: one fact, plus a pointer to the refusals,
+  // which are themselves violations.
+  it.each([
+    ['unparseable manifest', '{ "name": "a", ', 1],
+    ['undecidable spec', '{ "dependencies": { "aws-cdk-lib": "*" } }', 1],
+    ['no declaration at all', '{ "name": "a", "dependencies": {} }', 0],
+  ])('reports the fact without inferring a cause: %s', (_label, body, expectedRefusals) => {
+    const dir = scratch('cdkd-floor-nofloor-');
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a', 'package.json'), body);
+    const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
+    expect(report.fixtures).toBe(1);
+    expect(report.refusals.length).toBe(expectedRefusals);
+    const text = report.violations.join('\n');
+    expect(text).toContain('none yielded a decidable aws-cdk-lib floor');
+    // The retired wordings, each of which was wrong for one of these three.
+    expect(text).not.toContain('none of them readable');
+    expect(text).not.toContain('none declaring a decidable');
+  });
+
+  // The template is a refusal SOURCE that is not a fixture — the input that
+  // made every count-comparing version of this message wrong.
+  it('stays correct when the TEMPLATE also refuses', () => {
+    const dir = scratch('cdkd-floor-bothrefuse-');
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", ');
+    const report = checkIntegCdkLibFloor({
+      integRoot: dir,
+      templatePath: join(dir, 'no-such-template.md'),
+    });
+    expect(report.refusals.length).toBe(2); // one manifest + one template
+    expect(report.violations.join('\n')).toContain('none yielded a decidable aws-cdk-lib floor');
+  });
+
+  // Every path the checker prints must name the root it ACTUALLY read.
+  it('never names the hardcoded corpus path when a seam root was given', () => {
+    const dir = scratch('cdkd-floor-pathlabel-');
     mkdirSync(join(dir, 'a'), { recursive: true });
     writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", ');
     const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
-    expect(report.fixtures).toBe(1);
-    expect(report.violations.join('\n')).toContain('none of them readable');
-    expect(report.violations.join('\n')).not.toContain('none declaring a decidable');
+    const text = [...report.violations, ...report.refusals.map((r) => r.where)].join('\n');
+    expect(text).toContain(dir);
+    expect(text).not.toContain(INTEG_ROOT_REL);
   });
 });
 

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -284,21 +284,57 @@ describe('a non-uniform corpus (the uniform real one cannot see these)', () => {
 });
 
 describe('declaredSpec refuses what it cannot read', () => {
+  // The REASON is asserted per arm, not just `.kind`: `typeof null` and
+  // `typeof []` are both 'object', so one shared message named neither shape
+  // and contradicted itself while the table stayed green.
   it.each([
-    ['found', { dependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found'],
-    ['found in devDependencies', { devDependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found'],
-    ['absent', { name: 'x', dependencies: {} }, 'absent'],
-    ['no buckets at all', { name: 'x' }, 'absent'],
+    ['found', { dependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found', undefined],
+    ['found in devDependencies', { devDependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found', undefined],
+    ['absent', { name: 'x', dependencies: {} }, 'absent', undefined],
+    ['no buckets at all', { name: 'x' }, 'absent', undefined],
+    // peerDependencies / optionalDependencies are deliberately NOT the
+    // population -- a fixture is an app, not a library. Pinned so the choice
+    // is visible rather than an accident of the bucket list.
+    ['peerDependencies is not a bucket', { peerDependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'absent', undefined],
+    ['optionalDependencies is not a bucket', { optionalDependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'absent', undefined],
     // Each of these used to `continue` silently, dropping the fixture out of
     // the minimum -- a loosening, which the header classifies as a refusal.
-    ['manifest is an array', [], 'malformed'],
-    ['manifest is a string', 'nope', 'malformed'],
-    ['dependencies is a string', { dependencies: 'nope' }, 'malformed'],
-    ['dependencies is an array', { dependencies: [] }, 'malformed'],
-    ['spec is a number', { dependencies: { 'aws-cdk-lib': 2 } }, 'malformed'],
-    ['spec is null', { dependencies: { 'aws-cdk-lib': null } }, 'malformed'],
-  ])('classifies %s', (_label, manifest, kind) => {
-    expect(declaredSpec(manifest).kind).toBe(kind);
+    ['manifest is null', null, 'malformed', 'manifest is null'],
+    ['manifest is an array', [], 'malformed', 'manifest is a JSON array'],
+    ['manifest is a string', 'nope', 'malformed', 'not a JSON object (got string)'],
+    ['manifest is a number', 7, 'malformed', 'not a JSON object (got number)'],
+    ['dependencies is a string', { dependencies: 'nope' }, 'malformed', '"dependencies" is not a JSON object'],
+    ['dependencies is an array', { dependencies: [] }, 'malformed', '"dependencies" is not a JSON object'],
+    ['dependencies is null', { dependencies: null }, 'malformed', '"dependencies" is not a JSON object'],
+    ['spec is a number', { dependencies: { 'aws-cdk-lib': 2 } }, 'malformed', '"dependencies"."aws-cdk-lib" is not a string'],
+    ['spec is null', { dependencies: { 'aws-cdk-lib': null } }, 'malformed', '"dependencies"."aws-cdk-lib" is not a string'],
+  ])('classifies %s', (_label, manifest, kind, why) => {
+    const got = declaredSpec(manifest);
+    expect(got.kind).toBe(kind);
+    if (why !== undefined) {
+      expect(got.kind === 'malformed' ? got.why : '').toContain(why);
+    }
+  });
+
+  // A malformed FIRST bucket must not short-circuit a valid SECOND one. All
+  // three shapes are legal JSON and were `found` before the refusal landed;
+  // refusing them would be a decidable manifest rejected -- the exact mirror
+  // of the loosening this function exists to stop.
+  it.each([
+    ['null first bucket', null],
+    ['string first bucket', 'nope'],
+    ['first bucket with a non-string spec', { 'aws-cdk-lib': 2 }],
+  ])('still finds the spec in devDependencies when dependencies is %s', (_label, deps) => {
+    const got = declaredSpec({ dependencies: deps, devDependencies: { 'aws-cdk-lib': '^2.260.0' } });
+    expect(got).toEqual({ kind: 'found', spec: '^2.260.0' });
+  });
+
+  // ...and when NO bucket answers, every problem is reported, not just the first.
+  it('reports every malformed bucket when none answered', () => {
+    const got = declaredSpec({ dependencies: null, devDependencies: 'nope' });
+    expect(got.kind).toBe('malformed');
+    expect(got.kind === 'malformed' ? got.why : '').toContain('"dependencies" is not a JSON object');
+    expect(got.kind === 'malformed' ? got.why : '').toContain('"devDependencies" is not a JSON object');
   });
 
   it('surfaces a malformed manifest as a REFUSAL, not a smaller minimum', () => {
@@ -331,9 +367,20 @@ describe('the repoRoot seam', () => {
     expect(report.refusals.map((r) => r.where)).toContain(join('a', 'package.json'));
   });
 
-  it('accepts --repo-root= and refuses an empty one', () => {
-    const ok = runCli([`--repo-root=${REPO_ROOT}`]);
-    expect(ok.status).toBe(0);
+  // Passing REPO_ROOT here would be VACUOUS -- it is exactly parseArgs's
+  // default, so the arm could not tell "honoured" from "parsed and discarded"
+  // (measured: deleting the assignment left it green). `repoRoot` also seeds
+  // the default integRoot/templatePath, so an inert flag silently reads a
+  // corpus the caller never named. A scratch root with no tests/integration
+  // discriminates.
+  it('HONOURS --repo-root= rather than merely parsing it', () => {
+    const elsewhere = scratch('cdkd-floor-otherroot-');
+    const res = runCli([`--repo-root=${elsewhere}`]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain(`integ root unreadable: ${INTEG_ROOT_REL}`);
+  }, TIMEOUT);
+
+  it('refuses an empty --repo-root=', () => {
     const empty = runCli(['--repo-root=']);
     expect(empty.status).toBe(1);
     expect(empty.stderr).toContain('--repo-root= requires a non-empty value');

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  FLOORS,
+  INTEG_ROOT_REL,
+  SELF_PROBE_CASES,
+  TEMPLATE_REL,
+  checkIntegCdkLibFloor,
+  compareFloors,
+  extractTemplateFloor,
+  parseFloor,
+  runSelfProbe,
+} from '../../../scripts/check-integ-cdk-lib-floor.js';
+
+/**
+ * Enforcement for issue #2839: the `/new-integ` scaffold template's
+ * `aws-cdk-lib` floor must not fall behind the integ-fixture corpus. As with
+ * `check-verification-depth-rule.ts` and `check-source-control-bytes.ts`, this
+ * unit test IS the CI enforcement — there is no `vp run` task and no `ci.yml`
+ * step. The script's CLI exists so a human can read the current numbers.
+ *
+ * See the script header for WHY the rule is "template >= corpus minimum"
+ * rather than "all floors equal": dependabot bumps one directory at a time, so
+ * an equality fence would red-flag every one of its PRs.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+const SCRIPT = join(REPO_ROOT, 'scripts/check-integ-cdk-lib-floor.ts');
+const REAL_INTEG_ROOT = join(REPO_ROOT, INTEG_ROOT_REL);
+const REAL_TEMPLATE = join(REPO_ROOT, TEMPLATE_REL);
+
+/** Run the SHIPPED binary, so `main()`, `parseArgs` and the seam are all live. */
+function runCli(args: string[], env: Record<string, string> = {}) {
+  const res = spawnSync('node', [SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { status: res.status, stderr: res.stderr ?? '', stdout: res.stdout ?? '' };
+}
+
+/**
+ * A COPY of the real corpus's manifests — the only files this checker reads.
+ * Copying the manifests rather than a synthetic tree keeps the mutation probes
+ * real-code probes, and never writes to `tests/integration` itself.
+ */
+function copyRealManifests(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cdkd-floor-integ-'));
+  for (const entry of readdirSync(REAL_INTEG_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const src = join(REAL_INTEG_ROOT, entry.name, 'package.json');
+    if (!existsSync(src)) continue;
+    mkdirSync(join(dir, entry.name), { recursive: true });
+    writeFileSync(join(dir, entry.name, 'package.json'), readFileSync(src, 'utf8'));
+  }
+  return dir;
+}
+
+/** A COPY of the real scaffold template, optionally mutated. */
+function copyRealTemplate(mutate?: (text: string) => string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cdkd-floor-tpl-'));
+  const path = join(dir, 'SKILL.md');
+  const text = readFileSync(REAL_TEMPLATE, 'utf8');
+  writeFileSync(path, mutate ? mutate(text) : text);
+  return path;
+}
+
+function setFixtureSpec(integRoot: string, fixture: string, spec: string): void {
+  const path = join(integRoot, fixture, 'package.json');
+  const manifest = JSON.parse(readFileSync(path, 'utf8')) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const bucket = manifest.dependencies?.['aws-cdk-lib'] ? 'dependencies' : 'devDependencies';
+  manifest[bucket]!['aws-cdk-lib'] = spec;
+  writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+describe('parseFloor / compareFloors', () => {
+  it.each(SELF_PROBE_CASES.map((c) => [c.label, c] as const))(
+    'self-probe case %s behaves as declared',
+    (_label, testCase) => {
+      const got = parseFloor(testCase.spec);
+      if (testCase.expected === 'refused') {
+        expect(got).toBeNull();
+        return;
+      }
+      expect(got).not.toBeNull();
+      const [major, minor, patch] = testCase.floor!;
+      expect([got!.major, got!.minor, got!.patch]).toEqual([major, minor, patch]);
+    },
+  );
+
+  // The probe set is the primary defence against a predicate that stopped
+  // discriminating, so its SIZE and its negative majority are pinned. A set
+  // silently trimmed to its passing cases would leave every other assertion
+  // in this file green.
+  it('keeps a probe set that is majority-negative', () => {
+    expect(SELF_PROBE_CASES.length).toBe(12);
+    expect(SELF_PROBE_CASES.filter((c) => c.expected === 'refused').length).toBe(8);
+  });
+
+  it('runSelfProbe passes against the shipped classifier', () => {
+    expect(runSelfProbe()).toEqual([]);
+  });
+
+  it('runSelfProbe honors the force-fail seam', () => {
+    const prev = process.env['CDKD_SELF_PROBE_FORCE_FAIL'];
+    process.env['CDKD_SELF_PROBE_FORCE_FAIL'] = '1';
+    try {
+      expect(runSelfProbe()).toEqual([{ label: 'forced', detail: 'CDKD_SELF_PROBE_FORCE_FAIL=1' }]);
+    } finally {
+      if (prev === undefined) delete process.env['CDKD_SELF_PROBE_FORCE_FAIL'];
+      else process.env['CDKD_SELF_PROBE_FORCE_FAIL'] = prev;
+    }
+  });
+
+  it('orders by the floor, across every segment', () => {
+    const f = (s: string) => parseFloor(s)!;
+    expect(compareFloors(f('^2.169.0'), f('^2.260.0'))).toBeLessThan(0);
+    expect(compareFloors(f('^2.260.0'), f('^2.260.0'))).toBe(0);
+    expect(compareFloors(f('^3.0.0'), f('^2.999.999'))).toBeGreaterThan(0);
+    expect(compareFloors(f('^2.260.1'), f('^2.260.0'))).toBeGreaterThan(0);
+    // The OPERATOR does not change the floor — `~2.260.0` and `^2.260.0` admit
+    // the same lowest version, which is the only thing being compared.
+    expect(compareFloors(f('~2.260.0'), f('^2.260.0'))).toBe(0);
+  });
+});
+
+describe('extractTemplateFloor', () => {
+  it('reads the floor out of the real scaffold template', () => {
+    const floor = extractTemplateFloor(readFileSync(REAL_TEMPLATE, 'utf8'));
+    expect(floor).not.toBeNull();
+    expect(floor!.operator).toBe('^');
+  });
+
+  it('refuses a template with no aws-cdk-lib key', () => {
+    expect(extractTemplateFloor('```json\n{ "dependencies": {} }\n```\n')).toBeNull();
+  });
+
+  // Two occurrences mean the template grew a second manifest; picking the
+  // first would fence whichever happened to come first in the file.
+  it('refuses a template declaring the key twice', () => {
+    const twice = '"aws-cdk-lib": "^2.260.0"\n...\n"aws-cdk-lib": "^2.169.0"\n';
+    expect(extractTemplateFloor(twice)).toBeNull();
+  });
+
+  it('refuses a template whose spec has no decidable floor', () => {
+    expect(extractTemplateFloor('"aws-cdk-lib": "latest"\n')).toBeNull();
+  });
+});
+
+describe('the real repository satisfies the fence', () => {
+  const report = checkIntegCdkLibFloor({
+    integRoot: REAL_INTEG_ROOT,
+    templatePath: REAL_TEMPLATE,
+  });
+
+  it('reports no refusals and no violations', () => {
+    expect(report.refusals).toEqual([]);
+    expect(report.violations).toEqual([]);
+  });
+
+  // FLOORS pinned to LITERALS. Asserting `report.fixtures > FLOORS.fixtures`
+  // instead would be circular — it stays green with every floor zeroed — so
+  // the magnitudes below are INDEPENDENT literals, not derived from FLOORS.
+  it('pins the declared collapse floors', () => {
+    expect(FLOORS.fixtures).toBe(250);
+    expect(FLOORS.declaringFixtures).toBe(250);
+  });
+
+  it('reads a corpus far larger than the floors (measured 292/292 on 2026-09-09)', () => {
+    expect(report.fixtures).toBeGreaterThanOrEqual(280);
+    expect(report.declaringFixtures).toBeGreaterThanOrEqual(280);
+    // Every fixture carrying a manifest declares aws-cdk-lib; a gap would mean
+    // the reader silently stopped seeing one of the two dependency buckets.
+    expect(report.declaringFixtures).toBe(report.fixtures);
+  });
+
+  it('resolves both sides of the comparison', () => {
+    expect(report.minFloor).not.toBeNull();
+    expect(report.templateFloor).not.toBeNull();
+    expect(compareFloors(report.templateFloor!, report.minFloor!)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('real-code failure probes (the checker must prove it FAILS)', () => {
+  // Each case spawns the built script; per `.claude/rules/testing.md` a
+  // subprocess-spawning test declares its own timeout rather than riding the
+  // in-process 5 s default.
+  const TIMEOUT = 60_000;
+
+  it(
+    'control: the unmutated real tree exits 0',
+    () => {
+      const integRoot = copyRealManifests();
+      const template = copyRealTemplate();
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${template}`]);
+      expect(res.status).toBe(0);
+      expect(res.stderr).toContain('OK');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'fails when the real template is reverted to the pre-#2838 floor',
+    () => {
+      const integRoot = copyRealManifests();
+      const template = copyRealTemplate((t) => t.replace(/"aws-cdk-lib": "\^2\.\d+\.\d+"/, '"aws-cdk-lib": "^2.169.0"'));
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${template}`]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('below the lowest floor');
+      expect(res.stderr).toContain('^2.169.0');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'REFUSES rather than passes when the template key cannot be found',
+    () => {
+      const integRoot = copyRealManifests();
+      const template = copyRealTemplate((t) => t.replace('"aws-cdk-lib"', '"aws-cdk-lib-renamed"'));
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${template}`]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('could not extract exactly one');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'REFUSES rather than skips a fixture manifest that does not parse',
+    () => {
+      const integRoot = copyRealManifests();
+      writeFileSync(join(integRoot, 'basic', 'package.json'), '{ "name": "broken", ');
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('manifest does not parse');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'REFUSES rather than skips a spec with no decidable floor',
+    () => {
+      const integRoot = copyRealManifests();
+      setFixtureSpec(integRoot, 'basic', '*');
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('no decidable floor');
+    },
+    TIMEOUT,
+  );
+
+  // The dependabot-safety property, and the reason this is not an equality
+  // fence. Both directions of corpus spread must pass.
+  it(
+    'PASSES when one fixture is bumped ahead of the rest (the dependabot case)',
+    () => {
+      const integRoot = copyRealManifests();
+      setFixtureSpec(integRoot, 'basic', '^2.999.0');
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'PASSES when one fixture lags the template (the deliberate looseness)',
+    () => {
+      const integRoot = copyRealManifests();
+      setFixtureSpec(integRoot, 'basic', '^2.169.0');
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'fails loudly when the corpus root is unreadable',
+    () => {
+      const res = runCli([
+        `--integ-root=${join(tmpdir(), 'cdkd-floor-does-not-exist')}`,
+        `--template=${copyRealTemplate()}`,
+      ]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('integ root unreadable');
+    },
+    TIMEOUT,
+  );
+
+  // The floors are only consulted by `main()`, so nothing above would notice
+  // them going inert. A corpus of two fixtures is internally consistent and
+  // violates no rule — only the floor can reject it.
+  it(
+    'the collapse floors fire on a corpus that shrank',
+    () => {
+      const full = copyRealManifests();
+      const small = mkdtempSync(join(tmpdir(), 'cdkd-floor-small-'));
+      for (const fixture of ['basic', 'lambda']) {
+        mkdirSync(join(small, fixture), { recursive: true });
+        writeFileSync(
+          join(small, fixture, 'package.json'),
+          readFileSync(join(full, fixture, 'package.json'), 'utf8'),
+        );
+      }
+      const res = runCli([`--integ-root=${small}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('fixtures read (floor');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'the SPAWNED binary still consults the self-probe',
+    () => {
+      const res = runCli([], { CDKD_SELF_PROBE_FORCE_FAIL: '1' });
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain('SELF-PROBE FAILED');
+    },
+    TIMEOUT,
+  );
+
+  it.each([
+    ['unknown flag', '--chekc'],
+    ['empty integ-root', '--integ-root='],
+    ['empty template', '--template='],
+    ['positional', 'tests/integration'],
+  ])(
+    'refuses the malformed argument: %s',
+    (_label, arg) => {
+      const res = runCli([arg]);
+      expect(res.status).not.toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'under --json, stdout carries only the report',
+    () => {
+      const res = runCli(['--json', `--integ-root=${copyRealManifests()}`, `--template=${copyRealTemplate()}`]);
+      expect(res.status).toBe(0);
+      expect(() => JSON.parse(res.stdout)).not.toThrow();
+      expect(res.stdout).not.toContain('OK —');
+    },
+    TIMEOUT,
+  );
+});

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -18,6 +18,7 @@ import {
   TEMPLATE_REL,
   checkIntegCdkLibFloor,
   compareFloors,
+  declaredSpec,
   extractTemplateFloor,
   extractTemplateFloorDetailed,
   parseFloor,
@@ -137,6 +138,10 @@ describe('parseFloor / compareFloors', () => {
       expect(got).not.toBeNull();
       const [major, minor, patch] = testCase.floor!;
       expect([got!.major, got!.minor, got!.patch]).toEqual([major, minor, patch]);
+      // `.operator` and `.raw` were unasserted for every case but one, so a
+      // mutated operator default and a dropped `.trim()` both stayed green.
+      expect(got!.operator).toBe(testCase.spec.trim()[0]?.match(/[\^~]/) ? testCase.spec.trim()[0] : '=');
+      expect(got!.raw).toBe(testCase.spec.trim());
     },
   );
 
@@ -210,6 +215,129 @@ describe('extractTemplateFloor', () => {
     expect(extraction.matches).toBe(expected);
     expect(extraction.floor).toBeNull();
   });
+});
+
+/**
+ * The corpus is UNIFORM today (292 x `^2.260.0`), which makes min-SELECTION,
+ * dedup and ordering unobservable: swapping `sorted[0]` for the last element
+ * still names a `^2.260.0` fixture. Every case here deliberately builds a
+ * NON-UNIFORM corpus, so the value under test is not pinned by the fixture.
+ */
+describe('a non-uniform corpus (the uniform real one cannot see these)', () => {
+  function corpus(specs: Record<string, string>): string {
+    const dir = scratch('cdkd-floor-mixed-');
+    for (const [name, spec] of Object.entries(specs)) {
+      mkdirSync(join(dir, name), { recursive: true });
+      writeFileSync(
+        join(dir, name, 'package.json'),
+        JSON.stringify({ name, dependencies: { 'aws-cdk-lib': spec } }, null, 2),
+      );
+    }
+    return dir;
+  }
+
+  // Pins `sorted[0]`. With a uniform corpus, taking the LAST element instead
+  // still printed a `^2.260.0` fixture and every test stayed green.
+  it('names the LOWEST fixture and its spec in the below-the-floor message', () => {
+    const integRoot = corpus({
+      aaa: '^2.300.0',
+      mmm: '^2.100.0', // the lowest, and neither first nor last alphabetically
+      zzz: '^2.200.0',
+    });
+    const template = copyRealTemplate((t) =>
+      t.replace(/"aws-cdk-lib": "\^2\.\d+\.\d+"/, '"aws-cdk-lib": "^2.050.0"'),
+    );
+    const report = checkIntegCdkLibFloor({ integRoot, templatePath: template });
+    expect(report.minFloor?.raw).toBe('^2.100.0');
+    const text = report.violations.join('\n');
+    expect(text).toContain('below the lowest floor');
+    expect(text).toContain('^2.100.0');
+    expect(text).toContain(join(integRoot, 'mmm'));
+    // The discriminating half: a max-selection mutant names one of these.
+    expect(text).not.toContain(join(integRoot, 'aaa'));
+    expect(text).not.toContain(join(integRoot, 'zzz'));
+  });
+
+  // Pins `distinctFloors`, which had ZERO references: replacing it with `[]`
+  // exited 0 printing "0 distinct".
+  it('reports distinct floors, deduped and ascending', () => {
+    const integRoot = corpus({
+      a: '^2.300.0',
+      b: '^2.100.0',
+      c: '^2.300.0', // duplicate of a
+      d: '^2.200.0',
+    });
+    const report = checkIntegCdkLibFloor({ integRoot, templatePath: REAL_TEMPLATE });
+    expect(report.distinctFloors).toEqual(['^2.100.0', '^2.200.0', '^2.300.0']);
+  });
+
+  // The template sitting between two corpus floors must still PASS: the rule
+  // is "not below the MINIMUM", not "at or above every fixture".
+  it('passes when the template is above the minimum but below other fixtures', () => {
+    const integRoot = corpus({ low: '^2.100.0', high: '^2.900.0' });
+    const template = copyRealTemplate((t) =>
+      t.replace(/"aws-cdk-lib": "\^2\.\d+\.\d+"/, '"aws-cdk-lib": "^2.150.0"'),
+    );
+    const report = checkIntegCdkLibFloor({ integRoot, templatePath: template });
+    expect(report.violations).toEqual([]);
+  });
+});
+
+describe('declaredSpec refuses what it cannot read', () => {
+  it.each([
+    ['found', { dependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found'],
+    ['found in devDependencies', { devDependencies: { 'aws-cdk-lib': '^2.1.0' } }, 'found'],
+    ['absent', { name: 'x', dependencies: {} }, 'absent'],
+    ['no buckets at all', { name: 'x' }, 'absent'],
+    // Each of these used to `continue` silently, dropping the fixture out of
+    // the minimum -- a loosening, which the header classifies as a refusal.
+    ['manifest is an array', [], 'malformed'],
+    ['manifest is a string', 'nope', 'malformed'],
+    ['dependencies is a string', { dependencies: 'nope' }, 'malformed'],
+    ['dependencies is an array', { dependencies: [] }, 'malformed'],
+    ['spec is a number', { dependencies: { 'aws-cdk-lib': 2 } }, 'malformed'],
+    ['spec is null', { dependencies: { 'aws-cdk-lib': null } }, 'malformed'],
+  ])('classifies %s', (_label, manifest, kind) => {
+    expect(declaredSpec(manifest).kind).toBe(kind);
+  });
+
+  it('surfaces a malformed manifest as a REFUSAL, not a smaller minimum', () => {
+    const dir = scratch('cdkd-floor-malformed-');
+    mkdirSync(join(dir, 'good'), { recursive: true });
+    writeFileSync(
+      join(dir, 'good', 'package.json'),
+      JSON.stringify({ dependencies: { 'aws-cdk-lib': '^2.300.0' } }),
+    );
+    mkdirSync(join(dir, 'bad'), { recursive: true });
+    writeFileSync(join(dir, 'bad', 'package.json'), JSON.stringify({ dependencies: 'nope' }));
+    const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
+    // The point: `bad` does not silently vanish leaving `good` as the minimum.
+    expect(report.refusals.map((r) => r.reason)).toContain('"dependencies" is not a JSON object');
+    expect(report.violations.join('\n')).toContain('not a JSON object');
+  });
+});
+
+describe('the repoRoot seam', () => {
+  it('renders labels relative to a CALLER-supplied repoRoot', () => {
+    const dir = scratch('cdkd-floor-reporoot-');
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", ');
+    // With repoRoot = dir, the manifest is INSIDE it, so the label is relative.
+    const report = checkIntegCdkLibFloor({
+      integRoot: dir,
+      templatePath: REAL_TEMPLATE,
+      repoRoot: dir,
+    });
+    expect(report.refusals.map((r) => r.where)).toContain(join('a', 'package.json'));
+  });
+
+  it('accepts --repo-root= and refuses an empty one', () => {
+    const ok = runCli([`--repo-root=${REPO_ROOT}`]);
+    expect(ok.status).toBe(0);
+    const empty = runCli(['--repo-root=']);
+    expect(empty.status).toBe(1);
+    expect(empty.stderr).toContain('--repo-root= requires a non-empty value');
+  }, TIMEOUT);
 });
 
 describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -304,8 +304,18 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
 
   // finding 1 of round 5: the unreadable-root EARLY RETURN bypassed the label
   // helper, so it printed an absolute path where every sibling site printed a
-  // repo-relative one -- falsifying the "every printed path" invariant at the
-  // one site the conversion missed. No other arm reaches this branch.
+  // repo-relative one -- falsifying the "every path this file formats"
+  // invariant at the one site the conversion missed. No other arm reaches this
+  // branch.
+  //
+  // COUPLING, so a future cleanup does not read this arm as a labelling
+  // regression: it passes partly because the early return hand-writes its own
+  // `violations` and never runs the refusals-to-violations loop every other
+  // site goes through. Routing it through that loop -- the natural tidy-up --
+  // puts the refusal's `reason` on stderr, and a `reason` carries Node's
+  // errno text with a RAW absolute path by design (see `label()`'s exemption).
+  // If this arm reds after such a refactor, narrow the assertion to the
+  // violation line; do not start stripping the errno.
   it('labels the unreadable-root message like every other path', () => {
     const res = runCli([`--integ-root=${join(REPO_ROOT, INTEG_ROOT_REL, 'DOES-NOT-EXIST')}`]);
     expect(res.status).toBe(1);

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -216,16 +216,6 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     expect(report.violations.join('\n')).not.toContain(INTEG_ROOT_REL);
   });
 
-  it('reports a violation when manifests exist but none declares a floor', () => {
-    const dir = scratch('cdkd-floor-nodecl-');
-    mkdirSync(join(dir, 'a'), { recursive: true });
-    writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", "dependencies": {} }');
-    const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
-    expect(report.fixtures).toBe(1);
-    expect(report.declaringFixtures).toBe(0);
-    expect(report.violations.join('\n')).toContain('none yielded a decidable aws-cdk-lib floor');
-  });
-
   // The summary INFERS NO CAUSE. Two review rounds went into a conditional
   // trying to say why no floor was found; every version was wrong for some
   // input because it branched on `refusals.length` against `fixtures`, which
@@ -262,6 +252,44 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     });
     expect(report.refusals.length).toBe(2); // one manifest + one template
     expect(report.violations.join('\n')).toContain('none yielded a decidable aws-cdk-lib floor');
+  });
+
+  // finding 3 of round 4: the path in the BELOW-THE-FLOOR message was
+  // unpinned — reverting it to the hardcoded label left the whole suite green.
+  // This is the only arm that reaches that site (it needs a non-null minFloor).
+  it('names the real corpus AND template paths in the below-the-floor message', () => {
+    const integRoot = copyRealManifests();
+    const template = copyRealTemplate((t) =>
+      t.replace(/"aws-cdk-lib": "\^2\.\d+\.\d+"/, '"aws-cdk-lib": "^2.169.0"'),
+    );
+    const report = checkIntegCdkLibFloor({ integRoot, templatePath: template });
+    const text = report.violations.join('\n');
+    expect(text).toContain('below the lowest floor');
+    expect(text).toContain(integRoot);
+    expect(text).toContain(template);
+    expect(text).not.toContain(INTEG_ROOT_REL);
+    expect(text).not.toContain(TEMPLATE_REL);
+  });
+
+  // finding 2 of round 4: TEMPLATE_REL was hardcoded on the refusal sites too,
+  // so a seam template that could not be read was reported at the repo path.
+  it('names the real template path when the TEMPLATE itself refuses', () => {
+    const integRoot = copyRealManifests();
+    const missing = join(scratch('cdkd-floor-notpl-'), 'missing.md');
+    const report = checkIntegCdkLibFloor({ integRoot, templatePath: missing });
+    const text = [...report.violations, ...report.refusals.map((r) => r.where)].join('\n');
+    expect(text).toContain(missing);
+    expect(text).not.toContain(TEMPLATE_REL);
+  });
+
+  // The default (no-seam) invocation must still print REPO-RELATIVE paths --
+  // the label helper derives them, so this pins the house convention rather
+  // than an absolute path leaking into CI output.
+  it('prints repo-relative paths for the default invocation', () => {
+    const res = runCli([`--template=${copyRealTemplate((t) => t.replace(/"aws-cdk-lib": "\^2\.\d+\.\d+"/, '"aws-cdk-lib": "^2.169.0"'))}`]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain(`${INTEG_ROOT_REL}/`);
+    expect(res.stderr).not.toContain(REPO_ROOT);
   });
 
   // Every path the checker prints must name the root it ACTUALLY read.

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -210,6 +210,10 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     // The regression this pins: it used to return refusals:[] AND violations:[]
     // here, i.e. a fully clean report over a corpus it never read.
     expect(report.violations.join('\n')).toContain('the corpus was not read');
+    // ...and it must name the root ACTUALLY checked. A hardcoded
+    // `tests/integration` label sent the reader to a directory never read.
+    expect(report.violations.join('\n')).toContain(empty);
+    expect(report.violations.join('\n')).not.toContain(INTEG_ROOT_REL);
   });
 
   it('reports a violation when manifests exist but none declares a floor', () => {
@@ -220,6 +224,19 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     expect(report.fixtures).toBe(1);
     expect(report.declaringFixtures).toBe(0);
     expect(report.violations.join('\n')).toContain('none declaring a decidable aws-cdk-lib floor');
+  });
+
+  // The two ways `minFloor` can be null read identically in a summary line, and
+  // only one of them is true at a time. The refusals carry the detail; the
+  // summary must not assert the wrong one.
+  it('says NONE WERE READABLE when every manifest failed to parse', () => {
+    const dir = scratch('cdkd-floor-unparseable-');
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", ');
+    const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
+    expect(report.fixtures).toBe(1);
+    expect(report.violations.join('\n')).toContain('none of them readable');
+    expect(report.violations.join('\n')).not.toContain('none declaring a decidable');
   });
 });
 
@@ -411,19 +428,23 @@ describe('real-code failure probes (the checker must prove it FAILS)', () => {
     TIMEOUT,
   );
 
+  // A per-case needle, not one alternation for all four: with a shared
+  // `/unknown argument|requires a non-empty value/`, deleting the
+  // `--integ-root=` branch routes it to `unknown argument` and the case still
+  // passes — an arm passing on another arm's message.
   it.each([
-    ['unknown flag', '--chekc'],
-    ['empty integ-root', '--integ-root='],
-    ['empty template', '--template='],
-    ['positional', 'tests/integration'],
+    ['unknown flag', '--chekc', 'unknown argument: --chekc'],
+    ['empty integ-root', '--integ-root=', '--integ-root= requires a non-empty value'],
+    ['empty template', '--template=', '--template= requires a non-empty value'],
+    ['positional', 'tests/integration', 'unknown argument: tests/integration'],
   ])(
     'refuses the malformed argument: %s',
-    (_label, arg) => {
+    (_label, arg, needle) => {
       const res = runCli([arg]);
       // `not.toBe(0)` alone is satisfied by a spawn that never ran; `runCli`
       // now throws on that, and the exact code plus a needle pins the arm.
       expect(res.status).toBe(1);
-      expect(res.stderr).toMatch(/unknown argument|requires a non-empty value/);
+      expect(res.stderr).toContain(needle);
     },
     TIMEOUT,
   );

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, afterAll } from 'vite-plus/test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -11,6 +19,7 @@ import {
   checkIntegCdkLibFloor,
   compareFloors,
   extractTemplateFloor,
+  extractTemplateFloorDetailed,
   parseFloor,
   runSelfProbe,
 } from '../../../scripts/check-integ-cdk-lib-floor.js';
@@ -32,6 +41,22 @@ const SCRIPT = join(REPO_ROOT, 'scripts/check-integ-cdk-lib-floor.ts');
 const REAL_INTEG_ROOT = join(REPO_ROOT, INTEG_ROOT_REL);
 const REAL_TEMPLATE = join(REPO_ROOT, TEMPLATE_REL);
 
+/**
+ * Every temp dir this file makes, swept in `afterAll`. Each probe copies ~292
+ * manifests; without the sweep a run leaves ~21 such trees behind.
+ */
+const scratchDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratch(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  scratchDirs.push(dir);
+  return dir;
+}
+
 /** Run the SHIPPED binary, so `main()`, `parseArgs` and the seam are all live. */
 function runCli(args: string[], env: Record<string, string> = {}) {
   const res = spawnSync('node', [SCRIPT, ...args], {
@@ -39,6 +64,13 @@ function runCli(args: string[], env: Record<string, string> = {}) {
     encoding: 'utf8',
     env: { ...process.env, ...env },
   });
+  // A spawn that never ran reports `status: null`, which satisfies
+  // `not.toBe(0)` — a failure indistinguishable from the refusal being tested.
+  // Throwing here makes it a loud test error instead.
+  if (res.error) throw res.error;
+  if (res.status === null) {
+    throw new Error(`checker was killed by signal ${String(res.signal)}; stderr: ${res.stderr}`);
+  }
   return { status: res.status, stderr: res.stderr ?? '', stdout: res.stdout ?? '' };
 }
 
@@ -48,7 +80,7 @@ function runCli(args: string[], env: Record<string, string> = {}) {
  * real-code probes, and never writes to `tests/integration` itself.
  */
 function copyRealManifests(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'cdkd-floor-integ-'));
+  const dir = scratch('cdkd-floor-integ-');
   for (const entry of readdirSync(REAL_INTEG_ROOT, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const src = join(REAL_INTEG_ROOT, entry.name, 'package.json');
@@ -61,7 +93,7 @@ function copyRealManifests(): string {
 
 /** A COPY of the real scaffold template, optionally mutated. */
 function copyRealTemplate(mutate?: (text: string) => string): string {
-  const dir = mkdtempSync(join(tmpdir(), 'cdkd-floor-tpl-'));
+  const dir = scratch('cdkd-floor-tpl-');
   const path = join(dir, 'SKILL.md');
   const text = readFileSync(REAL_TEMPLATE, 'utf8');
   writeFileSync(path, mutate ? mutate(text) : text);
@@ -75,7 +107,11 @@ function setFixtureSpec(integRoot: string, fixture: string, spec: string): void 
     devDependencies?: Record<string, string>;
   };
   const bucket = manifest.dependencies?.['aws-cdk-lib'] ? 'dependencies' : 'devDependencies';
-  manifest[bucket]!['aws-cdk-lib'] = spec;
+  const deps = manifest[bucket];
+  if (!deps || !deps['aws-cdk-lib']) {
+    throw new Error(`${fixture} declares no aws-cdk-lib in ${bucket}; the probe would be vacuous`);
+  }
+  deps['aws-cdk-lib'] = spec;
   writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -151,6 +187,40 @@ describe('extractTemplateFloor', () => {
   it('refuses a template whose spec has no decidable floor', () => {
     expect(extractTemplateFloor('"aws-cdk-lib": "latest"\n')).toBeNull();
   });
+
+  // One refusal string used to cover all three failures, so "someone added a
+  // second example manifest" read as "the key is gone" and pointed the fix at
+  // the wrong edit. The counting form is what lets the message discriminate.
+  it.each([
+    ['none', '```json\n{ "dependencies": {} }\n```\n', 0],
+    ['two', '"aws-cdk-lib": "^2.260.0"\n"aws-cdk-lib": "^2.169.0"\n', 2],
+    ['one, undecidable', '"aws-cdk-lib": "latest"\n', 1],
+  ])('counts the declarations it found: %s', (_label, markdown, expected) => {
+    const extraction = extractTemplateFloorDetailed(markdown);
+    expect(extraction.matches).toBe(expected);
+    expect(extraction.floor).toBeNull();
+  });
+});
+
+describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
+  it('reports a violation for an existing but empty corpus root', () => {
+    const empty = scratch('cdkd-floor-empty-');
+    const report = checkIntegCdkLibFloor({ integRoot: empty, templatePath: REAL_TEMPLATE });
+    expect(report.fixtures).toBe(0);
+    // The regression this pins: it used to return refusals:[] AND violations:[]
+    // here, i.e. a fully clean report over a corpus it never read.
+    expect(report.violations.join('\n')).toContain('the corpus was not read');
+  });
+
+  it('reports a violation when manifests exist but none declares a floor', () => {
+    const dir = scratch('cdkd-floor-nodecl-');
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a', 'package.json'), '{ "name": "a", "dependencies": {} }');
+    const report = checkIntegCdkLibFloor({ integRoot: dir, templatePath: REAL_TEMPLATE });
+    expect(report.fixtures).toBe(1);
+    expect(report.declaringFixtures).toBe(0);
+    expect(report.violations.join('\n')).toContain('none declaring a decidable aws-cdk-lib floor');
+  });
 });
 
 describe('the real repository satisfies the fence', () => {
@@ -225,7 +295,22 @@ describe('real-code failure probes (the checker must prove it FAILS)', () => {
       const template = copyRealTemplate((t) => t.replace('"aws-cdk-lib"', '"aws-cdk-lib-renamed"'));
       const res = runCli([`--integ-root=${integRoot}`, `--template=${template}`]);
       expect(res.status).toBe(1);
-      expect(res.stderr).toContain('could not extract exactly one');
+      expect(res.stderr).toContain('found no `"aws-cdk-lib": "<spec>"` declaration');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'REFUSES a template that grew a SECOND manifest, and says it found two',
+    () => {
+      const integRoot = copyRealManifests();
+      // The realistic future edit: the skill gains a second example block.
+      const template = copyRealTemplate((t) => `${t}\n\`\`\`json\n{ "dependencies": { "aws-cdk-lib": "^2.169.0" } }\n\`\`\`\n`);
+      const res = runCli([`--integ-root=${integRoot}`, `--template=${template}`]);
+      expect(res.status).toBe(1);
+      // Naming the COUNT is the point — the old single string sent the reader
+      // looking for a missing key instead of a duplicated one.
+      expect(res.stderr).toContain('found 2 `"aws-cdk-lib": "<spec>"` declarations');
     },
     TIMEOUT,
   );
@@ -298,7 +383,7 @@ describe('real-code failure probes (the checker must prove it FAILS)', () => {
     'the collapse floors fire on a corpus that shrank',
     () => {
       const full = copyRealManifests();
-      const small = mkdtempSync(join(tmpdir(), 'cdkd-floor-small-'));
+      const small = scratch('cdkd-floor-small-');
       for (const fixture of ['basic', 'lambda']) {
         mkdirSync(join(small, fixture), { recursive: true });
         writeFileSync(
@@ -308,7 +393,10 @@ describe('real-code failure probes (the checker must prove it FAILS)', () => {
       }
       const res = runCli([`--integ-root=${small}`, `--template=${copyRealTemplate()}`]);
       expect(res.status).toBe(1);
+      // BOTH floors, not just the first: pinning only `fixtures` left the
+      // `declaringFixtures` block deletable with every test in this file green.
       expect(res.stderr).toContain('fixtures read (floor');
+      expect(res.stderr).toContain('declared aws-cdk-lib (floor');
     },
     TIMEOUT,
   );
@@ -332,7 +420,10 @@ describe('real-code failure probes (the checker must prove it FAILS)', () => {
     'refuses the malformed argument: %s',
     (_label, arg) => {
       const res = runCli([arg]);
-      expect(res.status).not.toBe(0);
+      // `not.toBe(0)` alone is satisfied by a spawn that never ran; `runCli`
+      // now throws on that, and the exact code plus a needle pins the arm.
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/unknown argument|requires a non-empty value/);
     },
     TIMEOUT,
   );

--- a/tests/unit/scripts/integ-cdk-lib-floor.test.ts
+++ b/tests/unit/scripts/integ-cdk-lib-floor.test.ts
@@ -36,6 +36,16 @@ import {
  * an equality fence would red-flag every one of its PRs.
  */
 
+/**
+ * Every arm that SPAWNS the checker declares this. Per `.claude/rules/testing.md`
+ * a subprocess-spawning test must not ride vitest's 5 s in-process default: the
+ * spawn pays Node startup plus type-stripping, which passes locally and times
+ * out on a loaded CI runner. Module scope, not inside a describe — arms in
+ * EARLIER blocks reference it, and a `const` in a later block is in its TDZ
+ * when their `it()` calls are evaluated.
+ */
+const TIMEOUT = 60_000;
+
 const REPO_ROOT = join(import.meta.dirname, '../../..');
 const SCRIPT = join(REPO_ROOT, 'scripts/check-integ-cdk-lib-floor.ts');
 const REAL_INTEG_ROOT = join(REPO_ROOT, INTEG_ROOT_REL);
@@ -290,7 +300,18 @@ describe('emptiness is a LIBRARY violation, not only a CLI floor', () => {
     expect(res.status).toBe(1);
     expect(res.stderr).toContain(`${INTEG_ROOT_REL}/`);
     expect(res.stderr).not.toContain(REPO_ROOT);
-  });
+  }, TIMEOUT);
+
+  // finding 1 of round 5: the unreadable-root EARLY RETURN bypassed the label
+  // helper, so it printed an absolute path where every sibling site printed a
+  // repo-relative one -- falsifying the "every printed path" invariant at the
+  // one site the conversion missed. No other arm reaches this branch.
+  it('labels the unreadable-root message like every other path', () => {
+    const res = runCli([`--integ-root=${join(REPO_ROOT, INTEG_ROOT_REL, 'DOES-NOT-EXIST')}`]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain(`${INTEG_ROOT_REL}/DOES-NOT-EXIST`);
+    expect(res.stderr).not.toContain(REPO_ROOT);
+  }, TIMEOUT);
 
   // Every path the checker prints must name the root it ACTUALLY read.
   it('never names the hardcoded corpus path when a seam root was given', () => {
@@ -339,11 +360,6 @@ describe('the real repository satisfies the fence', () => {
 });
 
 describe('real-code failure probes (the checker must prove it FAILS)', () => {
-  // Each case spawns the built script; per `.claude/rules/testing.md` a
-  // subprocess-spawning test declares its own timeout rather than riding the
-  // in-process 5 s default.
-  const TIMEOUT = 60_000;
-
   it(
     'control: the unmutated real tree exits 0',
     () => {


### PR DESCRIPTION
## Summary

Fences the `/new-integ` scaffold template's `aws-cdk-lib` floor against the
integ-fixture corpus, so the drift go-to-k/cdkd#2838 cleaned up cannot
re-accumulate from the same source.

That drift — `^2.169.0` ×172, `^2.172.0` ×91, `^2.176.0` ×15, `^2.257.0` ×6
across 292 fixtures — had one systematic cause:
`.claude/skills/new-integ/SKILL.md` emitted a hardcoded `^2.169.0` for every
fixture ever scaffolded, while dependabot moved individual fixtures forward
around it. Nothing watched the template.

## The rule, and why it is not an equality fence

**`template floor >= the LOWEST floor in the corpus`.**

The obvious fence — "every fixture floor is identical" — is wrong for this repo
and would have been worse than nothing. Dependabot bumps `aws-cdk-lib` **one
directory at a time** (go-to-k/cdkd#2487, go-to-k/cdkd#2488, go-to-k/cdkd#2834
are each a single fixture), so the corpus is legitimately non-uniform between
such merges, and an equality fence would red-flag every one of those PRs. A
fence that fires on correct, routine, bot-authored changes gets disabled, not
obeyed.

So the subject is the **generator**, not the corpus: the corpus may spread, the
template may not fall behind the back of it. Two PASS probes pin that property
in both directions.

What it deliberately does **not** claim is in the script header — chiefly that
it does not keep the corpus uniform (a hand-authored fixture with an old floor
lowers the minimum and the template still passes; that is the cost of being
dependabot-safe), and that it says nothing about the resolved version.

## Refusals are not passes

Every input it cannot read is a hard failure, never a skip:

- the template floor failing to extract — reporting `null` as "nothing to
  compare" would make the checker permanently and silently green, which is the
  failure mode it exists to prevent, one level up;
- a manifest that does not parse;
- a spec with no decidable floor (`*`, `latest`, `>=X`, an `||` union) — skipping
  one removes it from the minimum, which can only ever *loosen* the verdict.

## Defences (per `.claude/rules/testing.md`)

- **Collapse toward zero:** `FLOORS` pinned to literals by the test, whose
  magnitude assertions are *independent* literals rather than `> FLOORS.x`,
  which is circular and stays green with every floor zeroed. A probe proves the
  floors actually fire.
- **Collapse toward green:** 12 `SELF_PROBE_CASES` (8 negative) run before the
  tree is read, plus `CDKD_SELF_PROBE_FORCE_FAIL=1` proving the **spawned**
  binary still consults them.
- **Real-code failure probes**, against a copy of the real manifests and the
  real template, never writing to the tree.

## Not indexed in `layout-scripts.md`

`.claude/rules/layout-scripts.md` is where `code-layout.md` routes readers for
`scripts/**`, but it measures 79,649 B against its 80,000 B cap. The shortest
useful entry measured ~310 B, which would leave 41 — reproducing
go-to-k/cdkd#2288 for the next lane. The rationale lives in the script header
instead; the split that makes room, and this entry, are go-to-k/cdkd#2844.

## Test plan

`tests/unit/scripts/integ-cdk-lib-floor.test.ts` **is** the CI enforcement —
no `vp run` task and no `ci.yml` step, as with `check-verification-depth-rule.ts`
and `check-source-control-bytes.ts`. 39 cases.

Real-code probes, each run against a copy and confirmed by exit code **and**
message:

| Probe | Expected | Result |
|---|---|---|
| control, unmutated real tree | exit 0 | ✅ |
| template reverted to `^2.169.0` | exit 1, names it | ✅ `below the lowest floor … ^2.169.0` |
| template key renamed (extraction fails) | exit 1, refusal | ✅ `could not extract exactly one` |
| a manifest made unparseable | exit 1, refusal | ✅ `manifest does not parse` |
| a spec set to `*` | exit 1, refusal | ✅ `no decidable floor` |
| **one fixture bumped ahead** (dependabot case) | exit **0** | ✅ |
| **one fixture lagging** (deliberate looseness) | exit **0** | ✅ |
| corpus root unreadable | exit 1 | ✅ `integ root unreadable` |
| collapse floors on a shrunken corpus | exit 1 | ✅ `fixtures read (floor` |
| `CDKD_SELF_PROBE_FORCE_FAIL=1` on the spawned binary | exit 1 | ✅ `SELF-PROBE FAILED` |
| malformed args (unknown flag, empty seam values, positional) | non-zero | ✅ |

Repo-wide: `vp run check` 0 errors, `vp run typecheck:test` pass, `vp run build`
pass, `vp test run` 953 files / 20703 tests passed (1 skipped), no type errors.
`vp run gen:all-matrices` + `audit:coverage:check` left no artifact stale.

Against the real tree today: 292/292 fixtures, 1 distinct floor, template
`^2.260.0`.

Closes #2839
