### PR TITLE
docs(rules): document the aws-cdk-lib floor fence where its six siblings live

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -510,6 +510,45 @@ Enforced by `tests/unit/scripts/integ-fixture-removal-policy.test.ts`
 (classifier: `scripts/check-fixture-removal-policy.ts`); user-facing writeup in
 [docs/integ-fixture-conventions.md](../../docs/integ-fixture-conventions.md).
 
+### The `/new-integ` scaffold's `aws-cdk-lib` floor may not fall behind the corpus (mandatory)
+
+The scaffold template in `.claude/skills/new-integ/SKILL.md` emits an
+`aws-cdk-lib` floor into every fixture `package.json` it creates. It was pinned
+at `^2.169.0` while dependabot moved individual fixtures forward around it, and
+the result was FOUR floors across 292 fixtures (`^2.169.0` ×172, `^2.172.0` ×91,
+`^2.176.0` ×15, `^2.257.0` ×6) — cleaned up in issue
+[#2838](https://github.com/go-to-k/cdkd/pull/2838), fenced by issue
+[#2839](https://github.com/go-to-k/cdkd/issues/2839).
+
+The rule is **template floor >= the LOWEST floor in the corpus**, and the
+non-obvious half is why it is not "all floors are equal". Dependabot bumps
+`aws-cdk-lib` **one directory at a time** (go-to-k/cdkd#2487 / #2488 / #2834 are
+each a single fixture), so the corpus is legitimately non-uniform between such
+merges and an equality fence would red-flag every one of those PRs — and a fence
+that fires on correct, routine, bot-authored changes gets disabled, not obeyed.
+So the subject is the GENERATOR: the corpus may spread, the template may not
+fall behind the back of it. The cost is deliberate and stated — a fixture
+hand-authored with an old floor lowers the minimum and the template still
+passes.
+
+Every unreadable input is a REFUSAL, never a skip: a template floor that fails
+to extract (which would make the checker permanently, silently green), a
+manifest that does not parse, a spec with no decidable floor (`*` / `latest` /
+`>=X` / an `||` union), and a malformed dependency bucket. Skipping any of them
+drops a fixture out of the minimum, which can only LOOSEN the verdict. Only
+`dependencies` and `devDependencies` are the population — a fixture is an app,
+not a library, so `peerDependencies` is deliberately not consulted.
+
+Enforced by `tests/unit/scripts/integ-cdk-lib-floor.test.ts` (classifier:
+`scripts/check-integ-cdk-lib-floor.ts`), which IS the CI enforcement: no
+`vp run` task and no `ci.yml` step, the shape
+`check-verification-depth-rule.ts` and `check-source-control-bytes.ts` use. Its
+probes build a **non-uniform** corpus on purpose — the real one is uniform
+today, so min-selection, dedup and ordering are unobservable through it, and a
+`sorted[0]` → last-element mutant stayed green until they existed (the
+"fixture pins the value under test" trap, one layer up from
+[docs/integ-fixture-conventions.md](../../docs/integ-fixture-conventions.md)).
+
 ### A `local-*` fixture's Lambdas must declare the HOST architecture (mandatory)
 
 cdk-local pins `docker --platform` to each Lambda's declared `Architectures` —

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -515,8 +515,9 @@ Enforced by `tests/unit/scripts/integ-fixture-removal-policy.test.ts`
 The scaffold template in `.claude/skills/new-integ/SKILL.md` emits an
 `aws-cdk-lib` floor into every fixture `package.json` it creates. It was pinned
 at `^2.169.0` while dependabot moved individual fixtures forward around it, and
-the result was FOUR floors across 292 fixtures (`^2.169.0` ×172, `^2.172.0` ×91,
-`^2.176.0` ×15, `^2.257.0` ×6) — cleaned up in issue
+the result was FIVE floors across 292 fixtures (`^2.169.0` ×178, `^2.172.0` ×91,
+`^2.176.0` ×15, `^2.257.0` ×6, `^2.260.0` ×2 — measured at `81a305d8`, the
+parent of the cleanup) — cleaned up in PR
 [#2838](https://github.com/go-to-k/cdkd/pull/2838), fenced by issue
 [#2839](https://github.com/go-to-k/cdkd/issues/2839).
 
@@ -542,7 +543,10 @@ not a library, so `peerDependencies` is deliberately not consulted.
 Enforced by `tests/unit/scripts/integ-cdk-lib-floor.test.ts` (classifier:
 `scripts/check-integ-cdk-lib-floor.ts`), which IS the CI enforcement: no
 `vp run` task and no `ci.yml` step, the shape
-`check-verification-depth-rule.ts` and `check-source-control-bytes.ts` use. Its
+`check-verification-depth-rule.ts` and `check-source-control-bytes.ts` use.
+(Those two are indexed in [layout-scripts.md](layout-scripts.md), not here —
+the SHAPE is shared, the home is decided by the subject, and this one's subject
+is `tests/integration/**`.) Its
 probes build a **non-uniform** corpus on purpose — the real one is uniform
 today, so min-selection, dedup and ordering are unobservable through it, and a
 `sorted[0]` → last-element mutant stayed green until they existed (the

--- a/.claude/skills/new-integ/SKILL.md
+++ b/.claude/skills/new-integ/SKILL.md
@@ -67,6 +67,15 @@ The user provides a kebab-case test name (e.g., `ses-email-identity`,
    }
    ```
 
+   The `aws-cdk-lib` floor above is FENCED: it may not sit below the lowest
+   floor in `tests/integration/*/package.json`, or
+   `tests/unit/scripts/integ-cdk-lib-floor.test.ts` reds CI (issue
+   [#2839](https://github.com/go-to-k/cdkd/issues/2839)). Raising it is always
+   safe; lowering it, or letting it stay put while the corpus moves past it, is
+   what re-creates the drift this template caused. The rule and why it is not
+   an equality fence are in
+   [.claude/rules/testing.md](../../rules/testing.md).
+
    **`tsconfig.json`** (ESNext / NodeNext, with `rewriteRelativeImportExtensions`
    so the `.ts`-suffixed relative imports type-check):
    ```json

--- a/scripts/check-integ-cdk-lib-floor.ts
+++ b/scripts/check-integ-cdk-lib-floor.ts
@@ -10,8 +10,10 @@
  *
  * WHY THAT RULE AND NOT "ALL FLOORS ARE EQUAL"
  *
- * Before go-to-k/cdkd#2838 the 292 fixtures carried FOUR different floors
- * (`^2.169.0` x172, `^2.172.0` x91, `^2.176.0` x15, `^2.257.0` x6). The
+ * Before go-to-k/cdkd#2838 the 292 fixtures carried FIVE different floors
+ * (`^2.169.0` x178, `^2.172.0` x91, `^2.176.0` x15, `^2.257.0` x6,
+ * `^2.260.0` x2 -- measured at 81a305d8, the parent of the cleanup; the
+ * original note said "four ... x172", whose parts summed to 284 not 292). The
  * systematic source was this template: it emitted a hardcoded `^2.169.0` for
  * every fixture ever scaffolded, while dependabot moved individual fixtures
  * forward around it.

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -633,7 +633,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 51_000, 56_000],                            // measured  52,148 on 2026-09-06 (floor 48,000 -> 51,000 across the #2621 lane, exactly as this file's GUTTED-satellite case prescribes)
+  ['tests/setup.ts', 54_000, 56_000],                            // measured  54,624 on 2026-09-09 (floor 51,000 -> 54,000 by go-to-k/cdkd#2839's testing.md entry, the third time the GUTTED-satellite case below has prescribed this re-derivation: 46,000 -> 48,000 -> 51,000 -> 54,000)
   // 46_000 -> 48_000 on 2026-09-05: the go-to-k/cdkd#2595 retro added 1,126 B of
   // mutation-probe rules to `testing.md`, and the discriminate case below went
   // red exactly as its comment predicts ("testing.md growing spends it from the


### PR DESCRIPTION
## Summary

Documents `scripts/check-integ-cdk-lib-floor.ts` (shipped in go-to-k/cdkd#2845)
in `.claude/rules/testing.md`, beside the six sibling integ checkers already
documented there.

## The issue's premise was wrong, and measuring it is what showed that

go-to-k/cdkd#2844 was filed to unblock this entry by splitting
`.claude/rules/layout-scripts.md`, which sits **351 bytes** under its 80,000 B
cap. Measured on `main` at `f00ba284`:

- `layout-scripts.md` indexes **0 of the 9** `scripts/check-integ-*.ts`
  checkers. The whole family was never in that index.
- `testing.md` documents them instead — 6 by script path, the other two by
  their test — each beside the convention it enforces. That is coherent: their
  *subject* is `tests/integration/**`, and `testing.md` globs `tests/**`.

So the new checker is the 9th member of an existing family whose home is
`testing.md`, not a checker blocked out of `layout-scripts.md`. `testing.md`
had 31,272 B of headroom; **no split was needed**, and none is done here.

`layout-scripts.md`'s 351 B is still real, but it blocks the family it *does*
index — the codegen'd coverage matrices and the standalone critics. That is
what go-to-k/cdkd#2844 has been corrected and re-classified to (`next` / low,
with the measured seam recorded), so it gets picked up when someone adds a
generator or a standalone critic.

## A factual error, caught and corrected in two places

The first draft of the entry claimed "FOUR floors across 292 fixtures
(`^2.169.0` ×172, …)". Those parts sum to **284**, not 292 — the internal tell.
Re-measured at `81a305d8`, the parent of go-to-k/cdkd#2838's merge:

```
178 ^2.169.0   91 ^2.172.0   15 ^2.176.0   6 ^2.257.0   2 ^2.260.0   = 292
```

**FIVE** floors, and 178 not 172. The two `^2.260.0` fixtures are the ones
dependabot had already bumped (go-to-k/cdkd#2488, go-to-k/cdkd#2834) — precisely the
non-uniformity the fence exists to tolerate, so omitting them undercut the
paragraph's own argument.

The same wrong census had already merged into
`scripts/check-integ-cdk-lib-floor.ts`'s header via go-to-k/cdkd#2845, and the
rule file had faithfully copied it. Both are corrected here, and both now name
the commit the census was measured at so the next reader can re-derive it.

## The entry

It records the non-obvious half of the rule rather than restating the code:
why it is **template >= corpus MINIMUM** and not an equality fence (dependabot
bumps one directory at a time, so equality would red-flag every one of its PRs,
and a fence that fires on correct, routine, bot-authored changes gets disabled
rather than obeyed); the refusal-not-skip discipline and *why* each skip would
loosen the verdict; the deliberate `dependencies`/`devDependencies`-only
population; and why the probes build a **non-uniform** corpus — the real one is
uniform today, so min-selection, dedup and ordering are unobservable through it.

It also notes that the two scripts it names as precedent
(`check-verification-depth-rule.ts`, `check-source-control-bytes.ts`) are
indexed in `layout-scripts.md`, not here: the *shape* is shared across both
homes, and the *subject* decides which one.

## The payload floor is re-derived, as the fence itself prescribes

The addition spends the GUTTED-satellite band that
`tests/unit/scripts/rule-file-payload.test.ts` maintains: it took the
`tests/setup.ts` payload minus `test-stream-fence.md` to 51,204 B, above the
51,000 B floor, so the floor stopped discriminating a satellite gutted to
`SUBSTANTIVE_MIN_BYTES`. That case's own comment calls this "the prescribed
move — not slack to be debugged away, and not a reason to shrink the addition".

Re-derived **51,000 → 54,000**, the third time that case has called for it
(46,000 → 48,000 → 51,000 → 54,000). The constraint is
`withoutSatellite + SUBSTANTIVE_MIN_BYTES < floor <= live`, i.e.
(52,704, 54,624]; 54,000 keeps 1,296 B of growth room and 624 B of shrink
margin, and `live` stays under the unchanged 56,000 cap.

## Test plan

- `vp run check` — 0 errors. `vp run typecheck:test` — pass. `vp run build` — pass.
- `vp test run` — **954 files / 20780 tests passed**, 1 skipped, no type errors.
- `rule-file-payload.test.ts` — 306 cases green, including the GUTTED-satellite
  case that caught this, and every dead-glob / index-reachability assertion.
- `node scripts/check-integ-cdk-lib-floor.ts` — still `292/292 fixtures, 1
  distinct` against the real tree.
- No leftover AWS resources (0 `state.json` under the state bucket) and no
  `cdkd-local-` containers or networks.
- No `src/**` touched: no changelog entry (per the CLAUDE.md policy and
  go-to-k/cdkd#2779).

Also in this PR: `.claude/skills/new-integ/SKILL.md` gains a note beside its
template saying the floor is fenced — raising it is always safe, lowering it
(or letting it stay put while the corpus moves past it) reds CI. The template
had no idea it was under a fence.
