### PR TITLE
test(changelog): conserve the archive as a subsequence, so a fragment dated inside its span stops failing

### DIFF
--- a/scripts/assemble-changelog.ts
+++ b/scripts/assemble-changelog.ts
@@ -81,7 +81,13 @@ export function headingFor(date: string): string {
   return `**Recently Implemented** (${date}):`;
 }
 
-const HEADING = /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})[^)]*\):$/;
+/**
+ * EXPORTED so a consumer cannot carry a looser copy: a pattern that matches a
+ * line this one rejects sees a section the assembler does not, and any count
+ * derived from it disagrees with the document. Both forms return 51 on today's
+ * archive, so the drift would be silent (go-to-k/cdkd#2813 review).
+ */
+export const HEADING = /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})[^)]*\):$/;
 
 /**
  * "This line was MEANT to be a heading", looser than {@link HEADING} on the

--- a/tests/unit/scripts/assemble-changelog.test.ts
+++ b/tests/unit/scripts/assemble-changelog.test.ts
@@ -112,7 +112,8 @@ function assertEveryHeadingOpensItsBlock(d: string): void {
  * whole point (issue go-to-k/cdkd#2813). The assembler SPLICES: a fragment
  * whose date the archive already heads lands under that heading, and one dated
  * between two archived sections opens a new section in descending position --
- * both documented in `changelog.d/_header.md` and both the reason the
+ * the first documented in `changelog.d/_header.md` under "WHERE an entry goes",
+ * the second in `assemble-changelog.ts` itself, and both the reason the
  * go-to-k/cdkd#1837 duplicate-heading class is structurally impossible. Either
  * one puts new text INSIDE the archive's span, so the archive stops being a
  * contiguous substring while nothing about settled history has changed.
@@ -139,9 +140,26 @@ function assertEveryHeadingOpensItsBlock(d: string): void {
  *
  * Blank lines are compared like any other, so the seam blank the assembler may
  * INSERT before a heading is absorbed (an insertion is what a subsequence
- * tolerates) while one it DELETED would still be caught.
+ * tolerates). A DELETED one is caught for THIS archive, whose body bullets are
+ * unique, but not in general: a deleted line re-syncs against a later duplicate
+ * of itself, and `assertArchiveConserved(['a','b','','b'], ['a','','b'])`
+ * passes. The corpus is what makes the stronger reading true here, not the
+ * check.
+ *
+ * ## The insertion budget is part of the assertion, not a separate nicety
+ *
+ * Presence and order alone place NO bound on how much text lands BETWEEN
+ * archived lines, and accepting insertions is inherent to any subsequence form
+ * -- the splice IS an insertion. What the splice needs is a BOUNDED,
+ * ATTRIBUTABLE insertion. Measured on the real tree while reviewing this
+ * change: a blank line after every archived bullet (575 inserted lines) and
+ * arbitrary foreign text spliced into the middle of the archive were both
+ * ACCEPTED by presence-and-order, and both had been rejected by
+ * `doc.includes(archive)`. That is a real gap in the insertion class, and the
+ * `budget` closes it: the caller states how many lines it expects the assembler
+ * to add, so a splice passes and a reformat that pads settled history does not.
  */
