### PR TITLE
chore(review): start a review round on the author's reply, not on a push

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -23,16 +23,51 @@ issues the `Agent` calls.
 0. **A PUSH is not a round-completion signal — a REPLY is. Check for one
    before opening a round on a head you have not reviewed.**
 
+   Decide it from WHOSE TURN IT IS, never from a push timestamp. A round is a
+   conversation turn: your comment ends yours, the author's ends theirs. Two
+   push-timestamp spellings were tried and both skip the wait SILENTLY — a
+   `committed` timeline event carries the COMMIT date, not the push time (and
+   that is the ordinary non-force-push shape, so the error is the common
+   case), and an empty `$PUSH` makes jq's `.created_at > ""` true for every
+   comment ever written, which reads as "they replied". Neither errors.
+
    ```bash
-   # The newest push, and whether the author has said anything since it.
-   PUSH=$(gh api repos/go-to-k/cdkd/issues/<N>/timeline --paginate \
-     -q '[.[] | select(.event=="head_ref_force_pushed" or .event=="committed")
-          | .created_at // .committer.date] | last')
-   AUTHOR=$(gh pr view <N> --json author -q .author.login)
-   gh api repos/go-to-k/cdkd/issues/<N>/comments --paginate \
-     -q "[.[] | select(.user.login==\"$AUTHOR\" and .created_at > \"$PUSH\")] | length"
-   # 0 = the author has not spoken since the push. Wait.
+   PR=<N>; REPO=go-to-k/cdkd
+   ME=$(gh api user -q .login)
+   THEM=$(gh pr view "$PR" --repo "$REPO" --json author -q .author.login)
+   # All three surfaces: issue comments, review BODIES, and review-thread
+   # replies. A contributor answering from "Files changed" -- GitHub's default
+   # -- writes only the last two, and `issues/<N>/comments` never shows them.
+   said() { # said <login> -> newest ISO timestamp, or empty
+     { gh api "repos/$REPO/issues/$PR/comments" --paginate -q ".[]|select(.user.login==\"$1\")|.created_at"
+       gh api "repos/$REPO/pulls/$PR/comments"  --paginate -q ".[]|select(.user.login==\"$1\")|.created_at"
+       gh api "repos/$REPO/pulls/$PR/reviews"   --paginate -q ".[]|select(.user.login==\"$1\" and .submitted_at!=null)|.submitted_at"
+     } | sort | tail -1
+   }
+   MINE=$(said "$ME"); THEIRS=$(said "$THEM")
    ```
+
+   Then, in order — the first match wins:
+
+   - `MINE` empty → **no round has happened**; nothing to complete. Proceed.
+   - `THEIRS` newer than `MINE` → **their turn ended**. Proceed. ISO-8601
+     sorts lexically, so compare with bash's `[[ "$THEIRS" > "$MINE" ]]` — NOT
+     `[ ... ]`, whose `>` is undefined for strings and which zsh rejects
+     outright (`condition expected: >`, measured while writing this). In a
+     shell you do not control:
+     `[ "$(printf '%s\n%s\n' "$MINE" "$THEIRS" | sort | tail -1)" = "$THEIRS" ]`
+     with an added `!=` guard for the equal case.
+   - otherwise → **you spoke last and they have not answered**. Compute
+     `now - MINE`; under ~30 minutes, WAIT. Waiting means arming a signal, not
+     a bare intention: a foreground `sleep` is blocked, so start a background
+     poll (or a `Monitor`) and end the turn as WAITING naming it. At ~30
+     minutes or more, proceed and say in the comment which head you reviewed.
+
+   Residual, stated rather than papered over: a contributor who replies and
+   THEN pushes again reads as "their turn ended", so that push is reviewed
+   immediately. That is the pre-rule behaviour, and erring toward reviewing is
+   the safe direction — an unnecessary round costs a comment, a missed one
+   costs the contributor a stall.
 
    A contributor pushes MID-round routinely — to bank work before a rebase,
    to start CI on a partial change, after a fix they know is not the whole
