### PR TITLE
test(changelog): cap every fragment regardless of its filename date, so a pre-cutoff name no longer ships an uncapped entry

### DIFF
--- a/changelog.d/_header.md
+++ b/changelog.d/_header.md
@@ -23,7 +23,10 @@ The CLAUDE.md `## Known Limitations` section retains the load-bearing summary
 
 An entry is capped at **2000 characters**, counted over the bullet and every
 continuation line under it, and enforced by
-`tests/unit/scripts/changelog-entry-size.test.ts`. The entry keeps the
+`tests/unit/scripts/changelog-entry-size.test.ts`. In a fragment the count is
+the **whole file** as it reads, trailing whitespace stripped — so a blank line
+*between* two prose lines counts, where the assembled document's own check
+skips it. The two agree unless you pad. The entry keeps the
 user-visible behavior delta, the changed files, the issue / PR numbers, and the
 residual's issue number — roughly the headline plus the file list plus a few
 sentences of mechanism.
@@ -55,8 +58,14 @@ buys an exemption.
 The cap is still **forward-only**, but the forward-only part now applies only
 to the ARCHIVE: everything in `changelog.d/_archive.md` was written under no
 cap, is already correct, and rewriting it buys nothing, so entries under a
-heading dated before **2026-09-05** stay exempt *there*. Nothing can be filed
-into the archive any more, so nothing new can reach that exemption.
+heading dated before **2026-09-05** stay exempt *there*.
+
+That exemption is reachable, and saying otherwise would be papering over it:
+`_archive.md` is an ordinary tracked file the assembler reads on its own path,
+so a bullet appended to it under a pre-cutoff heading bypasses the fragment cap
+entirely. Nothing fences that. "No lane edits the archive again" is a
+convention, not a mechanism — what the fragment cap buys is that the *ordinary*
+way to write an entry is capped.
 
 Until issue [#2859](https://github.com/go-to-k/cdkd/issues/2859) the cap keyed
 on the heading date alone, which meant a fragment named with a pre-cutoff date

--- a/changelog.d/_header.md
+++ b/changelog.d/_header.md
@@ -26,7 +26,9 @@ continuation line under it, and enforced by
 `tests/unit/scripts/changelog-entry-size.test.ts`. In a fragment the count is
 the **whole file** as it reads, trailing whitespace stripped — so a blank line
 *between* two prose lines counts, where the assembled document's own check
-skips it. The two agree unless you pad. The entry keeps the
+skips it, and a `---` at column 0 counts along with everything below it, where
+that check stops at the rule. The two agree unless you pad or park a `---`
+mid-entry. The entry keeps the
 user-visible behavior delta, the changed files, the issue / PR numbers, and the
 residual's issue number — roughly the headline plus the file list plus a few
 sentences of mechanism.

--- a/changelog.d/_header.md
+++ b/changelog.d/_header.md
@@ -46,11 +46,24 @@ shrinks is the number of implementation facts one entry asserts with nothing
 verifying them. Narrowing `.markgate.yml`'s scope is a separate question.
 There is deliberately no per-entry opt-out.
 
-The cap is **forward-only**: it binds entries under a heading dated
-**2026-09-05 or later**. Everything written before that was written under no
-cap, is already correct, and rewriting it buys nothing. There is no allowlist
-of exempted entries — the date does the whole partition, so nothing has to be
-maintained as the file grows.
+**Every fragment you write is capped, whatever date its filename carries.** A
+fragment under `changelog.d/entries/` is new by construction, so the date in
+its name is a sort key for the assembler and never evidence about when the
+entry was written. There is no allowlist of exempted entries and no date that
+buys an exemption.
+
+The cap is still **forward-only**, but the forward-only part now applies only
+to the ARCHIVE: everything in `changelog.d/_archive.md` was written under no
+cap, is already correct, and rewriting it buys nothing, so entries under a
+heading dated before **2026-09-05** stay exempt *there*. Nothing can be filed
+into the archive any more, so nothing new can reach that exemption.
+
+Until issue [#2859](https://github.com/go-to-k/cdkd/issues/2859) the cap keyed
+on the heading date alone, which meant a fragment named with a pre-cutoff date
+shipped uncapped. That was survivable only because issue
+[#2813](https://github.com/go-to-k/cdkd/issues/2813) happened to refuse any
+fragment dated inside the archive's span; fixing #2813 would have widened the
+uncapped window by about three months, so the cap moved to the fragment itself.
 
 The cutoff is the day *after* the cap landed, not the day of. A same-day cutoff
 races every other lane merging that day: while this was in review, two

--- a/tests/unit/scripts/changelog-entry-size.test.ts
+++ b/tests/unit/scripts/changelog-entry-size.test.ts
@@ -1,6 +1,13 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { assembleChangelog } from '../../../scripts/assemble-changelog.js';
+import type { Entry as AssemblerEntry } from '../../../scripts/assemble-changelog.js';
+import {
+  ENTRIES_DIR,
+  FRAGMENT_DIR,
+  assembleChangelog,
+  readEntries,
+} from '../../../scripts/assemble-changelog.js';
 import { describe, expect, it } from 'vite-plus/test';
 
 /**
@@ -91,14 +98,49 @@ import { describe, expect, it } from 'vite-plus/test';
  *
  * ## Known limits, recorded rather than papered over
  *
- * An entry MISDATED under a pre-cutoff heading escapes the cap. Nothing here
- * can see that: a checker cannot distinguish an entry filed under an old date
- * from a genuinely old one, and the file's headings are not globally ordered
- * anyway -- 2026-08-24 is followed by 2026-08-25, and three dates repeat -- so a
- * monotonicity assertion would fail on the real file rather than catch the
- * evasion. What IS asserted is the one direction with a structural answer: the
- * FIRST heading carries the maximum date, so an older heading cannot be
- * inserted above the newest one to shelter a new entry beneath it.
+ * An entry MISDATED under a pre-cutoff heading used to escape the cap, and this
+ * paragraph used to say no checker could ever see it -- "a checker cannot
+ * distinguish an entry filed under an old date from a genuinely old one". That
+ * was true of the flat committed file, where a heading was the only evidence an
+ * entry carried. It stopped being true at go-to-k/cdkd#2811: `readEntries`
+ * returns the FRAGMENT set, and a fragment is new by construction whatever date
+ * its filename spells. So the cap now binds per fragment, with no date filter at
+ * all (`fragmentsOverLimit`), and the misdating channel is closed for everything
+ * a lane can still write.
+ *
+ * The date cutoff below is therefore no longer the cap's main instrument. It
+ * survives to keep the ARCHIVED text -- settled before the fragment layout
+ * existed, and edited by no lane again -- exempt in exactly the way it always
+ * was. Nothing can be filed into the archive any more, so nothing new can reach
+ * the exemption. (No count is quoted here on purpose: the one in
+ * `assemble-changelog.ts`'s header has already drifted, reading 574 against 575
+ * column-0 bullets measured 2026-09-09, and a second copy would drift the same
+ * way with nothing watching either.)
+ *
+ * What made the residual urgent rather than theoretical: go-to-k/cdkd#2813
+ * refused any fragment dated at or inside the archive's span, so the dates that
+ * were BOTH shippable and uncapped were only those older than the whole archive.
+ * Fixing that (go-to-k/cdkd#2857) widens the uncapped window by ~97 days unless
+ * the cap stops keying on the heading date -- which is this. Filed as
+ * go-to-k/cdkd#2859.
+ *
+ * One half of the old hazard is still worth asserting on the assembled document,
+ * because the archive is real text that a bad merge could reorder: the FIRST
+ * heading carries the maximum date, so an older heading cannot be inserted above
+ * the newest one to shelter an entry beneath it. A global monotonicity assertion
+ * is NOT available -- 2026-08-24 is followed by 2026-08-25, and three dates
+ * repeat -- so it would fail on the real file rather than catch anything.
+ *
+ * ## Two measurements, and why the fragment's own is the strict one
+ *
+ * A fragment is measured as the FILE reads, trailing whitespace stripped. The
+ * assembled-entry parser instead SKIPS blank lines, so a fragment carrying
+ * internal blank lines measures longer here than the entry it becomes. That is
+ * deliberate and it is the conservative direction: the fragment file is what the
+ * author edits and what the failure message names, and neither a blank line nor
+ * a `---` can shrink the number. Measured 2026-09-09 across all five fragments
+ * on the tree: zero internal blank lines, so the two measures agree exactly
+ * today and the divergence is latent rather than live.
  *
  * Aggregate prose parked in heading QUALIFIERS is another. Each heading may
  * carry 30 characters after its date, and `gives every section at least one
@@ -129,8 +171,14 @@ const assembled = () => assembleChangelog(REPO_ROOT);
 const LIMIT = 2000;
 
 /**
- * Entries under a heading dated on or after this are capped. See the header for
- * why it is the day after this landed and not the landing day itself.
+ * Entries under a heading dated on or after this are capped ON THE ASSEMBLED
+ * DOCUMENT. See the header for why it is the day after the cap landed and not
+ * the landing day itself.
+ *
+ * Since go-to-k/cdkd#2859 this governs only the ARCHIVED text: every fragment is
+ * capped by `fragmentsOverLimit` with no date filter, so the cutoff can no
+ * longer exempt anything a lane writes. Kept because `changelog.d/_archive.md`
+ * was written under no cap, and re-capping it retroactively buys nothing.
  */
 const CUTOFF = '2026-09-05';
 
@@ -297,6 +345,31 @@ function parseEntries(text: string): Parsed {
 function overLimit(parsed: Parsed): Entry[] {
   return parsed.entries.filter((e) => e.date !== null && e.date >= CUTOFF).filter((e) => e.text.length > LIMIT);
 }
+
+/**
+ * THE fragment predicate, and the reason it takes no date.
+ *
+ * A fragment under `changelog.d/entries/` is new by construction: the archive is
+ * a separate file, nothing can be filed into it, and `readEntries` returns only
+ * the former. So the date in a fragment's filename is a SORT KEY for the
+ * assembler, never evidence about when the entry was written -- which is exactly
+ * what the heading-date filter was forced to treat it as, back when the heading
+ * was the only evidence there was.
+ *
+ * Extracted, like `overLimit`, so the real-tree verdict and the synthetic one
+ * run the same code rather than two copies that can drift apart.
+ */
+function fragmentsOverLimit(fragments: readonly AssemblerEntry[]): AssemblerEntry[] {
+  return fragments.filter((f) => f.text.length > LIMIT);
+}
+
+const FRAGMENT_CAP_ADVICE =
+  `A changelog.d/entries/ fragment exceeds ${LIMIT} characters. The cap does NOT depend on the date in ` +
+  'the filename -- a fragment is new whatever date it carries, which is what stops an over-long entry ' +
+  'shipping under a pre-cutoff name (go-to-k/cdkd#2859). Same remedy as the assembled-document cap: keep ' +
+  'the user-visible behavior delta, the changed files, the issue / PR numbers and the residual\'s issue ' +
+  'number, and move a design decision to docs/design/<issue>-<slug>.md or a mechanism to the doc comment ' +
+  'on the module or test that implements it, linked from the entry.';
 
 const CAP_ADVICE =
   `A docs/changelog-cdkd.md entry exceeds ${LIMIT} characters (line numbers are in that file). ` +
@@ -553,6 +626,94 @@ describe('changelog entry size', () => {
       (e) => `L${e.line}: ${e.text.length} chars (limit ${LIMIT}): ${e.text.slice(2, 90)}...`
     );
     expect(offenders, CAP_ADVICE).toEqual([]);
+  });
+
+  it('caps every fragment, whatever date its filename carries', () => {
+    // The verdict go-to-k/cdkd#2859 exists for. The one above reads the
+    // ASSEMBLED document and exempts anything under a pre-cutoff heading; this
+    // one reads the fragments and exempts nothing.
+    const fragments = readEntries(REPO_ROOT);
+
+    // A checker must prove it sees its input: with zero fragments read, the
+    // verdict below is green for the wrong reason, and that is the state the
+    // repo was in for the whole day the layout landed. Recounted from the
+    // DIRECTORY rather than from `readEntries`, so a parser that silently
+    // dropped a file cannot satisfy its own floor.
+    const onDisk = readdirSync(join(REPO_ROOT, FRAGMENT_DIR, ENTRIES_DIR)).filter((n) => n !== '.gitkeep');
+    expect(fragments.length, 'readEntries lost a fragment the directory still holds').toBe(onDisk.length);
+
+    const offenders = fragmentsOverLimit(fragments).map(
+      (f) => `${f.file}: ${f.text.length} chars (limit ${LIMIT})`
+    );
+    expect(offenders, FRAGMENT_CAP_ADVICE).toEqual([]);
+  });
+
+  it('selects over-limit fragments and only those, ignoring the filename date', () => {
+    // The liveness proof for the fragment cap, and it is NOT optional: every
+    // fragment on the tree today is dated after the cutoff, so the real-tree
+    // verdict above would stay green with the date filter put back. Only a
+    // PRE-cutoff over-limit fragment can tell the two predicates apart, and none
+    // exists on the tree by construction -- so one is built here.
+    //
+    // Runs the real `readEntries`, not hand-built objects: the load-bearing
+    // claim is that a fragment's whole FILE is what gets measured, and only the
+    // reader that the assembler actually uses can prove that.
+    const root = mkdtempSync(join(tmpdir(), 'cdkd-fragment-cap-'));
+    try {
+      mkdirSync(join(root, FRAGMENT_DIR, ENTRIES_DIR), { recursive: true });
+      const write = (name: string, body: string) =>
+        writeFileSync(join(root, FRAGMENT_DIR, ENTRIES_DIR, name), body);
+
+      const long = 'x'.repeat(LIMIT + 1);
+      // Dated a year before the archive even opens -- the deepest the old
+      // exemption reached, and green under `overLimit` at any length.
+      write('2025-01-01-2859-ancient-and-over.md', `- **Ancient** ${long}`);
+      // Inside the archive's span: the band go-to-k/cdkd#2857 unlocks, which is
+      // what turns this from a latent hole into a reachable one.
+      write('2026-08-01-2859-in-span-and-over.md', `- **In span** ${long}`);
+      // One day under the cutoff: the boundary the date filter would still
+      // exempt, so this case dies if `fragmentsOverLimit` regrows a date test.
+      write('2026-09-04-2859-just-under-cutoff-and-over.md', `- **Just under cutoff** ${long}`);
+      // After the cutoff and over: flagged by BOTH predicates. Present so the
+      // fragment cap cannot be narrowed to "pre-cutoff only" -- the mirror of
+      // the mutation the case above kills.
+      write('2026-09-09-2859-after-cutoff-and-over.md', `- **After cutoff** ${long}`);
+      // Exactly at the limit, so `> LIMIT` cannot be loosened to `>=`. The
+      // prefix is counted in, which is the point: the FILE is the unit.
+      write('2026-09-09-2859-exactly-at-limit.md', `- **Exact** ${'e'.repeat(LIMIT - '- **Exact** '.length)}`);
+      // Comfortably short: the negative control. Without one, a predicate that
+      // returned every fragment would satisfy every other expectation here.
+      write('2026-09-09-2859-short.md', '- **Short** short enough.');
+      // Blank lines BETWEEN prose lines count here and are skipped by the
+      // assembled-entry parser -- the divergence the header records, pinned
+      // rather than asserted in prose alone. Sized to clear the limit ONLY
+      // because of the blanks: the two measures are computed below and the case
+      // is worthless unless they straddle it.
+      const paddedProse = `- **Blank padded** ${'b'.repeat(LIMIT - 60)}`;
+      const padded = [paddedProse, ...Array.from({ length: 40 }, () => ''), '  tail'].join('\n');
+      const asAssembledEntry = padded
+        .split('\n')
+        .filter((l, i) => i === 0 || l.trim() !== '')
+        .join('\n');
+      expect(padded.length, 'the blank-padded case must exceed the limit').toBeGreaterThan(LIMIT);
+      expect(
+        asAssembledEntry.length,
+        'and must fall UNDER it once blank lines are skipped, or it does not discriminate the two measures'
+      ).toBeLessThanOrEqual(LIMIT);
+      write('2026-09-09-2859-blank-padded.md', padded);
+
+      const flagged = fragmentsOverLimit(readEntries(root))
+        .map((f) => /\*\*(.+?)\*\*/.exec(f.text)?.[1] ?? f.file)
+        .sort();
+
+      // Selected: every over-limit fragment on BOTH sides of the cutoff --
+      // including the three the heading-date filter would have exempted -- plus
+      // the one that is over only because internal blank lines are counted. NOT
+      // selected: the short one, nor the one sitting exactly ON the limit.
+      expect(flagged).toEqual(['Ancient', 'After cutoff', 'Blank padded', 'In span', 'Just under cutoff'].sort());
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('holds the entry this change added to its own rule', () => {

--- a/tests/unit/scripts/changelog-entry-size.test.ts
+++ b/tests/unit/scripts/changelog-entry-size.test.ts
@@ -111,11 +111,22 @@ import { describe, expect, it } from 'vite-plus/test';
  * The date cutoff below is therefore no longer the cap's main instrument. It
  * survives to keep the ARCHIVED text -- settled before the fragment layout
  * existed, and edited by no lane again -- exempt in exactly the way it always
- * was. Nothing can be filed into the archive any more, so nothing new can reach
- * the exemption. (No count is quoted here on purpose: the one in
+ * was. (No count is quoted here on purpose: the one in
  * `assemble-changelog.ts`'s header has already drifted, reading 574 against 575
  * column-0 bullets measured 2026-09-09, and a second copy would drift the same
  * way with nothing watching either.)
+ *
+ * THE MISDATING CHANNEL IS CLOSED FOR FRAGMENTS, WHICH IS NOT THE SAME AS
+ * CLOSED. `assembleChangelog` reads `_archive.md` on its own path, so a bullet
+ * APPENDED to that file reaches the assembled document without ever passing
+ * through `readEntries` -- and appended under a pre-cutoff heading it is exempt
+ * from both predicates. `_archive.md` is an ordinary tracked file and nothing
+ * fences it. "No lane edits the archive again" is a CONVENTION, and an earlier
+ * revision of this comment stated it as a mechanism, which is the papering-over
+ * this section is named against. What the fragment cap buys is that the
+ * ORDINARY way to write an entry is now capped; the archive remains a way
+ * around it for anyone who decides to take it, and that is a residual, not a
+ * closure.
  *
  * What made the residual urgent rather than theoretical: go-to-k/cdkd#2813
  * refused any fragment dated at or inside the archive's span, so the dates that
@@ -634,12 +645,21 @@ describe('changelog entry size', () => {
     // one reads the fragments and exempts nothing.
     const fragments = readEntries(REPO_ROOT);
 
-    // A checker must prove it sees its input: with zero fragments read, the
-    // verdict below is green for the wrong reason, and that is the state the
-    // repo was in for the whole day the layout landed. Recounted from the
-    // DIRECTORY rather than from `readEntries`, so a parser that silently
-    // dropped a file cannot satisfy its own floor.
+    // A checker must prove it sees its input, and that takes BOTH assertions
+    // below -- the equality alone is a CONSISTENCY check, satisfied at 0 === 0.
+    // `entries/` held nothing but `.gitkeep` for the whole day the layout
+    // landed, and in that state `offenders` is empty for the wrong reason with
+    // the equality green.
+    //
+    // The floor is safe because the population only GROWS: nothing moves a
+    // fragment into `_archive.md` (no script, and no fragment has ever been
+    // deleted -- `git log --diff-filter=D` over the directory is empty), so the
+    // day-zero state cannot recur. If an archiving step is ever added, this
+    // assertion is the right place to fail and force the question.
     const onDisk = readdirSync(join(REPO_ROOT, FRAGMENT_DIR, ENTRIES_DIR)).filter((n) => n !== '.gitkeep');
+    expect(onDisk.length, 'no fragment on disk at all -- this verdict has no subject').toBeGreaterThan(0);
+    // Recounted from the DIRECTORY rather than from `readEntries`, so a parser
+    // that silently dropped a file cannot satisfy its own floor.
     expect(fragments.length, 'readEntries lost a fragment the directory still holds').toBe(onDisk.length);
 
     const offenders = fragmentsOverLimit(fragments).map(
@@ -681,6 +701,15 @@ describe('changelog entry size', () => {
       // Exactly at the limit, so `> LIMIT` cannot be loosened to `>=`. The
       // prefix is counted in, which is the point: the FILE is the unit.
       write('2026-09-09-2859-exactly-at-limit.md', `- **Exact** ${'e'.repeat(LIMIT - '- **Exact** '.length)}`);
+      // Exactly ONE over, so `> LIMIT` cannot be shifted to `> LIMIT + 1`.
+      // Every other over-limit case here clears the limit by a dozen-plus
+      // characters and survives that mutation; the assembled-document sibling
+      // carries a `Just over` entry for exactly this reason, and without one
+      // the fragment suite is a mutation weaker than the predicate it mirrors.
+      write(
+        '2026-09-09-2859-just-over.md',
+        `- **Just over** ${'j'.repeat(LIMIT + 1 - '- **Just over** '.length)}`
+      );
       // Comfortably short: the negative control. Without one, a predicate that
       // returned every fragment would satisfy every other expectation here.
       write('2026-09-09-2859-short.md', '- **Short** short enough.');
@@ -691,14 +720,16 @@ describe('changelog entry size', () => {
       // is worthless unless they straddle it.
       const paddedProse = `- **Blank padded** ${'b'.repeat(LIMIT - 60)}`;
       const padded = [paddedProse, ...Array.from({ length: 40 }, () => ''), '  tail'].join('\n');
-      const asAssembledEntry = padded
-        .split('\n')
-        .filter((l, i) => i === 0 || l.trim() !== '')
-        .join('\n');
+      // The second measure comes from the REAL `parseEntries`, not a hand-rolled
+      // "skip the blanks". Re-implementing it here would keep this straddle
+      // green while the claim it pins went false -- if that parser ever stops
+      // skipping blank lines, or its `---` flush arm moves, the divergence
+      // simply is not there any more and this case must say so.
+      const asAssembledEntry = parseEntries(padded).entries[0]!.text;
       expect(padded.length, 'the blank-padded case must exceed the limit').toBeGreaterThan(LIMIT);
       expect(
         asAssembledEntry.length,
-        'and must fall UNDER it once blank lines are skipped, or it does not discriminate the two measures'
+        'and must fall UNDER it as an assembled entry, or it does not discriminate the two measures'
       ).toBeLessThanOrEqual(LIMIT);
       write('2026-09-09-2859-blank-padded.md', padded);
 
@@ -710,7 +741,9 @@ describe('changelog entry size', () => {
       // including the three the heading-date filter would have exempted -- plus
       // the one that is over only because internal blank lines are counted. NOT
       // selected: the short one, nor the one sitting exactly ON the limit.
-      expect(flagged).toEqual(['Ancient', 'After cutoff', 'Blank padded', 'In span', 'Just under cutoff'].sort());
+      expect(flagged).toEqual(
+        ['Ancient', 'After cutoff', 'Blank padded', 'In span', 'Just over', 'Just under cutoff'].sort()
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #2859

## What

The 2000-character changelog entry cap keyed on the **date of the heading an
entry sat under**: `overLimit` filters `e.date >= CUTOFF` (`2026-09-05`). So a
fragment file named with a pre-cutoff date shipped uncapped.

`fragmentsOverLimit` now caps every fragment with **no date filter at all**,
alongside the existing assembled-document check rather than replacing it.

## Why the old limit was unfixable and then wasn't

The fence's header said so outright — "a checker cannot distinguish an entry
filed under an old date from a genuinely old one" — and for the flat committed
file that was true: a heading was the only evidence an entry carried.

It stopped being true at go-to-k/cdkd#2811. `readEntries` returns the **fragment set**, and
a fragment is new by construction, so the date in its filename is a sort key for
the assembler and never evidence about when it was written.

## Why now

go-to-k/cdkd#2813 refused any fragment dated at or inside the archive's span, so the dates
that were BOTH shippable and uncapped were only those older than the whole
archive:

```
before          date < 2026-05-31        shippable, uncapped
                2026-05-31 .. 2026-09-08 NOT shippable (the go-to-k/cdkd#2813 defect)
                date >= 2026-09-09       shippable, capped
```

go-to-k/cdkd#2857 correctly removes that refusal, which widens the uncapped window to
`date < 2026-09-05` — about three months. This closes the hole before the
widening arrives. **Not a defect in go-to-k/cdkd#2857**: the hole predates it and the
fence's header documents the limit deliberately.

## Real-code failure probe

Per `.claude/rules/testing.md`, a checker must prove it still REJECTS, against
real code rather than a synthetic fixture:

| probe | result |
| --- | --- |
| `2026-09-04-2859-probe-over-limit.md` (2140 chars) written into the real `changelog.d/entries/` | new verdict **RED**, naming the file and its length |
| the same fragment, against the pre-existing `caps entries dated on or after the cutoff` | **GREEN** — the hole, demonstrated live |
| tree restored | `git diff --stat HEAD` receipt clean |

The second row is the point: the old fence is not merely weaker, it is
structurally blind to that fragment.

## The synthetic case is not optional

Every fragment on the tree is dated after the cutoff, so the real-tree verdict
alone would stay green with the date filter put back. `selects over-limit
fragments and only those, ignoring the filename date` builds a temp fragment
tree and runs the real `readEntries` over: a pre-archive date, an in-span date,
the day before the cutoff, a post-cutoff control, an exactly-at-limit control
(so `> LIMIT` cannot be loosened to `>=`) and a short control.

The three pre-cutoff arms die if `fragmentsOverLimit` regrows a date test; the
post-cutoff arm dies if it is narrowed to pre-cutoff only.

A `expect(fragments.length).toBe(onDisk.length)` floor, recounted from the
DIRECTORY rather than from `readEntries`, stops the real-tree verdict going
vacuously green — the state the repo was in for the whole day the layout landed.

## Two measurements

A fragment is measured as the file reads. That counts blank lines BETWEEN prose
lines, which the assembled-entry parser skips. The divergence is pinned by a
case that computes both measures and asserts they straddle the limit, rather
than asserted in prose. Measured 2026-09-09: zero internal blank lines across
the five fragments on the tree, so the two agree exactly today.

## Review round

Five findings, all real, all applied in `b44de3d1`:

1. **The population floor did not floor anything** (major). The equality against
   the directory listing is a *consistency* check, satisfied at `0 === 0` — the
   exact vacuous green its own comment claimed to stop. Added a `> 0` floor,
   safe because the population only grows (nothing archives a fragment;
   `git log --diff-filter=D` over the directory is empty). Probed by moving the
   five fragments out: the floor reds naming itself, exactly one test fails,
   and the equality alone stayed green.
2. **"Nothing can be filed into the archive any more" was a convention stated
   as a mechanism.** `assembleChangelog` reads `_archive.md` on its own path, so
   a bullet appended there under a pre-cutoff heading reaches the document
   without passing through `readEntries` and is exempt from both predicates.
   The paragraph this PR *replaced* was a correctly-stated known limit, so the
   replacement papered over a residual in the section named against exactly
   that. Now recorded as a residual in both places.
3. **No `LIMIT + 1` case**, so the off-by-one mutation survived — every
   over-limit fragment cleared by a dozen-plus characters. Added one; the
   mutation now reds, dropping `Just over`.
4. **The straddle pin re-implemented `parseEntries`** instead of calling it.
   Replaced, and the mutation the hand model could not catch is named in the
   commit: if `parseEntries` stops skipping blank lines the hand model keeps
   asserting a straddle that no longer exists.
5. `_header.md`'s contract sentence described the assembled measure only.

## Also

- `changelog.d/_header.md`'s forward-only paragraph rewritten to match: every
  fragment is capped whatever its name; the cutoff survives scoped to the
  archive, which nothing can be filed into any more.
- **A bare count was deliberately not restated.** The archive measures 575
  column-0 bullets while `scripts/assemble-changelog.ts`'s header still says
  574 — an early draft of this change propagated 574 into three new places. All
  three now avoid the count; the single surviving mention is attributed and
  dated. That comment in `assemble-changelog.ts` is left alone: it is about the
  file-split decision, not the cap, and is outside this change's scope.

## Verification

Full suite 955 files / 20,814 tests green (20,813 passed, 1 skipped);
typecheck, `typecheck:test`, lint, format and build clean; `gen:all-matrices`
and `audit:coverage:check` produce no drift. All five changelog fences green.

No `src/**` change, so no changelog fragment and no integ gate applies
(`integ-destroy` / `integ-broad` / `integ-local` all n/a by their own path
detection).