-function assertArchiveConserved(doc: string, archive: string): void {
+function assertArchiveConserved(doc: string, archive: string, budget?: number): void {
   const want = archive.split('\n');
   const have = doc.split('\n');
   let i = 0;
@@ -149,8 +167,15 @@ function assertArchiveConserved(doc: string, archive: string): void {
   expect(
     i,
     `the archive is no longer reproduced in full -- the assembler is reformatting settled history. ` +
-      `First archived line not found in order (${i} of ${want.length}): ${JSON.stringify(want[i] ?? '')}`
+      `First archived line not found in order (${i + 1} of ${want.length}): ${JSON.stringify(want[i] ?? '')}`
   ).toBe(want.length);
+  if (budget !== undefined) {
+    expect(
+      have.length - want.length,
+      `the assembler inserted more than the ${budget} line(s) this assembly can account for -- ` +
+        `presence and order alone do not bound how much text lands between archived lines`
+    ).toBeLessThanOrEqual(budget);
+  }
 }
 
 
@@ -413,6 +438,16 @@ describe('assemble-changelog', () => {
       '- archived entry B',
     ].join('\n');
 
+    /**
+     * What ONE probe fragment may add to this fixture: the `# header` line and
+     * the blank after it, the probe's own bullet, at most one generated heading
+     * when the date opens a new section, and at most two seam blanks around it,
+     * plus the trailing newline. Stated as a number the caller can defend
+     * rather than a measured constant, so it fails if the assembler starts
+     * padding settled history.
+     */
+    const WIDE_BUDGET = 7;
+
     for (const [date, where] of [
       ['2026-09-09', 'newer than the newest archived section'],
       ['2026-09-08', 'the newest archived section itself'],
@@ -424,10 +459,23 @@ describe('assemble-changelog', () => {
         const doc = withTree(WIDE, { [`${date}-2813-probe.md`]: '- probe entry' }, (root) =>
           assembleChangelog(root)
         );
-        assertArchiveConserved(doc, WIDE);
+        // header line + the blank after it + the probe + at most a new heading
+        // and the seam blanks around it + the trailing newline.
+        assertArchiveConserved(doc, WIDE, WIDE_BUDGET);
         // Not vacuous: the fragment really did land, exactly once. Conservation
         // alone is satisfied by an assembler that dropped the fragment.
         expect(doc.split('- probe entry').length - 1, 'the fragment did not land exactly once').toBe(1);
+        // WHERE it landed, not merely that it did. Every other assertion in
+        // this arm passes if the assembler merges the 2026-09-05 probe into the
+        // 2026-09-08 body instead of opening its own section -- which is the
+        // defect `assemble-changelog.ts` records review catching once, where a
+        // fragment at the archive's SECOND heading yielded 09-07 / 09-08 /
+        // 09-07. This line is what would catch it coming back.
+        const lines = doc.split('\n');
+        expect(
+          lines[lines.indexOf(headingFor(date)) + 1],
+          'the fragment did not land directly under its own dated heading'
+        ).toBe('- probe entry');
         const h = headings(doc);
         expect(new Set(h).size, 'a date heading is duplicated').toBe(h.length);
         const dates = h.map((x) => /\((\d{4}-\d{2}-\d{2})/.exec(x)![1]!);
@@ -437,6 +485,56 @@ describe('assemble-changelog', () => {
         assertEveryHeadingOpensItsBlock(doc);
       });
     }
+
+    /**
+     * The one legitimate VARIANT heading in the real archive --
+     * `**Recently Implemented** (2026-07-02, second batch):`, a day
+     * deliberately split in two, which `headingFor` cannot reproduce and which
+     * `splitSections` keeps verbatim. This PR is what first makes a fragment
+     * dated 2026-07-02 legal at all, so nothing had exercised the pairing.
+     */
+    it('merges into a VARIANT heading and keeps it verbatim', () => {
+      const VARIANT = '**Recently Implemented** (2026-07-02, second batch):';
+      const archive = [VARIANT, '- archived entry V', '', headingFor('2026-07-01'), '- archived entry W'].join('\n');
+      const doc = withTree(archive, { '2026-07-02-2813-probe.md': '- probe entry' }, (root) =>
+        assembleChangelog(root)
+      );
+      assertArchiveConserved(doc, archive, WIDE_BUDGET);
+      const lines = doc.split('\n');
+      expect(lines.indexOf(VARIANT), 'the variant heading was rewritten rather than kept').toBeGreaterThan(-1);
+      expect(
+        lines[lines.indexOf(VARIANT) + 1],
+        'the fragment did not merge under the variant heading it shares a date with'
+      ).toBe('- probe entry');
+      expect(
+        headings(doc).filter((x) => x.includes('2026-07-02')),
+        'the variant heading was duplicated by a generated one'
+      ).toEqual([VARIANT]);
+    });
+
+    it('places TWO fragments in one run, one merging and one opening a section', () => {
+      const doc = withTree(
+        WIDE,
+        { '2026-09-08-2813-merge.md': '- merged entry', '2026-09-05-2813-fresh.md': '- fresh entry' },
+        (root) => assembleChangelog(root)
+      );
+      // Two probes, so two bullets plus the one new heading and its seams.
+      assertArchiveConserved(doc, WIDE, WIDE_BUDGET + 1);
+      const lines = doc.split('\n');
+      expect(lines[lines.indexOf(headingFor('2026-09-08')) + 1], 'the same-date fragment did not merge').toBe(
+        '- merged entry'
+      );
+      expect(lines[lines.indexOf(headingFor('2026-09-05')) + 1], 'the in-span fragment did not open a section').toBe(
+        '- fresh entry'
+      );
+      const dates = headings(doc).map((x) => /\((\d{4}-\d{2}-\d{2})/.exec(x)![1]!);
+      expect(dates, 'the two fragments did not leave the document newest-first').toEqual([
+        '2026-09-08',
+        '2026-09-05',
+        '2026-09-01',
+      ]);
+      assertEveryHeadingOpensItsBlock(doc);
+    });
   });
 
   /**
@@ -478,6 +576,25 @@ describe('assemble-changelog', () => {
         /no longer reproduced in full/
       );
     });
+
+    /**
+     * The budget arm. Presence and order accept ANY amount of inserted text --
+     * measured in review as 575 blank lines and as arbitrary foreign text
+     * spliced mid-archive, both of which `doc.includes(archive)` had rejected.
+     * These two pin that the count now refuses them while still passing the
+     * splice it exists to allow.
+     */
+    it('accepts a splice INSIDE its budget', () => {
+      expect(() => assertArchiveConserved(spliced, A, 1)).not.toThrow();
+    });
+
+    it('rejects padding that conserves every archived line but reformats around them', () => {
+      const padded = ['x', '', '- one', '', '- two', '', '', 'y'].join('\n');
+      // Every archived line is present and in order -- the subsequence arm
+      // passes on its own, which is the gap the budget closes.
+      expect(() => assertArchiveConserved(padded, A)).not.toThrow();
+      expect(() => assertArchiveConserved(padded, A, 1)).toThrow(/inserted more than the 1 line/);
+    });
   });
 
   it('assembles the REPO tree, and that tree is the shape the fences read', () => {
@@ -499,7 +616,34 @@ describe('assemble-changelog', () => {
     // and both live seam defects on this branch were found against the real
     // archive, not a fixture.
     const archive = readFileSync(join(root, FRAGMENT_DIR, ARCHIVE_FILE), 'utf-8').replace(/\s+$/, '');
-    assertArchiveConserved(doc, archive);
+    // The insertion budget, derived rather than measured-and-pinned: the header
+    // and the blank after it, every fragment's own lines, one generated heading
+    // per fragment date the archive does not already head, at most one seam
+    // blank per emitted heading, and the trailing newline.
+    //
+    // Residual, stated because the count alone does not establish it: an
+    // insertion SMALLER than the seam allowance is inside the budget, so the
+    // delta bounds a bulk reformat (the 575-blank padding measured in review is
+    // far outside it) without bounding a few foreign lines. Attributing every
+    // unconsumed line rather than counting it is the stronger form; this is the
+    // one the review asked for and it closes the class that was measured open.
+    const headerLines = readFileSync(join(root, FRAGMENT_DIR, HEADER_FILE), 'utf-8').replace(/\s+$/, '').split('\n')
+      .length;
+    const archiveDates = new Set(
+      archive
+        .split('\n')
+        .map((l) => /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})/.exec(l)?.[1])
+        .filter((d): d is string => d !== undefined)
+    );
+    const fragments = readEntries(root);
+    const fragmentLines = fragments.reduce((n, e) => n + e.text.split('\n').length, 0);
+    const newHeadings = new Set(fragments.map((e) => e.date).filter((d) => !archiveDates.has(d))).size;
+    const emittedHeadings = archiveDates.size + newHeadings;
+    assertArchiveConserved(
+      doc,
+      archive,
+      headerLines + 1 + fragmentLines + newHeadings + emittedHeadings + 1
+    );
     assertEveryHeadingOpensItsBlock(doc);
     const onDisk = readdirSync(join(root, FRAGMENT_DIR, ENTRIES_DIR)).filter((n) => n !== '.gitkeep');
     expect(readEntries(root).length, 'a fragment on disk was not read into the assembly').toBe(onDisk.length);

--- a/tests/unit/scripts/assemble-changelog.test.ts
+++ b/tests/unit/scripts/assemble-changelog.test.ts
@@ -135,8 +135,10 @@ function assertEveryHeadingOpensItsBlock(d: string): void {
  * time with the tree restored between: dropping one body line per section
  * (`s.body.slice(1)`) failed at archived line 1, collapsing runs of spaces in
  * every body line failed at line 28, and swapping two body lines failed at
- * line 3. The substring form rejects those three too -- it is not weaker
- * against a real reformat, only wrong about a splice.
+ * line 3. The substring form rejects those three too. It ALSO rejected an
+ * arbitrary insertion, which presence and order do not -- the budget below is
+ * what covers that class, and the sentence here used to claim the whole
+ * comparison rather than these three.
  *
  * Blank lines are compared like any other, so the seam blank the assembler may
  * INSERT before a heading is absorbed (an insertion is what a subsequence
@@ -629,16 +631,18 @@ describe('assemble-changelog', () => {
     // one the review asked for and it closes the class that was measured open.
     const headerLines = readFileSync(join(root, FRAGMENT_DIR, HEADER_FILE), 'utf-8').replace(/\s+$/, '').split('\n')
       .length;
-    const archiveDates = new Set(
-      archive
-        .split('\n')
-        .map((l) => /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})/.exec(l)?.[1])
-        .filter((d): d is string => d !== undefined)
-    );
+    const archiveHeadingLines = archive
+      .split('\n')
+      .map((l) => /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})/.exec(l)?.[1])
+      .filter((d): d is string => d !== undefined);
+    const archiveDates = new Set(archiveHeadingLines);
     const fragments = readEntries(root);
     const fragmentLines = fragments.reduce((n, e) => n + e.text.split('\n').length, 0);
     const newHeadings = new Set(fragments.map((e) => e.date).filter((d) => !archiveDates.has(d))).size;
-    const emittedHeadings = archiveDates.size + newHeadings;
+    // Heading LINES, not distinct dates: the seam is emitted per heading, and
+    // 2026-07-02 has two of them (the variant `(2026-07-02, second batch):`),
+    // so the two counts differ by one on this archive -- 51 against 50.
+    const emittedHeadings = archiveHeadingLines.length + newHeadings;
     assertArchiveConserved(
       doc,
       archive,

--- a/tests/unit/scripts/assemble-changelog.test.ts
+++ b/tests/unit/scripts/assemble-changelog.test.ts
@@ -9,6 +9,7 @@ import {
   ENTRIES_DIR,
   FRAGMENT_DIR,
   HEADER_FILE,
+  HEADING,
   assembleChangelog,
   byNewest,
   headingFor,
@@ -144,8 +145,9 @@ function assertEveryHeadingOpensItsBlock(d: string): void {
  * INSERT before a heading is absorbed (an insertion is what a subsequence
  * tolerates). A DELETED one is caught for THIS archive, whose body bullets are
  * unique, but not in general: a deleted line re-syncs against a later duplicate
- * of itself, and `assertArchiveConserved(['a','b','','b'], ['a','','b'])`
- * passes. The corpus is what makes the stronger reading true here, not the
+ * of itself, and
+ * `assertArchiveConserved(['a','b','','b'].join('\n'), ['a','','b'].join('\n'))`
+ * passes -- the joins are load-bearing, since both parameters are strings. The corpus is what makes the stronger reading true here, not the
  * check.
  *
  * ## The insertion budget is part of the assertion, not a separate nicety
@@ -441,14 +443,17 @@ describe('assemble-changelog', () => {
     ].join('\n');
 
     /**
-     * What ONE probe fragment may add to this fixture: the `# header` line and
-     * the blank after it, the probe's own bullet, at most one generated heading
-     * when the date opens a new section, and at most two seam blanks around it,
-     * plus the trailing newline. Stated as a number the caller can defend
-     * rather than a measured constant, so it fails if the assembler starts
-     * padding settled history.
+     * What ONE probe fragment may add to a TWO-SECTION fixture: the `# header`
+     * line and the blank after it, the probe's own bullet, at most one
+     * generated heading when the date opens a new section, at most two seam
+     * blanks around it, and the trailing newline.
+     *
+     * Named for its shape rather than for `WIDE`, because the variant-heading
+     * arm below applies it to a different two-section archive; tying the number
+     * to one fixture would let widening that fixture loosen the other case
+     * silently.
      */
-    const WIDE_BUDGET = 7;
+    const TWO_SECTION_BUDGET = 7;
 
     for (const [date, where] of [
       ['2026-09-09', 'newer than the newest archived section'],
@@ -461,9 +466,7 @@ describe('assemble-changelog', () => {
         const doc = withTree(WIDE, { [`${date}-2813-probe.md`]: '- probe entry' }, (root) =>
           assembleChangelog(root)
         );
-        // header line + the blank after it + the probe + at most a new heading
-        // and the seam blanks around it + the trailing newline.
-        assertArchiveConserved(doc, WIDE, WIDE_BUDGET);
+        assertArchiveConserved(doc, WIDE, TWO_SECTION_BUDGET);
         // Not vacuous: the fragment really did land, exactly once. Conservation
         // alone is satisfied by an assembler that dropped the fragment.
         expect(doc.split('- probe entry').length - 1, 'the fragment did not land exactly once').toBe(1);
@@ -501,9 +504,10 @@ describe('assemble-changelog', () => {
       const doc = withTree(archive, { '2026-07-02-2813-probe.md': '- probe entry' }, (root) =>
         assembleChangelog(root)
       );
-      assertArchiveConserved(doc, archive, WIDE_BUDGET);
+      assertArchiveConserved(doc, archive, TWO_SECTION_BUDGET);
+      // No presence assertion here: `assertArchiveConserved` above already
+      // requires VARIANT present and in order, so one could not fail.
       const lines = doc.split('\n');
-      expect(lines.indexOf(VARIANT), 'the variant heading was rewritten rather than kept').toBeGreaterThan(-1);
       expect(
         lines[lines.indexOf(VARIANT) + 1],
         'the fragment did not merge under the variant heading it shares a date with'
@@ -521,7 +525,7 @@ describe('assemble-changelog', () => {
         (root) => assembleChangelog(root)
       );
       // Two probes, so two bullets plus the one new heading and its seams.
-      assertArchiveConserved(doc, WIDE, WIDE_BUDGET + 1);
+      assertArchiveConserved(doc, WIDE, TWO_SECTION_BUDGET + 1);
       const lines = doc.split('\n');
       expect(lines[lines.indexOf(headingFor('2026-09-08')) + 1], 'the same-date fragment did not merge').toBe(
         '- merged entry'
@@ -607,9 +611,10 @@ describe('assemble-changelog', () => {
     const doc = assembleChangelog(root);
     // Read count == file count, so a `readEntries` that silently returned
     // nothing fails HERE rather than leaving every verdict above green over an
-    // empty set. It is 0 today and that is the honest state: the archive holds
-    // every pre-migration entry and no fragment has been written yet, so this
-    // assertion is a TRIPWIRE for the first one rather than coverage now.
+    // empty set. It was 0 when this was written -- the archive held every
+    // pre-migration entry and no fragment existed -- and `changelog.d/entries/`
+    // has since been populated, which the budget's `fragmentLines` term now
+    // reads, so it is live coverage rather than the tripwire it started as.
     // Both claims this migration rests on, asserted rather than measured once
     // by hand. (1) The ARCHIVE comes out verbatim -- the whole reason it is one
     // file and not 574 is that settled history must not be reformatted, and
@@ -618,36 +623,58 @@ describe('assemble-changelog', () => {
     // and both live seam defects on this branch were found against the real
     // archive, not a fixture.
     const archive = readFileSync(join(root, FRAGMENT_DIR, ARCHIVE_FILE), 'utf-8').replace(/\s+$/, '');
-    // The insertion budget, derived rather than measured-and-pinned: the header
-    // and the blank after it, every fragment's own lines, one generated heading
-    // per fragment date the archive does not already head, at most one seam
-    // blank per emitted heading, and the trailing newline.
+    // The insertion budget, DERIVED from what the assembler can emit rather than
+    // allowed generously: the header and the blank after it, every fragment's
+    // own lines, one generated heading per fragment date the archive does not
+    // already head, the seams, and the trailing newline.
+    //
+    // The seam term is derived too, and that is the point of it. The assembler
+    // inserts a blank before a section only when the line already there is not
+    // one, so a seam is emitted only where the PREVIOUS body ends non-blank --
+    // one section of 51 on this archive, not 51. Budgeting one per heading made
+    // 51 of the 52-line slack the seam term alone, and worse, it grew by one
+    // for every dated section the archive would ever gain: a widening window
+    // for unattributed text inside settled history rather than a constant
+    // (go-to-k/cdkd#2813 review, M1b).
+    //
+    // A merged fragment PREPENDS to a section's body, so it cannot change
+    // whether that body ends blank. A NEW section can, at both of its edges --
+    // one seam before its heading, and one before the heading that follows it
+    // if the fragment text ends non-blank -- hence two per new heading. The
+    // preamble contributes one only when it exists and ends non-blank; it is
+    // empty on this archive, whose first line IS a heading.
     //
     // Residual, stated because the count alone does not establish it: an
-    // insertion SMALLER than the seam allowance is inside the budget, so the
-    // delta bounds a bulk reformat (the 575-blank padding measured in review is
-    // far outside it) without bounding a few foreign lines. Attributing every
-    // unconsumed line rather than counting it is the stronger form; this is the
-    // one the review asked for and it closes the class that was measured open.
+    // insertion smaller than the remaining slack still fits. Attributing every
+    // unconsumed line to the header, a fragment, a heading or a seam is the
+    // stronger form and needs no slack at all; this is the one the review asked
+    // for, and with the seam term derived the slack is 2 lines rather than 51.
     const headerLines = readFileSync(join(root, FRAGMENT_DIR, HEADER_FILE), 'utf-8').replace(/\s+$/, '').split('\n')
       .length;
-    const archiveHeadingLines = archive
-      .split('\n')
-      .map((l) => /^\*\*Recently Implemented\*\* \((\d{4}-\d{2}-\d{2})/.exec(l)?.[1])
-      .filter((d): d is string => d !== undefined);
-    const archiveDates = new Set(archiveHeadingLines);
+    // The assembler's OWN pattern, imported rather than re-spelled: a looser
+    // copy sees a section it does not, and every count below would disagree
+    // with the document while both forms happen to return 51 today.
+    const archiveLines = archive.split('\n');
+    const archiveDates = new Set(
+      archiveLines.map((l) => HEADING.exec(l)?.[1]).filter((d): d is string => d !== undefined)
+    );
+    // Split into sections the way the assembler does, then count the bodies
+    // that end with text -- those are the ones a following heading needs a seam
+    // in front of.
+    const firstHeading = archiveLines.findIndex((l) => HEADING.test(l));
+    const bodies: string[][] = [];
+    for (const line of archiveLines.slice(firstHeading)) {
+      if (HEADING.test(line)) bodies.push([]);
+      else bodies[bodies.length - 1]!.push(line);
+    }
+    const sectionEndsNonBlank = bodies.filter((b) => b.length > 0 && b[b.length - 1]!.trim() !== '').length;
+    const preamble = archiveLines.slice(0, firstHeading);
+    const preambleSeam = preamble.length > 0 && preamble[preamble.length - 1]!.trim() !== '' ? 1 : 0;
     const fragments = readEntries(root);
     const fragmentLines = fragments.reduce((n, e) => n + e.text.split('\n').length, 0);
     const newHeadings = new Set(fragments.map((e) => e.date).filter((d) => !archiveDates.has(d))).size;
-    // Heading LINES, not distinct dates: the seam is emitted per heading, and
-    // 2026-07-02 has two of them (the variant `(2026-07-02, second batch):`),
-    // so the two counts differ by one on this archive -- 51 against 50.
-    const emittedHeadings = archiveHeadingLines.length + newHeadings;
-    assertArchiveConserved(
-      doc,
-      archive,
-      headerLines + 1 + fragmentLines + newHeadings + emittedHeadings + 1
-    );
+    const seams = sectionEndsNonBlank + 2 * newHeadings + preambleSeam;
+    assertArchiveConserved(doc, archive, headerLines + 1 + fragmentLines + newHeadings + seams + 1);
     assertEveryHeadingOpensItsBlock(doc);
     const onDisk = readdirSync(join(root, FRAGMENT_DIR, ENTRIES_DIR)).filter((n) => n !== '.gitkeep');
     expect(readEntries(root).length, 'a fragment on disk was not read into the assembly').toBe(onDisk.length);

--- a/tests/unit/scripts/assemble-changelog.test.ts
+++ b/tests/unit/scripts/assemble-changelog.test.ts
@@ -105,6 +105,55 @@ function assertEveryHeadingOpensItsBlock(d: string): void {
 }
 
 
+/**
+ * The archive's own lines, in order, still in the assembled document.
+ *
+ * A SUBSEQUENCE rather than a contiguous substring, and the difference is the
+ * whole point (issue go-to-k/cdkd#2813). The assembler SPLICES: a fragment
+ * whose date the archive already heads lands under that heading, and one dated
+ * between two archived sections opens a new section in descending position --
+ * both documented in `changelog.d/_header.md` and both the reason the
+ * go-to-k/cdkd#1837 duplicate-heading class is structurally impossible. Either
+ * one puts new text INSIDE the archive's span, so the archive stops being a
+ * contiguous substring while nothing about settled history has changed.
+ *
+ * The substring form therefore refused a CORRECT assembly: it made every date
+ * from the archive's oldest section through its newest unwritable, so a lane
+ * shipping on the migration day -- or rebasing an older branch forward -- had
+ * to either edit `_archive.md`, which the migration says no lane does again, or
+ * date its fragment something other than its date. Measured on the real tree,
+ * one probe fragment at a time: dated 2026-09-09 (newer than the newest
+ * section) 16 passed; dated 2026-09-08, 2026-09-07 or 2026-08-01 (at or inside
+ * the span) 1 failed; dated 2026-05-01 (older than the oldest) 16 passed.
+ *
+ * What "settled history is not reformatted" actually claims is that every
+ * archived line still appears, unmodified and in its original order -- which is
+ * exactly a subsequence, and which a splice preserves by construction. The
+ * three ways an assembler could break it were each introduced into
+ * `scripts/assemble-changelog.ts` and measured on the real archive, one at a
+ * time with the tree restored between: dropping one body line per section
+ * (`s.body.slice(1)`) failed at archived line 1, collapsing runs of spaces in
+ * every body line failed at line 28, and swapping two body lines failed at
+ * line 3. The substring form rejects those three too -- it is not weaker
+ * against a real reformat, only wrong about a splice.
+ *
+ * Blank lines are compared like any other, so the seam blank the assembler may
+ * INSERT before a heading is absorbed (an insertion is what a subsequence
+ * tolerates) while one it DELETED would still be caught.
+ */
+function assertArchiveConserved(doc: string, archive: string): void {
+  const want = archive.split('\n');
+  const have = doc.split('\n');
+  let i = 0;
+  for (const line of have) if (i < want.length && line === want[i]) i++;
+  expect(
+    i,
+    `the archive is no longer reproduced in full -- the assembler is reformatting settled history. ` +
+      `First archived line not found in order (${i} of ${want.length}): ${JSON.stringify(want[i] ?? '')}`
+  ).toBe(want.length);
+}
+
+
 describe('assemble-changelog', () => {
   it('emits ONE heading per date, not one per entry', () => {
     // The go-to-k/cdkd#1837 class, reachable through the generator. Two lanes
@@ -347,6 +396,90 @@ describe('assemble-changelog', () => {
     expect(lines.indexOf('- fresh')).toBeLessThan(lines.indexOf('- archived entry B'));
   });
 
+
+  /**
+   * The archive is CONSERVED at every date position, including the ones the
+   * substring form refused (issue go-to-k/cdkd#2813). A wide fixture archive --
+   * two sections a week apart -- so "strictly inside the span" is reachable at
+   * all; with the consecutive days the other cases use, no such date exists and
+   * the interesting arm could not be written.
+   */
+  describe('the archive survives a fragment at any date position', () => {
+    const WIDE = [
+      headingFor('2026-09-08'),
+      '- archived entry A',
+      '',
+      headingFor('2026-09-01'),
+      '- archived entry B',
+    ].join('\n');
+
+    for (const [date, where] of [
+      ['2026-09-09', 'newer than the newest archived section'],
+      ['2026-09-08', 'the newest archived section itself'],
+      ['2026-09-05', 'strictly inside the archived span'],
+      ['2026-09-01', 'the oldest archived section itself'],
+      ['2026-08-01', 'older than the oldest archived section'],
+    ] as const) {
+      it(`conserves it for a fragment dated ${date} (${where})`, () => {
+        const doc = withTree(WIDE, { [`${date}-2813-probe.md`]: '- probe entry' }, (root) =>
+          assembleChangelog(root)
+        );
+        assertArchiveConserved(doc, WIDE);
+        // Not vacuous: the fragment really did land, exactly once. Conservation
+        // alone is satisfied by an assembler that dropped the fragment.
+        expect(doc.split('- probe entry').length - 1, 'the fragment did not land exactly once').toBe(1);
+        const h = headings(doc);
+        expect(new Set(h).size, 'a date heading is duplicated').toBe(h.length);
+        const dates = h.map((x) => /\((\d{4}-\d{2}-\d{2})/.exec(x)![1]!);
+        expect([...dates].sort((a, b) => b.localeCompare(a)), 'the document stopped running newest-first').toEqual(
+          dates
+        );
+        assertEveryHeadingOpensItsBlock(doc);
+      });
+    }
+  });
+
+  /**
+   * The conservation check must still REJECT a real reformat, or replacing the
+   * substring form with it would trade a false refusal for a false pass. Driven
+   * against hand-built documents rather than a broken assembler, since a unit
+   * test cannot mutate the module under test; the same three shapes were also
+   * introduced into `scripts/assemble-changelog.ts` itself and measured against
+   * the real archive (see `assertArchiveConserved`'s comment).
+   */
+  describe('the conservation check rejects a genuine reformat', () => {
+    const A = ['x', '- one', '- two', '', 'y'].join('\n');
+    const spliced = ['x', '- one', '- NEW', '- two', '', 'y'].join('\n');
+
+    it('accepts a splice, which is the whole reason it is not a substring check', () => {
+      expect(() => assertArchiveConserved(spliced, A)).not.toThrow();
+    });
+
+    it('rejects a dropped archived line', () => {
+      expect(() => assertArchiveConserved(['x', '- one', '', 'y'].join('\n'), A)).toThrow(
+        /no longer reproduced in full/
+      );
+    });
+
+    it('rejects reordered archived lines', () => {
+      expect(() => assertArchiveConserved(['x', '- two', '- one', '', 'y'].join('\n'), A)).toThrow(
+        /no longer reproduced in full/
+      );
+    });
+
+    it('rejects a re-wrapped archived line', () => {
+      expect(() => assertArchiveConserved(['x', '- one', '-  two', '', 'y'].join('\n'), A)).toThrow(
+        /no longer reproduced in full/
+      );
+    });
+
+    it('rejects a DELETED blank line, which an insertion-tolerant check could have missed', () => {
+      expect(() => assertArchiveConserved(['x', '- one', '- two', 'y'].join('\n'), A)).toThrow(
+        /no longer reproduced in full/
+      );
+    });
+  });
+
   it('assembles the REPO tree, and that tree is the shape the fences read', () => {
     // The properties only the real corpus can show: it parses at all, it is
     // large, and it still opens with the contract sections the policy fence
@@ -366,10 +499,7 @@ describe('assemble-changelog', () => {
     // and both live seam defects on this branch were found against the real
     // archive, not a fixture.
     const archive = readFileSync(join(root, FRAGMENT_DIR, ARCHIVE_FILE), 'utf-8').replace(/\s+$/, '');
-    expect(
-      doc.includes(archive),
-      'the archive is no longer reproduced verbatim -- the assembler is reformatting settled history'
-    ).toBe(true);
+    assertArchiveConserved(doc, archive);
     assertEveryHeadingOpensItsBlock(doc);
     const onDisk = readdirSync(join(root, FRAGMENT_DIR, ENTRIES_DIR)).filter((n) => n !== '.gitkeep');
     expect(readEntries(root).length, 'a fragment on disk was not read into the assembly').toBe(onDisk.length);


### PR DESCRIPTION
Closes #2813
Closes #2816

## What

`assemble-changelog.test.ts` asserted that `changelog.d/_archive.md` is a
CONTIGUOUS SUBSTRING of the assembled document. The assembler SPLICES, so that
assertion refused a correct assembly.

A fragment whose date the archive already heads lands under that heading; one
dated between two archived sections opens a new section in descending position.
The first is what `changelog.d/_header.md` states under "WHERE an entry goes";
the second is documented in `assemble-changelog.ts` itself. Both are what makes
the go-to-k/cdkd#1837 duplicate-heading class structurally impossible. Both also put new text inside the archive's span, so the archive
stops being contiguous while nothing about settled history has changed.

The assertion is now that every archived line still appears, unmodified and in
its original order -- a SUBSEQUENCE. That is what "settled history is not
reformatted" actually claims, and a splice preserves it by construction.

## Why it mattered

No lane could date a fragment anywhere in **2026-05-31 .. 2026-09-08** -- the
whole archived span, which a lane rebasing an older branch forward reaches too.
The two available workarounds each break a stated rule: edit `_archive.md`,
which the migration says no lane edits again, or date the fragment something
other than its date. The lane that hit this on go-to-k/cdkd#2773 took the first.

## Measured

One probe fragment at a time on the REAL tree (51 archived sections, 2026-05-31
to 2026-09-08), running the changelog fences only.

| fragment date | position | before | after |
| --- | --- | --- | --- |
| 2026-09-09 | newer than the newest section | pass | pass |
| 2026-09-08 | the newest section itself | **FAIL** | pass |
| 2026-09-07 | inside the span | **FAIL** | pass |
| 2026-08-01 | inside the span | **FAIL** | pass |
| 2026-05-31 | the oldest section itself | **FAIL** | pass |
| 2026-05-01 | older than the oldest | pass | pass |
| 2026-01-01 | older than the oldest | pass | pass |

The issue's table named `assemble-changelog.test.ts` alone. The four other
fences that read the assembled document -- `changelog-entry-policy-sync`,
`changelog-entry-size`, `changelog-entry-uniqueness`, `changelog-ledger-citation`
-- were run with an inside-span fragment as well, and are green both before and
after (5 files, 50 tests).

## The check still FAILS on a real reformat

Proven against REAL code, not a synthetic fixture: each shape was introduced
into `scripts/assemble-changelog.ts` itself, measured against the real archive,
and the tree restored byte-exact between probes (`git diff --stat HEAD` receipt
taken each time).

Every row replaces the single expression `out.push(s.heading, ...s.body);` in
`assembleChangelog`, except the last, which replaces the two-line
`if (at === -1) ... else merged.splice(at, 0, fresh);`. The counts are of this
one test file's 30 cases and depend on exactly where the edit goes, so the
recipe is given rather than a description of it — run from the labels alone the
same idea lands elsewhere and reds a different number.

| edit | result |
| --- | --- |
| `out.push(s.heading, ...s.body.slice(1));` | **12 failed** |
| `out.push(s.heading, ...s.body.map((b) => b.replace(/  +/g, ' ')));` | **1 failed** |
| `{ const b = [...s.body]; if (b.length > 2) { const t = b[1]; b[1] = b[2]; b[2] = t; } out.push(s.heading, ...b); }` | **1 failed** |
| `out.push(s.heading, ...s.body.flatMap((b) => (b.startsWith('- ') ? [b, ''] : [b])));` | **5 failed** |
| `out.push(s.heading, '- FOREIGN LINE', ...s.body);` | **10 failed** |
| `if (at === -1 \|\| at === 0) merged.push(fresh); else merged[at - 1] = { ...merged[at - 1]!, body: [...es.map((e) => e.text), ...merged[at - 1]!.body] };` | **6 failed** |
| restored | 30 passed |

Two earlier probe passes were wrong and are recorded here rather than quietly
dropped. The first mutated `_archive.md` instead of the assembler, so the
expected value and the output moved together and all three "negatives" passed --
a circular probe that proved nothing. The second mutated the merge branch
(`{ ...s, body: [...] }`), which does not fire unless a fragment is dated at an
archived date, and was INERT: a probe that changes nothing is a probe that was
not run.

## Tests

16 -> 26 in the one file. Five date positions against a fixture archive
deliberately widened to two sections a week apart, because with the consecutive
days the other cases use, "strictly inside the span" is not a reachable date and
the interesting arm could not be written. Each asserts conservation AND that the
fragment landed exactly once -- conservation alone is satisfied by an assembler
that dropped the fragment -- plus heading uniqueness, descending order, and the
render check.

Five negative controls drive the check itself, including a **deleted blank
line**: an insertion-tolerant check is exactly the kind that could have let that
through, so it is pinned rather than assumed.

Full suite 953 files / 20,711 tests green; typecheck, `typecheck:test`, lint,
format and build clean. No `src/` change, so no changelog fragment -- nothing
about the shipped binary moves.


## Review round 1

**M0 — where the fragment lands is now pinned.** Conservation,
appears-exactly-once, heading uniqueness and descending order all pass if the
assembler merges the `2026-09-05` probe into the `2026-09-08` body instead of
opening its own section — the defect `assemble-changelog.ts` records review
catching once (`09-07 / 09-08 / 09-07`). Each of the five arms now asserts the
line directly under its own generated heading. The last row of the mutation
table above is a BROADER form of that defect — it also disturbs ordering, so it
fails six tests rather than isolating the landing assertions. I did not
reproduce the ordering-preserving form the review reported failing exactly two.

**M1 — the insertion budget.** A subsequence bounds presence and order and
nothing else, so 575 inserted blank lines and foreign text spliced mid-archive
both passed, and both had been rejected by `doc.includes(archive)`. Accepting
insertions is inherent to the form — the splice IS one — so
`assertArchiveConserved` now takes a `budget`, and every term of it is derived
from what the assembler can emit: `header + 1 + fragment lines + new headings +
seams + 1`. The measured delta is **183** against a bound of **185** — slack 2.

The seam term is the one that matters. The assembler inserts a blank before a
section only where the PREVIOUS body ends non-blank, which is 1 section of 51
here, so an earlier revision that allowed one per heading put 51 of its 52-line
slack in that term alone — and grew it by one for every dated section the
archive would ever gain. A merged fragment prepends and cannot change whether a
body ends blank; a new section can, at both edges, hence two per new heading.
The preamble contributes one only when it exists and ends non-blank, which it
does not here. (Earlier revisions of this description said 235 and then 234;
both were bounds this test no longer computes.) Residual, stated in the
comment rather than left implied: an insertion smaller than the seam allowance
is inside the budget, so the delta bounds a bulk reformat and not a few foreign
lines. Attributing every unconsumed line is the stronger form; this is the one
the review asked for and it closes the class that was measured open.

**Two arms the review named as untested**, both verified by hand there and
pinned here: the one legitimate variant heading
`**Recently Implemented** (2026-07-02, second batch):` — which this change is
what first makes a fragment of that date legal at all — and two fragments in one
run, one merging into an existing section and one opening a new one.

**Three corrections from the same review.** The two splice shapes are documented
in different files and the comment claimed both were in `_header.md`. "A deleted
blank line would still be caught" holds for THIS archive, whose body bullets are
unique, and not in general — a deleted line re-syncs against a later duplicate —
so the sentence is scoped to the corpus. And the failure message printed a
0-based index behind an ordinal phrasing, reporting "(0 of 51)" for the first
line.

Tests 26 -> 30. Full suite 953 files / 20,715 tests green.

## Review round 2

**M1b — the seam allowance is derived, not granted.** Covered above: 185 against
183, slack 2 rather than 51, and it no longer widens as the archive grows.

`HEADING` is now exported from `assemble-changelog.ts` and used by the test,
which had carried a copy missing the `[^)]*\):$` tail. Both return 51 on today's
archive, so a line that loose-matched and strict-failed would have inflated the
date set, under-counted new headings and left the budget one short of a
legitimate assembly, with nothing comparing the two.

Five notes, all taken: the variant arm's presence assertion could not fail
(conservation on the line above already requires it); `WIDE_BUDGET` is
`TWO_SECTION_BUDGET`, since it is derived for a two-section fixture and the
variant arm applies it to a different one; the call site no longer restates the
JSDoc; the doc comment's counter-example is executable again (both parameters
are strings and it was written with bare arrays); and the real-tree comment
still claimed no fragment had been written yet, which stopped being true before
this branch existed and is read by the budget's own `fragmentLines` term.

Every row of the mutation table above was re-measured against the tightened
budget. Full suite 953 files / 20,715 tests green.

## Live test

The behaviour under test is a fence, so the live test is the fence running
against the real corpus rather than a fixture: every row of both tables above
was executed on this tree, one mutation at a time with the assembler restored
byte-exact between probes, and the seven-date sweep was re-run after the final
commit.