@@ -52,12 +87,14 @@ issues the `Agent` calls.
    to see why. This version requires nothing of the contributor, is not
    opt-in, and applies to every contributor uniformly.
 
-   **Bounded, so a contributor who does not write replies is never stuck**:
-   wait for a reply, and if none has landed ~30 minutes after the push, open
-   the round anyway and say in the comment which head you reviewed. Skip the
-   wait outright when the maintainer asked for the review explicitly, when
-   the PR is yours, or when the push is the FIRST one on a PR that has had no
-   review round yet — there is no round for it to be completing.
+   The ~30 minute bound is measured, not picked: across this contributor's
+   PRs, 41 of 43 replies landed within 30 minutes of the push they answered.
+
+   Skip the wait outright, each condition decidable from a command rather than
+   a judgement: the maintainer asked for this review in the current turn; the
+   PR is yours (`[ "$ME" = "$THEM" ]`); or `MINE` is empty, which is the same
+   first-branch test as above — there is no round for the push to be
+   completing.
 
    When you do open a round, name the head sha you reviewed. That is what
    lets a crossed reply be recognised as crossed instead of re-litigated.
@@ -269,7 +306,11 @@ issues the `Agent` calls.
    waits for all, and synthesizes:
 
    - Any **blocker** → the marker is NOT set; address the blockers and
-     re-run `/review-pr <N>` **from step 1**, on the PR's CURRENT stats. A
+     re-run `/review-pr <N>` **from step 0**, on the PR's CURRENT stats —
+     step 0 and not step 1, because a fix-round re-review IS the case step 0
+     exists for: go-to-k/cdkd#2753's crossing happened on exactly this
+     re-entry, so starting at step 1 leaves the rule inert on its own
+     motivating case. A
      fix round adds LOC and files AND a `fix:` commit, so the tier is not
      fixed for the life of a PR and neither is whether `pr-review-gate.sh`
      requires the marker at all: go-to-k/cdkd#2593 opened at 306 LOC / 4

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -20,6 +20,48 @@ issues the `Agent` calls.
 
 ## Steps
 
