### PR TITLE
chore(deps): raise the assets/demo-gif aws-cdk-lib floor to ^2.260.0

### DIFF
--- a/assets/demo-gif/package.json
+++ b/assets/demo-gif/package.json
@@ -9,7 +9,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.169.0",
-    "constructs": "^10.0.0"
+    "aws-cdk-lib": "^2.260.0",
+    "constructs": "^10.5.0"
   }
 }

--- a/assets/demo-gif/pnpm-lock.yaml
+++ b/assets/demo-gif/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: ^2.169.0
-        version: 2.256.1(constructs@10.6.0)
+        specifier: ^2.260.0
+        version: 2.268.0(constructs@10.6.0)
       constructs:
-        specifier: ^10.0.0
+        specifier: ^10.5.0
         version: 10.6.0
     devDependencies:
       '@types/node':
@@ -24,28 +24,29 @@ importers:
 
 packages:
 
-  '@aws-cdk/asset-awscli-v1@2.2.273':
-    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+  '@aws-cdk/asset-awscli-v1@2.2.292':
+    resolution: {integrity: sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==}
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
-    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
 
-  '@aws-cdk/cloud-assembly-schema@53.27.0':
-    resolution: {integrity: sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==, tarball: https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz}
+  '@aws-cdk/cloud-assembly-schema@54.22.0':
+    resolution: {integrity: sha512-vsOuFw4+UC5+m2YZLhCecxt6wibIOmXCszA4uXaBcde2tZWx06vp1z5ByHnJeLS83A11XpAkW/TiIBGCL6jxuQ==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
       - semver
 
   '@types/node@20.19.41':
-    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==, tarball: https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz}
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
-  aws-cdk-lib@2.256.1:
-    resolution: {integrity: sha512-18xLE+iqzjvpYGGKJy+9zyvF8loUSXjpVV2MtVLPQ/hPgeWHQiVsqLOWNsBemd3pU7o0L9wXfRY+xqG80vlZFw==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.1.tgz}
+  aws-cdk-lib@2.268.0:
+    resolution: {integrity: sha512-bm0mWG0xxIJtV0vhkmnFy6TFgwqBowvXeRKudhAsjM0TMOEcyFPBbwjUNlAA6S1+AjUwEt5yaMrT0A/P97lUqg==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       constructs: ^10.5.0
     bundledDependencies:
+      - '@aws/cloudformation-validate'
       - '@balena/dockerignore'
       - '@aws-cdk/cloud-assembly-api'
       - case
@@ -55,38 +56,37 @@ packages:
       - minimatch
       - punycode
       - semver
-      - table
       - yaml
       - mime-types
 
   constructs@10.6.0:
-    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
 snapshots:
 
-  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+  '@aws-cdk/asset-awscli-v1@2.2.292': {}
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
 
-  '@aws-cdk/cloud-assembly-schema@53.27.0': {}
+  '@aws-cdk/cloud-assembly-schema@54.22.0': {}
 
   '@types/node@20.19.41':
     dependencies:
       undici-types: 6.21.0
 
-  aws-cdk-lib@2.256.1(constructs@10.6.0):
+  aws-cdk-lib@2.268.0(constructs@10.6.0):
     dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-awscli-v1': 2.2.292
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
-      '@aws-cdk/cloud-assembly-schema': 53.27.0
+      '@aws-cdk/cloud-assembly-schema': 54.22.0
       constructs: 10.6.0
 
   constructs@10.6.0: {}


### PR DESCRIPTION
## Summary

Raises `assets/demo-gif`'s `aws-cdk-lib` floor to `^2.260.0` (and `constructs` to
`^10.5.0`) and regenerates that directory's `pnpm-lock.yaml` in place.

Closes #2865

## Why

`assets/demo-gif` keeps its own tracked `pnpm-lock.yaml`, separate from the root
one and from the integ fixtures. It resolved `aws-cdk-lib@2.256.1` — below the
`2.260.0` floor for GHSA-vcrf-j523-4mrf — so Dependabot alert 1 stayed open. It is
the **last open `aws-cdk-lib` alert on the repo**:

| alerts | manifest | closed by |
|---|---|---|
| 49-90 | `tests/integration/*/pnpm-lock.yaml` | go-to-k/cdkd#2838 (deleted them) |
| 9, 26, 28 | root `pnpm-lock.yaml` | go-to-k/cdkd#2866 (direct specifier at `^2.260.0`) |
| 1 | `assets/demo-gif/pnpm-lock.yaml` | this PR |

go-to-k/cdkd#2838 excluded this directory deliberately, and the reason is recorded
in `scripts/check-integ-cdk-lib-floor.ts:39-42`: raising its floor **without
regenerating that lockfile** recreates the specifier/manifest mismatch that PR was
removing. This PR regenerates it, so that condition is satisfied.

## Keep the lockfile, do not delete it

go-to-k/cdkd#2865 framed this as a choice, so stating the call explicitly: the
lockfile **stays**. Unlike the fixture corpus go-to-k/cdkd#2838 stripped, this
directory is not an integ fixture — nothing installs it during a test run, and its
lockfile pins what the recorded demo GIF was produced with. Deleting it would make
the demo non-reproducible to remove one alert that a regeneration removes anyway.

The checker's exclusion of `assets/demo-gif/` is therefore left as-is: both stated
grounds (not an integ fixture; has its own tracked lockfile) are still true.

## `constructs` floor

Raised `^10.0.0` -> `^10.5.0`, the same correction go-to-k/cdkd#2866 made at the
root: `^10.5.0` is `aws-cdk-lib`'s own peer floor, and the lower range *admits*
versions below it. As at the root, it did not *resolve* there — this is a
declared-range correction, not a fix for an observed unmet peer.

## Test plan

- **The mismatch check, which is the one that matters here:**
  `CI=1 pnpm install --ignore-workspace --frozen-lockfile` in `assets/demo-gif`
  — **rc=0**. That is the exact command that hard-fails with
  `ERR_PNPM_OUTDATED_LOCKFILE` on the specifier/manifest mismatch
  go-to-k/cdkd#2838 measured.
- Resolution moved `aws-cdk-lib` 2.256.1 -> 2.268.0 and `constructs` 10.6.0; the
  importer-block `specifier:` lines now read `^2.260.0` / `^10.5.0`, matching the
  manifest. `lockfileVersion` stays `9.0`.
- No consumer to break: nothing outside the directory references `demo-gif` except
  the checker comment above and the directory's own README.
- `vp check --fix` + `vp run check` — 0 errors (10 pre-existing warnings in
  untouched provider files).
- `vp run typecheck:test`, `vp run build` — pass.
- `vp test run` — 955 files / 20813 tests passed, 1 skipped, no type errors, no
  `Errors` line.
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — no artifact went
  stale.
- `assets/**` is in neither the `check` nor the `docs` gate scope, so no marker
  cycle and no real-AWS run is implicated. Both were re-run anyway because the
  branch switch staled them.
- Review: `inline` spot-check per `/review-pr`'s heuristic — 2 files, 4 LOC once
  the auto-generated lockfile is excluded, no up-bias path, no `fix:` commits. The
  spot-check is the diff read plus the frozen-lockfile verification above.

## After this merges

Every `aws-cdk-lib` Dependabot alert on the repo should be `fixed`. Verify with:

```bash
gh api "repos/go-to-k/cdkd/dependabot/alerts?state=open&per_page=100" \
  --jq '.[] | select(.dependency.package.name=="aws-cdk-lib")'
```