+0. **A PUSH is not a round-completion signal — a REPLY is. Check for one
+   before opening a round on a head you have not reviewed.**
+
+   ```bash
+   # The newest push, and whether the author has said anything since it.
+   PUSH=$(gh api repos/go-to-k/cdkd/issues/<N>/timeline --paginate \
+     -q '[.[] | select(.event=="head_ref_force_pushed" or .event=="committed")
+          | .created_at // .committer.date] | last')
+   AUTHOR=$(gh pr view <N> --json author -q .author.login)
+   gh api repos/go-to-k/cdkd/issues/<N>/comments --paginate \
+     -q "[.[] | select(.user.login==\"$AUTHOR\" and .created_at > \"$PUSH\")] | length"
+   # 0 = the author has not spoken since the push. Wait.
+   ```
+
+   A contributor pushes MID-round routinely — to bank work before a rebase,
+   to start CI on a partial change, after a fix they know is not the whole
+   round. Nothing distinguishes those from the push that finishes a round, so
+   a push alone does not say "your turn": go-to-k/cdkd#2840 measured 7 pairs
+   of adjacent opposite-author comments under 5 minutes across 15 PRs, the
+   tightest 39 s, and the concrete cost on go-to-k/cdkd#2753 was a review
+   round answering a head the author had already moved past plus a second
+   comment repeating requests their reply had crossed.
+
+   **The rule is on the REVIEWER side on purpose.** Both contributor-side
+   signals proposed in that issue — mark the PR draft while responding, or
+   apply a `review ok` label — were refused: nothing can enforce either, the
+   label needs triage permission a fork contributor does not have (measured:
+   403 on go-to-k/cdkd#2809), and both fail SILENTLY, so a contributor who
+   forgets the ritual is punished by a review that never arrives and no way
+   to see why. This version requires nothing of the contributor, is not
+   opt-in, and applies to every contributor uniformly.
+
+   **Bounded, so a contributor who does not write replies is never stuck**:
+   wait for a reply, and if none has landed ~30 minutes after the push, open
+   the round anyway and say in the comment which head you reviewed. Skip the
+   wait outright when the maintainer asked for the review explicitly, when
+   the PR is yours, or when the push is the FIRST one on a PR that has had no
+   review round yet — there is no round for it to be completing.
+
+   When you do open a round, name the head sha you reviewed. That is what
+   lets a crossed reply be recognised as crossed instead of re-litigated.
+
 1. **Fetch PR stats**:
 
    ```bash

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -150,7 +150,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-09T03:18:49Z	PASS	82	verify.sh	issue #2785 gate refresh, 9 deleted 0 errors, orph clean
+lambda	2026-09-09T04:16:00Z	PASS	82	verify.sh	maintainer merge-gate broad-set run for PR 2753 (deploy-engine.ts in integ-broad scope): 9 deleted, 0 errors, 0 orphans
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans
@@ -263,7 +263,7 @@ schema-v8-to-v9-migration	2026-08-26T02:45:22Z	PASS	171	verify.sh	maintainer-sid
 sdk-ccapi-crossref	2026-08-10T04:23:28Z	PASS	85	verify.sh	0810 sweep b2; post-#1355 CC snapshot path, heterogeneous routing, 4 del 0 err, 0 orph
 sdk-to-cc-autoroute	2026-09-08T10:06:14Z	PASS	125	verify.sh	2750 fix verification: phase 4 now asserts the record does NOT carry the dropped property (and keeps Threshold=4), phase 5 asserts EvaluationWindow reaches AWS via the re-route with the re-armed witness intact. rc 0, 1 deleted / 0 errors, 0 orphans
 secrets-array-nested	2026-08-26T17:19:35Z	PASS	215	verify.sh	gating PR 2295, RE-RUN on the final tree after a round-3 review fix to the arm helper. The identity check in assert_unkeyed_string_array sat AFTER the all-strings check, which rejects any array containing an object first, so the identity branch was UNREACHABLE -- its comment claimed the probe answers true on this fixture Environment[], which was true of the jq expression and false of the helper. Measured before/after: BEFORE reported "elements are object, not all plain strings", AFTER reports the identity message. That guard is the arm own premise, so it is not a nit. POSITIVE: the gate PAIRED the unkeyed Command array and persisted the expression. NEGATIVE CONTROL: it REFUSED the indistinguishable twin. destroy 2 deleted / 0 errors, 0 orphans, 0 surviving state object versions
-secrets-dynamic-ref	2026-09-08T16:42:41Z	PASS	550	verify.sh	issue #2516 lane, FINAL tree (main at c3f2330c, incl. #2777 #2807 #2812) after a dependency refresh the stale worktree needed; 0 errors, 0 orphans, 0 surviving state versions
+secrets-dynamic-ref	2026-09-09T04:13:00Z	PASS	466	verify.sh	maintainer merge-gate run for PR 2753 (issue #2516) from the reviewing worktree: Guard 3c expressions in properties/observedProperties/outputs, clean destroy, 0 orphans, 0 surviving state versions
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 secretsmanager-update-value-source	2026-09-04T00:49:00Z	PASS	70	verify.sh	rc ok, orph clean, versions swept (maintainer merge-gate rerun of PR 2476)
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean


### PR DESCRIPTION
Closes #2840

## What

A contributor pushes MID-round routinely — to bank work before a rebase, to
start CI on a partial change, after a fix they know is not the whole round.
Nothing distinguishes those from the push that finishes a round, so a push does
not mean "your turn". Their reply does.

Opening a review round on a push instead cost, on go-to-k/cdkd#2753: a round-4
review against `f4ac65c9` posted at 02:49:18Z when the author had pushed
`76b63b44` at 02:48:11Z, a follow-up at 02:50:28Z repeating the two open
requests, and the author's reply at 02:51:07Z answering round 3 — three
comments in 109 seconds, one of them redundant. go-to-k/cdkd#2840 measured the
wider shape across the author's 15 PRs here: 7 adjacent opposite-author comment
pairs under 5 minutes, the tightest 39 s.

`review-pr` gains a **step 0**: before opening a round on a head you have not
reviewed, decide from WHOSE TURN IT IS. Compare the newest thing you said
against the newest thing the author said; if you spoke last, wait. Bounded at
~30 minutes — measured, not picked: 41 of 43 replies on this contributor's PRs
landed inside it. Skipped for your own PR, for an explicit review request, and
when you have never commented (there is no round for the push to complete).
When you do open a round, name the head sha you reviewed — that is what lets a
crossed reply be recognised as crossed instead of re-litigated.

## Review round: the first cut used push timestamps and was wrong three ways

All three skipped the wait SILENTLY, in the unsafe direction, and none errored:

- an empty `$PUSH` made jq's `.created_at > ""` true for **every comment ever
  written**, which reads as "they replied";
- a `committed` timeline event carries the **commit** date, not the push time —
  and that is the ordinary non-force-push shape, so this was the common case,
  not an exotic one. Comments written before the actual push counted as
  answers;
- the snippet emitted only a count, so a session arriving hours later read `0`,
  followed the inline `# 0 = … Wait`, and waited long after the fallback had
  expired.

Push timestamps are dropped entirely. The replacement reads all three comment
surfaces — issue comments, review **bodies**, and review-thread replies; the
last two are what a contributor writes from "Files changed", GitHub's default,
and `issues/<N>/comments` never shows them.

Also from that round: the comparison operator is spelled out, because
`[ "$A" > "$B" ]` is undefined for strings and zsh rejects it outright
(`condition expected: >`, measured); each skip condition names a command rather
than asking for a judgement; the residual is stated (a reply followed by
another push reads as "their turn ended", so that push is reviewed at once —
the pre-rule behaviour, and the safe direction); and step 6's re-entry now says
**"from step 0"**, without which the rule was inert on the very case it was
written for, since go-to-k/cdkd#2753's crossing happened on a fix-round
re-review.

## Why the rule is reviewer-side

go-to-k/cdkd#2840 proposed two contributor-side signals and both are refused,
with the reasoning kept in the skill so it is not re-proposed:

- **draft-while-responding** — nothing enforces it. There is no
  branch-protection rule for it, and no workflow here keys off `draft` /
  `ready_for_review` (measured: 0 matches across 10 workflow files), so it can
  only ever be opt-in and does nothing for contributors who do not adopt it.
- **a `review ok` label** — needs triage permission a fork contributor does not
  have. Measured on go-to-k/cdkd#2809: `gh issue edit --add-label` returned
  403, "Must have admin rights to Repository", and I applied that label by
  hand, which inverts who does the work.

Both also fail SILENTLY: forget the ritual and the PR is simply not reviewed,
with nothing telling the contributor why. The reviewer-side rule requires
nothing of them, is not opt-in, and applies to every contributor uniformly.

## Also in this PR

The two merge-gate integ rows for go-to-k/cdkd#2753, which had nowhere to be
committed on a fork branch — `secrets-dynamic-ref` (466 s) and `lambda` (82 s),
both run from the reviewing worktree, both clean: 0 errors, 0 orphans, 0
surviving state versions.

## Tests

No `src/` change. `skill-file-payload.test.ts` and `verification-depth-rule.test.ts`
cover the edited file (40 cases, green). Full suite 953 files / 20,701 tests
green; typecheck, `typecheck:test`, lint, format and build clean;
`gen:all-matrices` + `audit:coverage:check` left the tree clean.

## Live test

The probe is executable, so it was executed rather than reasoned about: every
branch was run against live PRs before commit — `their-turn / wait` on
go-to-k/cdkd#2753, `own PR: skip` on this PR and on go-to-k/cdkd#2838, and the
empty-`MINE` arm on a PR with no prior round. The surrounding rule is a session
instruction whose real live test is the next review round this repo runs.
