### PR TITLE
fix(s3): restore three inert BucketLocationConstraint cast fences and re-derive the enum gap

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -247,13 +247,13 @@ s3-analytics-inventory	2026-08-13T00:49:56Z	PASS	135	verify.sh	1707/1717/1718 li
 s3-asset-deploy	2026-09-01T14:53:10Z	PASS	180	verify.sh	PR#2398 arm 3/6: asset-storage file/ZIP upload path, rc 0, 0 orphans
 s3-cloudfront	2026-08-20T11:58:20Z	PASS	226	verify.sh	#2079 lane: real Distribution created with the retry-stable acquireIdempotencyToken CallerReference, updated, drift-checked and deleted; AWS accepted the new token and release() ran on the success path. Does NOT reach the retried-500 replay (not inducible) -- that arm is unit-only, stated in the PR. Destroy clean, 0 distributions left in the account
 s3-directory-bucket	2026-08-13T11:19:53Z	PASS	-	verify.sh	issue 1815 partition ARN builders; rc 0, destroy clean, 0 orphans
-s3-event-notification	2026-08-10T04:16:05Z	PASS	73	verify.sh	0810 staleness sweep b1; #1437 EventBridgeEnabled/NESTED_KEY_TARGETS live-verified, 14 del 0 err, 0 orph
+s3-event-notification	2026-09-09T10:40:58Z	PASS	420	verify.sh	rc ok, orph clean
 s3-lifecycle	2026-09-02T12:34:35Z	PASS	290	verify.sh	issue 2301 item 3 round-2; live redaction fence added, rc 0, orph clean
 s3-object-lock	2026-08-27T14:41:38Z	PASS	43	verify.sh	issue 2322 lane, 2nd run gating the FINAL tree: a review round removed four unexecuted prose claims from the provider comment, which is enough to stale integ-destroy under hash:diff even though the diff stays comment-only. Same verdicts: rc 0, all 3 phases, destroy 1 deleted 0 errors, orphan scan clean
 s3-replication-and-filter	2026-08-11T15:11:16Z	PASS	110	verify.sh	issue #1605 versioning+logging replay downgrade; 7 del/0 err, 0 orph
 s3-subconfig-removal	2026-08-12T17:31:00Z	PASS		verify.sh	rc 0, 1 deleted 0 errors, re-run on the rebased tree, orphan sweep clean
 s3-tables	2026-08-22T19:12:07Z	PASS	46	verify.sh	issue 2176 masking sweep; rc 0, destroy 0 errors, orphans clean
-s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans
+s3-vectors	2026-09-09T10:08:18Z	PASS	300	verify.sh	rc ok, orph clean
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-09-05T22:50:31Z	PASS	88	verify.sh	PR2662 gate run; destroy 5 deleted 0 errors, 0 orphans
 schema-v5-to-v6-migration	2026-08-10T05:24:30Z	PASS	57	verify.sh	0810 P2 sweep b7; v5->v8 transparent auto-upgrade verified, 0 err 0 orph

--- a/src/provisioning/providers/s3-bucket-provider.ts
+++ b/src/provisioning/providers/s3-bucket-provider.ts
@@ -6135,11 +6135,13 @@ export class S3BucketProvider implements ResourceProvider {
       // checks membership -- and nothing should: a membership FILTER is exactly
       // the regression this note ends by naming.
       //
-      // THE GAP IS BIGGER THAN AN EARLIER REVISION OF THIS COMMENT SAID. That
-      // revision named FOUR absent regions, which was a spot-check presented as
-      // an enumeration. Cross-checking the WHOLE region list against the enum
-      // gives THIRTEEN, plus `us-east-1` which is absent by design. Re-derive
-      // it rather than trusting this list -- both tables move:
+      // THE SIZE OF THE GAP IS NOT STABLE, AND THIS NOTE HAS BEEN WRONG ABOUT
+      // IT TWICE, in two different ways. One revision named FOUR absent
+      // regions, which was never right -- a spot-check written as an
+      // enumeration. The cross-check that replaced it said THIRTEEN, five of
+      // them commercial, which WAS right when written and is not now: the SDK
+      // enum GREW under it. Treat any count below as a dated measurement and
+      // re-derive, because both tables move:
       //
       //   node --input-type=module -e "
       //   import { BucketLocationConstraint } from '@aws-sdk/client-s3';
@@ -6147,28 +6149,33 @@ export class S3BucketProvider implements ResourceProvider {
       //   const m = new Set(Object.values(BucketLocationConstraint));
       //   console.log(RegionInfo.regions.map(r => r.name).filter(r => !m.has(r)).sort().join('\n'));"
       //
-      // Measured 2026-08-27 against this repo's `@aws-sdk/client-s3` 3.1018.0
-      // (33 enum members) and `aws-cdk-lib` 2.244.0 (46 regions). Five are
-      // COMMERCIAL (`RegionInfo.get(r).partition === 'aws'`): `ap-east-2`,
-      // `ap-southeast-6`, `ap-southeast-7`, `ca-west-1`, `mx-central-1`. The
-      // other eight are NON-commercial -- `eusc-de-east-1` is `aws-eusc`, and
-      // the seven `aws-iso*` regions (which share four partitions between
-      // them, not one each) are
-      // `eu-isoe-west-1`, `us-iso-east-1`, `us-iso-west-1`, `us-isob-east-1`,
-      // `us-isob-west-1`, `us-isof-east-1`, `us-isof-south-1`.
+      // Measured 2026-09-09 against this repo's `@aws-sdk/client-s3` 3.1126.0
+      // (38 enum members) and `aws-cdk-lib` 2.268.0 (46 regions): EIGHT absent
+      // regions, plus `us-east-1` which is absent by design. NONE of the eight
+      // is commercial -- `eusc-de-east-1` is `aws-eusc`, its own partition, and
+      // the seven `aws-iso*` ones (which share four partitions between them,
+      // not one each) are `eu-isoe-west-1`, `us-iso-east-1`, `us-iso-west-1`,
+      // `us-isob-east-1`, `us-isob-west-1`, `us-isof-east-1`,
+      // `us-isof-south-1`. The five the previous revision called COMMERCIAL --
+      // `ap-east-2`, `ap-southeast-6`, `ap-southeast-7`, `ca-west-1`,
+      // `mx-central-1` -- all became enum members between 3.1018.0 and 3.1126.0.
       //
-      // What is MEASURED is the type claim, and the scope is worth stating
-      // because an earlier revision of this note overstated it: all thirteen
-      // are absent from the enum, and this cast sends whichever of them
-      // `getRegion()` reports. Whether S3 ACCEPTS each one was not probed
-      // region by region -- no deploy was made to any of them -- so nothing
-      // here asserts that. The code cannot tell them apart in any case: the
-      // gate below is a single `!== 'us-east-1'` with NO partition branch, so
-      // all thirteen traverse byte-identical lines.
+      // NOTHING BELOW DEPENDS ON THAT COUNT, which is why the drift was a
+      // documentation defect here and not a bug. (It WAS a live defect in the
+      // three sibling fences, which each pinned `ca-west-1` for its absence and
+      // went inert when it became a member -- see
+      // `tests/unit/_enum-absent-region.ts`.) What is MEASURED is the type
+      // claim: this cast sends whichever region `getRegion()` reports, member
+      // or not, and no membership test exists on the path. Whether S3
+      // ACCEPTS each one was not probed region by region -- no deploy was made
+      // to any of them -- so nothing here asserts that. The code cannot tell
+      // them apart in any case: the gate below is a single `!== 'us-east-1'`
+      // with NO partition branch, so every region traverses byte-identical
+      // lines.
       //
       // WHY THE CAST IS NOT DROPPED -- both alternatives measured, not assumed:
       //  - the SDK has NOT widened the field. `CreateBucketConfiguration`
-      //    (`@aws-sdk/client-s3` `dist-types/models/models_0.d.ts:1581`) still
+      //    (`@aws-sdk/client-s3` `dist-types/models/models_0.d.ts:1764`) still
       //    declares `LocationConstraint?: BucketLocationConstraint | undefined`.
       //  - declaring this bag's `LocationConstraint` as `string` and deleting
       //    the `as` does NOT compile. `tsc` then fails at the
@@ -6183,8 +6190,8 @@ export class S3BucketProvider implements ResourceProvider {
       // not deletion of the cast -- that fails to compile, as above. It is a
       // future "soundness fix" that filters the region to enum members: that
       // COMPILES, leaves every `us-east-1` / `eu-west-1` case green, and
-      // silently omits `CreateBucketConfiguration` for the thirteen -- which
-      // BREAKS THE DEPLOY in each of them, loudly.
+      // silently omits `CreateBucketConfiguration` for every region the enum
+      // does not list -- which BREAKS THE DEPLOY in each of them, loudly.
       //
       // `this.s3Client` is REGION-BOUND (`constructor`: `awsClients.s3`; and
       // `getRegion()` reads `this.s3Client.config.region()`), so a `ca-west-1`
@@ -6210,7 +6217,7 @@ export class S3BucketProvider implements ResourceProvider {
       // wrong-region bucket is not the outcome; a failed deploy is.
       //
       // `tests/unit/provisioning/s3-bucket-provider-location-constraint-case.test.ts`
-      // pins enum-ABSENT regions on the wire verbatim for exactly that reason,
+      // pins every swept region on the wire verbatim for exactly that reason,
       // and the three SIBLING cast sites are pinned the same way in their own
       // suites (`tests/unit/assets/asset-storage.test.ts`,
       // `tests/unit/cli/bootstrap.test.ts`, `tests/unit/cli/state-migrate.test.ts`)

--- a/tests/unit/_enum-absent-region.ts
+++ b/tests/unit/_enum-absent-region.ts
@@ -1,0 +1,78 @@
+/**
+ * The region literal the `as BucketLocationConstraint` fences pin.
+ *
+ * Four call sites cast a region string to `BucketLocationConstraint` — three of
+ * them the raw one, and `s3-bucket-provider.ts` its own `canonicalRegion` —
+ * (`src/provisioning/providers/s3-bucket-provider.ts`,
+ * `src/cli/commands/bootstrap.ts`, `src/cli/commands/state-migrate.ts`,
+ * `src/assets/asset-storage.ts`). The regression each of their fences exists to
+ * catch is a future "soundness fix" that FILTERS the region to enum members:
+ * that compiles, leaves every `us-east-1` / `eu-west-1` row green, and silently
+ * omits `CreateBucketConfiguration` for a region the enum does not list -- which
+ * on a REGIONAL endpoint answers `IllegalLocationConstraintException`, i.e. a
+ * broken deploy. A fence can only catch it while the region it pins is ABSENT
+ * from the enum.
+ *
+ * ## Why this is one shared constant instead of a literal per file
+ *
+ * The three sibling fences each pinned `'ca-west-1'` and each said, in prose,
+ * that they chose it BECAUSE the enum omitted it. `@aws-sdk/client-s3` then
+ * moved 3.1018.0 -> 3.1126.0 and the enum grew 33 -> 38 members, taking
+ * `ca-west-1` with it -- so all three went SILENTLY inert, green through the
+ * exact regression they were written for, at three of the four cast sites
+ * (issue [#2862](https://github.com/go-to-k/cdkd/issues/2862)). Nothing could
+ * have caught that, because each file states the property in a comment and none
+ * of them asserts it.
+ *
+ * Sharing the literal makes the property assertable CENTRALLY, instead of in a
+ * copy per fenced row that drifts silently. Only one of the four suites is
+ * actually PREVENTED from hosting its own — `asset-storage.test.ts` mocks
+ * `@aws-sdk/client-s3` with a plain factory carrying no enum, so a guard written
+ * there would assert against its own mock (`state-migrate.test.ts` mocks with an
+ * `importActual` spread and `bootstrap.test.ts` does not mock the module at all,
+ * so either COULD).
+ *
+ * **The guard is in
+ * `tests/unit/provisioning/s3-bucket-provider-location-constraint-case.test.ts`**,
+ * beside the sweep that pins the same property for the fourth site, and
+ * `tests/unit/scripts/enum-absent-region-binding.test.ts` repeats it as a
+ * guard-the-guard for its own rows — deliberately, since those rows would
+ * otherwise report a healthy binding to a dead value. Both copies read live
+ * data, so they cannot disagree. Either fails the moment this region becomes a
+ * member, turning the silent inertness above into a loud failure naming what to
+ * re-derive.
+ *
+ * Re-derive a replacement with:
+ *
+ *   node --input-type=module -e "
+ *   import { BucketLocationConstraint } from '@aws-sdk/client-s3';
+ *   import { RegionInfo } from 'aws-cdk-lib/region-info';
+ *   const m = new Set(Object.values(BucketLocationConstraint));
+ *   console.log(RegionInfo.regions.map(r => r.name).filter(r => !m.has(r)).sort().join('\n'));"
+ *
+ * As of 2026-09-09 every absent region is non-commercial (`aws-iso*` plus
+ * `eusc-de-east-1`); `us-east-1` is absent BY DESIGN and must never be chosen,
+ * since it is the one region whose `LocationConstraint` must be OMITTED.
+ *
+ * The partition does not matter to the gate this constant is pinning: all four
+ * sites decide the `CreateBucketConfiguration` on a bare `region !== 'us-east-1'`
+ * with no partition branch, so an `aws-iso` region traverses byte-identical
+ * lines to a commercial one. It DOES reach other code on three of them —
+ * `bootstrap.ts`, `state-migrate.ts` and `asset-storage.ts` each build a bucket
+ * policy through `buildDenyExternalAccessPolicy`, which derives the partition
+ * one hop further out (`src/utils/deny-external-access-policy.ts`), so the ARNs
+ * there read
+ * `arn:aws-iso:s3:::…` where `ca-west-1` produced `arn:aws:s3:::…`. No row
+ * asserts those ARNs, so the change is inert today; a row added later that DOES
+ * assert one must derive the partition rather than hardcode `aws`.
+ */
+export const ENUM_ABSENT_REGION = 'us-iso-east-1';
+
+/**
+ * A mis-cased spelling of {@link ENUM_ABSENT_REGION}, for the row where issue
+ * [#2282](https://github.com/go-to-k/cdkd/issues/2282)'s case fold and issue
+ * [#2322](https://github.com/go-to-k/cdkd/issues/2322)'s enum widening meet:
+ * the fold has to survive on a region the enum omits. Kept beside the constant
+ * so re-deriving one cannot leave the other behind.
+ */
+export const ENUM_ABSENT_REGION_MISCASED = 'US-Iso-East-1';

--- a/tests/unit/assets/asset-storage.test.ts
+++ b/tests/unit/assets/asset-storage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { ENUM_ABSENT_REGION } from '../_enum-absent-region.js';
 
 const { mockS3Send, mockEcrSend, mockLoggerInfo, mockLoggerDebug, mockLoggerWarn } = vi.hoisted(
   () => ({
@@ -523,8 +524,15 @@ describe('ensureAssetStorage', () => {
   // constraint answers `IllegalLocationConstraintException` -- the deploy
   // fails. (Not, as an earlier revision of the sibling suite claimed, a quiet
   // bucket in us-east-1: that default belongs to the GLOBAL endpoint, which
-  // this path does not use.) `ca-west-1` is absent from the 33-member enum,
-  // so this row reds where `ap-northeast-1` cannot.
+  // this path does not use.) The region must be one the enum OMITS, or this
+  // row is no better than the `ap-northeast-1` one above. It is not spelled
+  // here: this row pinned `ca-west-1` until the SDK enum grew and took it,
+  // leaving the row silently inert (issue #2862). `ENUM_ABSENT_REGION` carries
+  // the choice, and the guard that fails when it stops being absent lives in
+  // `tests/unit/provisioning/`
+  // `s3-bucket-provider-location-constraint-case.test.ts` -- it cannot live
+  // here, because this file mocks `@aws-sdk/client-s3` with a factory that
+  // carries no enum, so a guard written here would assert against the mock.
   it('passes LocationConstraint for a region ABSENT from the SDK enum (issue #2322)', async () => {
     mockS3Send.mockImplementation((cmd: { _type: string }) =>
       cmd._type === 'HeadBucket' ? Promise.reject(awsError('NotFound', 404)) : Promise.resolve({})
@@ -534,11 +542,11 @@ describe('ensureAssetStorage', () => {
         ? Promise.reject(awsError('RepositoryNotFoundException'))
         : Promise.resolve({})
     );
-    const { options } = makeOptions({ region: 'ca-west-1' });
+    const { options } = makeOptions({ region: ENUM_ABSENT_REGION });
     await ensureAssetStorage(options);
     const createCall = mockS3Send.mock.calls.find((c) => c[0]._type === 'CreateBucket')![0];
     expect(createCall.CreateBucketConfiguration).toEqual({
-      LocationConstraint: 'ca-west-1',
+      LocationConstraint: ENUM_ABSENT_REGION,
     });
   });
 

--- a/tests/unit/cli/bootstrap.test.ts
+++ b/tests/unit/cli/bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { ENUM_ABSENT_REGION } from '../_enum-absent-region.js';
 
 const {
   mockS3Send,
@@ -425,23 +426,29 @@ describe('cdkd bootstrap', () => {
   // fail on a change that stops sending it -- and `src/cli/commands/
   // bootstrap.ts:274` casts with `as BucketLocationConstraint` just like the S3
   // provider. This is the POSITIVE polarity, and it deliberately uses a region
-  // the 33-member enum omits: a future "soundness fix" filtering the region to
-  // enum members would omit `CreateBucketConfiguration` here, and on a REGIONAL
+  // the enum omits: a future "soundness fix" filtering the region to enum
+  // members would omit `CreateBucketConfiguration` here, and on a REGIONAL
   // endpoint that answers `IllegalLocationConstraintException` -- a failed
   // bootstrap, not a bucket quietly placed in us-east-1 (that default belongs
-  // to the GLOBAL endpoint, which this path does not use). A member region such
-  // as `eu-west-1` would stay green through exactly that change.
+  // to the GLOBAL endpoint, which this path does not use). A MEMBER region
+  // would stay green through exactly that change, which is why the region is
+  // not spelled here: this row pinned `ca-west-1` until the SDK enum grew and
+  // took it, leaving the row silently inert (issue #2862). `ENUM_ABSENT_REGION`
+  // carries the choice, and the guard that fails when it stops being absent
+  // lives in `tests/unit/provisioning/`
+  // `s3-bucket-provider-location-constraint-case.test.ts` -- see that module's
+  // doc comment for why it cannot live here.
   it('sends the LocationConstraint for a region ABSENT from the SDK enum (issue #2322)', async () => {
     scriptStateBucket(false);
 
-    await runBootstrap(['--region', 'ca-west-1']);
+    await runBootstrap(['--region', ENUM_ABSENT_REGION]);
 
     const createBucket = mockS3Send.mock.calls
       .map((c) => c[0] as { constructor: { name: string }; input: Record<string, unknown> })
       .find((c) => c.constructor.name === 'CreateBucketCommand');
     expect(createBucket, 'no CreateBucket issued - anchor drifted?').toBeDefined();
     expect(createBucket!.input['CreateBucketConfiguration']).toEqual({
-      LocationConstraint: 'ca-west-1',
+      LocationConstraint: ENUM_ABSENT_REGION,
     });
   });
 

--- a/tests/unit/cli/state-migrate.test.ts
+++ b/tests/unit/cli/state-migrate.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { ENUM_ABSENT_REGION } from '../_enum-absent-region.js';
 /**
  * Issue [#2275](https://github.com/go-to-k/cdkd/issues/2275): the confirmation
  * prompt this file drives now REFUSES a non-interactive stdin
@@ -628,10 +629,15 @@ describe('cdkd state migrate', () => {
   // `IllegalLocationConstraintException`: the migrate fails outright. (It does
   // NOT quietly create the bucket in us-east-1 -- that default is a property of
   // the GLOBAL `s3.amazonaws.com` endpoint, which this path never uses.)
-  // `ca-west-1` is absent from the 33-member enum, so the row discriminates
-  // where a member region such as `eu-west-1` would not.
+  // The region must be one the enum OMITS, or the row does not discriminate at
+  // all. It is not spelled here: this row pinned `ca-west-1` until the SDK enum
+  // grew and took it, leaving the row silently inert (issue #2862).
+  // `ENUM_ABSENT_REGION` carries the choice, and the guard that fails when it
+  // stops being absent lives in `tests/unit/provisioning/`
+  // `s3-bucket-provider-location-constraint-case.test.ts` -- see that module's
+  // doc comment for why it cannot live here.
   it('sends the destination LocationConstraint for a region ABSENT from the SDK enum (issue #2322)', async () => {
-    const region = 'ca-west-1';
+    const region = ENUM_ABSENT_REGION;
     mockResolveBucketRegion.mockResolvedValue(region);
     planS3({
       HeadBucketCommand: [

--- a/tests/unit/provisioning/s3-bucket-provider-location-constraint-case.test.ts
+++ b/tests/unit/provisioning/s3-bucket-provider-location-constraint-case.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { BucketLocationConstraint, NoSuchBucket } from '@aws-sdk/client-s3';
 import { RegionInfo } from 'aws-cdk-lib/region-info';
+import { ENUM_ABSENT_REGION, ENUM_ABSENT_REGION_MISCASED } from '../_enum-absent-region.js';
 
 const { mockSend, clientRegion } = vi.hoisted(() => ({
   mockSend: vi.fn(),
@@ -56,9 +57,10 @@ const CREATE_PROPS = { BucketName: BUCKET };
  * deploy dies before anything else on the path runs. The issue framed the gate
  * alone; the send side is the same root cause one expression over and is fixed
  * by the same line. (Validity is about the NAME, not about
- * `BucketLocationConstraint` membership: that enum has 33 members, excludes
- * `us-east-1` by design, and also excludes THIRTEEN further real regions that
- * the provider's `as` cast still sends and S3 still accepts. The cast is a
+ * `BucketLocationConstraint` membership: that enum excludes `us-east-1` by
+ * design, and also excludes a HANDFUL of further real regions -- eight as of
+ * 2026-09-09, a count that moves with every SDK release -- that the provider's
+ * `as` cast still sends and S3 still accepts. The cast is a
  * DELIBERATE widening of a stale enum, settled in issue
  * [#2322](https://github.com/go-to-k/cdkd/issues/2322) and fenced by the last
  * describe block in this file rather than only described in prose.)
@@ -194,7 +196,8 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
 
   /**
    * Issue [#2322](https://github.com/go-to-k/cdkd/issues/2322) -- the regions
-   * the SDK's own enum does NOT contain.
+   * the cast must send unfiltered, whether or not the SDK's own enum lists
+   * them.
    *
    * `create()` sends `canonicalRegion as BucketLocationConstraint`, and the
    * `as` asserts a membership the value need not have. That is settled as
@@ -229,7 +232,7 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
    * The list is DERIVED, not spot-checked -- and an earlier revision of this
    * file, of the provider comment, and of issue #2282's changelog entry each
    * named FOUR regions, which was a spot-check written as an enumeration. The
-   * full cross-check gives thirteen. Re-derive with:
+   * full cross-check gave thirteen when this list was written. Re-derive with:
    *
    *   node --input-type=module -e "
    *   import { BucketLocationConstraint } from '@aws-sdk/client-s3';
@@ -240,21 +243,41 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
    * Measured 2026-08-27 against `@aws-sdk/client-s3` 3.1018.0 (33 members) and
    * `aws-cdk-lib` 2.244.0 (46 regions).
    *
-   * ALL THIRTEEN ARE SWEPT, with no commercial / non-commercial split. An
-   * earlier revision swept six it called "commercial" and excluded seven
-   * `aws-iso*` ones as "not reachable from a commercial deploy". Both halves
-   * were wrong: `eusc-de-east-1` is NOT commercial (`RegionInfo.get(...)
-   * .partition === 'aws-eusc'`, its own partition, which `PARTITION_TABLE` in
-   * `src/utils/aws-partition.ts` lists beside the iso prefixes), so only FIVE
-   * of the six were; and cdkd has explicit `aws-iso*` support, so the
-   * exclusion was overstated too. The honest reason to sweep them all is that
-   * the production gate is a single `canonicalRegion !== 'us-east-1'` with NO
-   * partition branch -- every one of the thirteen traverses byte-identical
-   * lines -- so a partition split would have been a classification to maintain
-   * that bought no coverage. Sweeping all thirteen deletes the question.
+   * THE LIST IS FROZEN ON PURPOSE, AND FIVE ENTRIES ARE NO LONGER ABSENT.
+   * Re-measured 2026-09-09 against `@aws-sdk/client-s3` 3.1126.0 (38 members)
+   * and `aws-cdk-lib` 2.268.0: `ap-east-2`, `ap-southeast-6`, `ap-southeast-7`,
+   * `ca-west-1` and `mx-central-1` became enum members, leaving eight absent.
+   * They are KEPT rather than pruned, because what this block fences does not
+   * depend on enum membership at all: the production gate is a single
+   * `canonicalRegion !== 'us-east-1'` with NO membership test and NO partition
+   * branch, so EVERY region here must reach `CreateBucketConfiguration`
+   * unfiltered, member or not. Keeping the member entries is what gives the
+   * sweep BOTH polarities: with members and non-members present, either
+   * direction of a membership filter reds, where a non-members-only list
+   * catches only the one. Pruning to the currently-absent eight would delete
+   * that half and re-tie this file to a table that has already moved under it
+   * twice (issue [#2862](https://github.com/go-to-k/cdkd/issues/2862)), so the
+   * rows below FENCE the freeze rather than leaving it a policy stated only
+   * here: one requires a MEMBER to survive, its non-member twin is the
+   * `still has a gap to fence` row, and a LENGTH floor stops the list being
+   * pruned to one entry of each. Removing a name is therefore a deliberate
+   * edit to that floor. Whether a name is still a REAL region is a separate
+   * question, answered by the `pins only REAL regions` row.
+   *
+   * The sweep has no commercial / non-commercial split, and that also predates
+   * the enum growth. An earlier revision swept six it called "commercial" and
+   * excluded seven `aws-iso*` ones as "not reachable from a commercial
+   * deploy". Both halves were wrong: `eusc-de-east-1` is NOT commercial
+   * (`RegionInfo.get(...).partition === 'aws-eusc'`, its own partition, which
+   * `PARTITION_TABLE` in `src/utils/aws-partition.ts` lists beside the iso
+   * prefixes), so only FIVE of the six were; and cdkd has explicit `aws-iso*`
+   * support, so the exclusion was overstated too. Since every entry traverses
+   * byte-identical lines, a partition split would have been a classification
+   * to maintain that bought no coverage. Sweeping them all deletes the
+   * question.
    */
-  describe('regions ABSENT from the SDK enum (issue #2322)', () => {
-    const ENUM_ABSENT_REGIONS: string[] = [
+  describe('regions the cast must send unfiltered (issue #2322)', () => {
+    const CAST_SWEPT_REGIONS: string[] = [
       'ap-east-2',
       'ap-southeast-6',
       'ap-southeast-7',
@@ -280,10 +303,61 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
       // above documents, asserted rather than described.
       const real = new Set(RegionInfo.regions.map((r) => r.name));
       expect(real.has('eu-west-1'), 'guard-the-guard: the table must be non-empty').toBe(true);
-      expect(ENUM_ABSENT_REGIONS.filter((r) => !real.has(r))).toEqual([]);
+      expect(CAST_SWEPT_REGIONS.filter((r) => !real.has(r))).toEqual([]);
     });
 
-    it('still has a gap to fence -- the shipped enum omits these regions', () => {
+    it('still sweeps at least one enum MEMBER -- the frozen list keeps both polarities', () => {
+      // The list is FROZEN (see the block comment), and freezing it was a
+      // policy stated in prose with nothing enforcing it: a contributor who
+      // "tidied" it down to the currently-absent regions would get a fully
+      // green suite while deleting the member half. This row is that fence.
+      // Its non-member twin is the `still has a gap to fence` row below -- not
+      // restated here, because two spellings of one assertion drift.
+      //
+      // What the member entries buy is ordinary-region coverage of this same
+      // sweep plus the stability of the freeze; the regression they are NOT
+      // needed for is the membership filter, which the non-member rows catch.
+      const members = new Set<string>(Object.values(BucketLocationConstraint));
+      expect(members.has('eu-west-1'), 'guard-the-guard: the enum must be populated').toBe(true);
+      expect(
+        CAST_SWEPT_REGIONS.filter((r) => members.has(r)),
+        'no swept region is an enum MEMBER -- the member polarity was pruned away'
+      ).not.toEqual([]);
+      // The polarity assertions alone are satisfied by a two-entry list (one
+      // member, one not), so the FREEZE itself needs its own floor -- without
+      // it the block comment's claim to fence the freeze is false.
+      expect(
+        CAST_SWEPT_REGIONS.length,
+        'the frozen sweep list lost entries -- it may only grow'
+      ).toBeGreaterThanOrEqual(13);
+    });
+
+    it('the region the other three cast-site fences pin is still absent from the enum', () => {
+      // `bootstrap.test.ts`, `state-migrate.test.ts` and `asset-storage.test.ts`
+      // each fence one of the other three `as BucketLocationConstraint` cast
+      // sites, and each is only able to catch a membership filter while the
+      // region it passes is ABSENT from the enum. They pinned `ca-west-1` and
+      // went silently inert when the SDK enum grew and took it (issue #2862).
+      // The assertion lives here, once, rather than in three copies that drift
+      // -- see `tests/unit/_enum-absent-region.ts` for which of them could have
+      // hosted their own and which could not.
+      const members = new Set<string>(Object.values(BucketLocationConstraint));
+      expect(members.has('eu-west-1'), 'guard-the-guard: the enum must be populated').toBe(true);
+      expect(ENUM_ABSENT_REGION).not.toBe('us-east-1');
+      expect(
+        members.has(ENUM_ABSENT_REGION),
+        `${ENUM_ABSENT_REGION} is now an enum member -- the three sibling fences are INERT; re-derive it in tests/unit/_enum-absent-region.ts`
+      ).toBe(false);
+
+      // The mis-cased spelling must FOLD to the canonical one AND differ from
+      // it. Without the second half, setting MISCASED to the all-lowercase
+      // spelling passes here and hollows out the fold row below, which would
+      // then stay green with `canonicalizeRegion` deleted.
+      expect(ENUM_ABSENT_REGION_MISCASED.toLowerCase()).toBe(ENUM_ABSENT_REGION);
+      expect(ENUM_ABSENT_REGION_MISCASED).not.toBe(ENUM_ABSENT_REGION);
+    });
+
+    it('still has a gap to fence -- the shipped enum omits SOME of these regions', () => {
       const members = new Set<string>(Object.values(BucketLocationConstraint));
 
       // Guard-the-guard. An always-empty `members` would make the absence
@@ -299,12 +373,12 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
       // being an interesting case. It reds only when the enum has caught up on
       // ALL of them, which is the moment the cast, this block and the provider
       // comment should all be re-derived rather than trusted.
-      const absent = ENUM_ABSENT_REGIONS.filter((r) => !members.has(r));
+      const absent = CAST_SWEPT_REGIONS.filter((r) => !members.has(r));
       expect(absent.length).toBeGreaterThan(0);
     });
 
-    it.each(ENUM_ABSENT_REGIONS)(
-      'sends LocationConstraint %s verbatim even though the enum omits it',
+    it.each(CAST_SWEPT_REGIONS)(
+      'sends LocationConstraint %s verbatim, with no membership filter',
       async (region) => {
         clientRegion.value = region;
 
@@ -318,14 +392,17 @@ describe('S3BucketProvider create() CreateBucketConfiguration region case (issue
 
     it('folds a mis-cased enum-absent region rather than dropping the field', async () => {
       // The two issues meet here: #2282's fold has to survive on a region
-      // #2322 says is not in the enum. `CA-West-1` must reach the wire as
-      // `ca-west-1` -- not raw (S3 rejects it as a NAME) and not omitted.
-      clientRegion.value = 'CA-West-1';
+      // #2322 says is not in the enum, so the region must be a CURRENTLY
+      // absent one -- this row read `CA-West-1` until the SDK enum grew and
+      // took `ca-west-1`, at which point the intersection it names stopped
+      // being exercised (issue #2862). The mis-cased spelling must reach the
+      // wire folded -- not raw (S3 rejects it as a NAME) and not omitted.
+      clientRegion.value = ENUM_ABSENT_REGION_MISCASED;
 
       await provider.create('MyBucket', RESOURCE_TYPE, CREATE_PROPS);
 
       expect(createBucketInput()['CreateBucketConfiguration']).toEqual({
-        LocationConstraint: 'ca-west-1',
+        LocationConstraint: ENUM_ABSENT_REGION,
       });
     });
   });

--- a/tests/unit/scripts/enum-absent-region-binding.test.ts
+++ b/tests/unit/scripts/enum-absent-region-binding.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { BucketLocationConstraint } from '@aws-sdk/client-s3';
+import { RegionInfo } from 'aws-cdk-lib/region-info';
+import { ENUM_ABSENT_REGION } from '../_enum-absent-region.js';
+
+/**
+ * Fences the BINDING between the shared enum-absent region constant and the
+ * four suites that depend on it.
+ *
+ * Four call sites cast a region string to `BucketLocationConstraint`
+ * (`s3-bucket-provider.ts`, `bootstrap.ts`, `state-migrate.ts`,
+ * `asset-storage.ts`). Each is fenced by ONE test row passing a region the SDK
+ * enum does NOT list, so that a future "soundness fix" filtering the region to
+ * enum members reds instead of silently omitting `CreateBucketConfiguration` --
+ * which on a REGIONAL endpoint answers `IllegalLocationConstraintException`,
+ * i.e. a broken deploy.
+ *
+ * Three of those rows hardcoded `ca-west-1`. `@aws-sdk/client-s3` 3.1018.0 ->
+ * 3.1126.0 grew the enum 33 -> 38 members and took `ca-west-1` with it, so all
+ * three went SILENTLY inert -- green through the exact regression they exist to
+ * catch (issue [#2862](https://github.com/go-to-k/cdkd/issues/2862)).
+ *
+ * `s3-bucket-provider-location-constraint-case.test.ts` asserts the constant is
+ * still absent, so the enum growing again is LOUD. This file fences what that
+ * cannot see: a fenced row that stops passing the constant leaves it intact and
+ * worthless.
+ *
+ * ## Why a PINNED use site rather than source analysis
+ *
+ * The question is "does THIS row still pass the shared constant", and three
+ * revisions answered the harder question "is this identifier used anywhere in
+ * this file" instead. All three were measured wrong on the real tree: a
+ * `[a-z]{2}`-headed region regex was blind to `eusc-de-east-1` (one of the eight
+ * currently-absent regions); a quote-pairing reader desynced on apostrophes in
+ * comments, so a hardcoded `'eusc-de-east-1'` sat in the source and the row
+ * passed; and an import-stripping matcher ate 692 characters of real code out of
+ * `asset-storage.test.ts`, failing an untouched file.
+ *
+ * Pinning the exact expression each row uses needs none of that -- it is the
+ * same primitive as the import check, an exact substring. Its worst case is a
+ * VISIBLE failure when someone reformats that one line, with the expected string
+ * in the message; the alternatives' worst case was a silent pass or a false
+ * failure on a file nobody touched.
+ *
+ * A scan for hardcoded region LITERALS was also tried and REMOVED. These suites
+ * are the only home of the issue-1794 `DenyExternalAccess` partition rows, which
+ * legitimately name `aws-iso` / `aws-eusc` regions; the scan would have reported
+ * one as an inert fence, with a remedy that is wrong there (a partition row
+ * needs a region/partition PAIR) -- and a check that misdiagnoses gets deleted
+ * along with the coverage beside it. The use-site pin catches the same mutation
+ * without looking at anything but its own line.
+ *
+ * ## Known bounds
+ *
+ * - A FIFTH `as BucketLocationConstraint` cast site landing in `src/` gets no
+ *   row here; `SIBLING_CAST_SITES` is a literal list and this file cannot see
+ *   the new site. The length assertion below makes SHRINKING it loud, not
+ *   growing the source.
+ * - The pinned expression is compared verbatim, so a purely cosmetic edit to
+ *   that line reds. That is the trade named above, and the fix is one line.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UNIT_ROOT = join(HERE, '..');
+
+/**
+ * The suites fencing the three NON-provider cast sites: the import specifier
+ * each must use, and the EXACT expression through which it passes the constant.
+ *
+ * A literal list, not a glob, and its length is asserted below -- deleting an
+ * entry would otherwise just register fewer `it.each` rows and stay green,
+ * which is the same silent-shrink mutation this file exists to stop, one level
+ * up.
+ */
+const SIBLING_CAST_SITES = [
+  {
+    file: 'cli/bootstrap.test.ts',
+    specifier: '../_enum-absent-region.js',
+    useSite: "'--region', ENUM_ABSENT_REGION",
+  },
+  {
+    file: 'cli/state-migrate.test.ts',
+    specifier: '../_enum-absent-region.js',
+    useSite: 'const region = ENUM_ABSENT_REGION;',
+  },
+  {
+    file: 'assets/asset-storage.test.ts',
+    specifier: '../_enum-absent-region.js',
+    useSite: '{ region: ENUM_ABSENT_REGION }',
+  },
+] as const;
+
+/**
+ * The provider suite's own row where issue #2282's case fold meets #2322's enum
+ * widening -- it must pass the MIS-CASED spelling, or the fold is untested. Its
+ * sibling constants are pinned in that suite; what is pinned here is that the
+ * row still READS the mis-cased one.
+ */
+const MISCASED_CAST_SITE = {
+  file: 'provisioning/s3-bucket-provider-location-constraint-case.test.ts',
+  specifier: '../_enum-absent-region.js',
+  useSite: 'clientRegion.value = ENUM_ABSENT_REGION_MISCASED;',
+} as const;
+
+const read = (relative: string): string => readFileSync(join(UNIT_ROOT, relative), 'utf8');
+
+/** Every real region name, from the same table the guard suite measures against. */
+const allRegions = (): Set<string> => new Set(RegionInfo.regions.map((r) => r.name));
+
+/** Enum members, i.e. the regions a membership filter would KEEP. */
+const enumMembers = (): Set<string> => new Set<string>(Object.values(BucketLocationConstraint));
+
+const ALL_CAST_SITES = [...SIBLING_CAST_SITES, MISCASED_CAST_SITE] as const;
+
+describe('the enum-absent region constant is BOUND to every row that depends on it', () => {
+  it('guard-the-guard: the constant is a real region, not us-east-1, and the enum still omits it', () => {
+    // Duplicated on purpose from the provider suite's own guard row: the rows
+    // below are otherwise satisfied by a binding to a constant that has itself
+    // gone stale, and this file would report a healthy binding to a dead value.
+    // Both copies read live data, so they cannot disagree.
+    const members = enumMembers();
+    expect(members.has('eu-west-1'), 'the enum must be populated').toBe(true);
+    expect(allRegions().has(ENUM_ABSENT_REGION), 'must be a real region').toBe(true);
+    // `us-east-1` is absent BY DESIGN and is the one region whose
+    // LocationConstraint must be OMITTED, so it can never fence these sites.
+    expect(ENUM_ABSENT_REGION).not.toBe('us-east-1');
+    expect(members.has(ENUM_ABSENT_REGION)).toBe(false);
+  });
+
+  it('covers all three non-provider cast sites -- the list cannot shrink silently', () => {
+    // Without this, deleting an entry registers fewer rows and the file stays
+    // green: the population would leave without a failure, which is exactly the
+    // shape of the defect being fenced.
+    expect(SIBLING_CAST_SITES.map((s) => s.file)).toEqual([
+      'cli/bootstrap.test.ts',
+      'cli/state-migrate.test.ts',
+      'assets/asset-storage.test.ts',
+    ]);
+  });
+
+  it.each(ALL_CAST_SITES)('$file imports the constant it fences with', ({ file, specifier }) => {
+    const source = read(file);
+    expect(
+      source.includes(`from '${specifier}'`),
+      `${file} no longer imports from ${specifier}`
+    ).toBe(true);
+    expect(
+      source.includes('ENUM_ABSENT_REGION'),
+      `${file} imports from ${specifier} but names no ENUM_ABSENT_REGION binding`
+    ).toBe(true);
+  });
+
+  it.each(ALL_CAST_SITES)('$file still PASSES the constant at its fenced row', ({
+    file,
+    useSite,
+  }) => {
+    // The import alone proves nothing -- an unused import is caught by neither
+    // `tsconfig.test.json` (`noUnusedLocals: false`) nor lint (scoped to
+    // `src/**`) -- so a row swapping in a hardcoded region while keeping the
+    // import would go inert exactly the way `ca-west-1` did.
+    expect(
+      read(file).includes(useSite),
+      `${file} no longer contains \`${useSite}\` -- if the row was reformatted, update this pin; if it stopped passing the shared constant, that fence is INERT`
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`@aws-sdk/client-s3` moved 3.1018.0 -> 3.1126.0 and its `BucketLocationConstraint`
enum grew from 33 to 38 members. `aws-cdk-lib` is still 46 regions, so the
`RegionInfo` side did not move.

Closes #2862

## The issue understated this: three fences were INERT, not just a stale comment

Four call sites cast a region string to `BucketLocationConstraint`
(`s3-bucket-provider.ts`, `bootstrap.ts`, `state-migrate.ts`,
`asset-storage.ts`). Each is fenced by one test row passing a region the enum
does NOT list, so that a future "soundness fix" filtering the region to enum
members reds — instead of silently omitting `CreateBucketConfiguration`, which
on a REGIONAL endpoint answers `IllegalLocationConstraintException`, i.e. a
broken deploy.

**Three of those rows hardcoded `ca-west-1`, and said in prose that they chose
it because the enum omitted it.** It is now a member, so all three went silently
inert — green through the exact regression they exist to catch, at three of the
four sites.

Measured one site at a time, applying a membership filter to each source file in
turn and restoring byte-exact between probes:

| site | rows red WITH this change | rows red BEFORE it |
|---|---|---|
| `s3-bucket-provider.ts` | 9 (the 8 non-member sweep rows + the mis-cased row) | 9 |
| `bootstrap.ts` | 1 | **0** |
| `state-migrate.ts` | 1 | **0** |
| `asset-storage.ts` | 1 | **0** |

## The fix

The region literal moves to `tests/unit/_enum-absent-region.ts`, asserted in
`s3-bucket-provider-location-constraint-case.test.ts` — a suite with the unmocked
enum, beside the sweep that pins the same property for the fourth site — with a
failure message naming the file to re-derive. That turns the silent inertness
into a loud failure.

`tests/unit/scripts/enum-absent-region-binding.test.ts` fences what that guard
cannot see: a fenced row that stops passing the shared constant. It pins the
EXACT expression each row uses and compares it by substring, the same primitive
as the import check.

**Getting that fence right took four attempts, and the first three are recorded
in its header** — each was measured wrong on the real tree rather than reasoned
about:

1. a `[a-z]{2}`-headed region regex was blind to `eusc-de-east-1` — one of the
   eight currently-absent regions, i.e. a hole in exactly the guarded
   population;
2. after replacing it with live `RegionInfo` data, a quote-pairing reader
   desynced on apostrophes in comments (`doesn't`), so a hardcoded
   `'eusc-de-east-1'` sat in the source and the row still passed;
3. an import-stripping matcher then ate 692 characters of real code out of
   `asset-storage.test.ts` and failed an untouched file.

All three answered the harder question "is this identifier used anywhere in this
file". Round 4's test review pointed out the right question is "does THIS row
still pass the constant", which needs no analysis at all. A scan for hardcoded
region LITERALS was also written and then REMOVED: round 4's security review
showed it would red-flag the legitimate `DenyExternalAccess` partition rows in
the same files, with a remedy that is wrong there — and a check that misdiagnoses
gets deleted along with the coverage beside it.

`us-iso-east-1` is safe at all four sites: each decides the
`CreateBucketConfiguration` on a bare `region !== 'us-east-1'` with no partition
branch. It does reach other code on three of them — the bucket policy's ARNs now
read `arn:aws-iso:s3:::…` — which no row asserts today and which the shared
module records for whoever adds one.

## The documentation half (what the issue was filed for)

The provider comment and its test file both stated the gap as THIRTEEN regions,
five of them commercial. On the comment's own convention (excluding `us-east-1`,
absent by design) it is now **EIGHT, and none is commercial** — `ap-east-2`,
`ap-southeast-6`, `ap-southeast-7`, `ca-west-1` and `mx-central-1` all became
members. Re-measured 2026-09-09 and restated. (The issue body's own "9" was not
like-for-like; corrected in a comment there.)

This is the second time the note went stale by tying its rationale to enum
membership, so the rationale is **untied from it** rather than the number patched
a third time: what the block fences is that no membership filter exists on this
path, true whatever the enum currently lists.

The frozen 13-region sweep list is KEPT rather than pruned to the current eight,
and that decision is now fenced rather than stated in prose — pruning it was the
mutation the round-1 test review found nothing caught. The mis-cased row (where
go-to-k/cdkd#2282's case fold and go-to-k/cdkd#2322's enum widening meet) also
went inert with `ca-west-1`, and its shared spelling is now pinned to DIFFER from
the canonical one, since equal spellings would leave that row green with
`canonicalizeRegion` deleted.

## Review

Four rounds. `/review-pr`'s heuristic resolves **`3-axis`** here — 444 LOC / 8
files is `1-reviewer` by size, biased UP by the `src/provisioning/providers/**`
path — plus the additive `pr-security-reviewer` on the same trigger. Rounds 1-3
were code + test only; round 4 ran the full **spec + code + test + security**
set at the current head.

- **Round 1** found the blocker above — both reviewers independently. Also: a
  title claiming the enum omits every swept entry; a "Both were true when
  written" clause that mislabelled the earlier FOUR-region revision.
- **Round 2** found three false claims I had written (the "only suite with an
  unmocked enum" — `bootstrap.test.ts` mocks nothing; "the partition does not
  matter to any of the four call sites" — three derive one; a `derivePartitionAndUrlSuffix`
  reference a grepper cannot find), plus a hole where setting the mis-cased
  constant to the all-lowercase spelling hollowed out the fold row.
- **Round 3** found the regex hole (1) above, and that
  `expect(source).toContain('ENUM_ABSENT_REGION')` was vacuous — every sibling
  names the constant in a comment.
- **Round 4** (spec + code + test + security, no blockers) found four mutations
  nothing caught, a stale SDK line citation the version bump had left behind
  (`models_0.d.ts:1581` → `:1764`), and three comments asserting more than the
  code did — including one claiming to fence the sweep list's freeze while a
  two-entry list passed. It also supplied the use-site formulation that closed
  the bound the previous rounds had given up on.

Every finding is fixed. No blockers outstanding, and no bound is left stated
where it could be fenced.

## Test plan

- `vp check --fix` + `vp run check` — 0 errors (10 pre-existing warnings in
  untouched provider files).
- `vp run typecheck:test`, `vp run build` — pass.
- `vp test run` — 956 files / 20825 tests passed, 1 skipped, no type errors, no
  `Errors` line.
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — no artifact went
  stale.
- **Mutation probes, one at a time, tree restored byte-exact between each** (two
  were re-run after the first attempt proved unfaithful — a type-only import and
  an enum-free mock made the first filter drop every region rather than only
  non-members; only the faithful results are reported):

  | probe | result |
  |---|---|
  | membership filter at each of the four cast sites | reds 9 / 1 / 1 / 1 |
  | shared constant becomes a member | reds, naming the file to re-derive |
  | sweep list pruned to the currently-absent 8 | reds (`the member polarity was pruned away`) |
  | sweep list pruned to 2 entries, one of each polarity | reds (`expected 2 to be greater than or equal to 13`) |
  | a fenced row swaps in a MEMBER region, import kept | reds |
  | the mis-cased fold row swaps in the canonical spelling | reds |
  | an entry is deleted from the cast-site list | reds |
  | sibling hardcodes `eusc-de-east-1` | reds |
  | sibling drops the import | reds |

  The last four were all UNCAUGHT until round 4; each was re-measured after the
  fix, with the tree restored byte-exact between probes.

- **`/run-integ s3-vectors`: PASS** — rc=0, VectorBucket / state file / CMK all
  verified gone after destroy.
- **`/run-integ s3-event-notification`: PASS** — rc=0, 14 resources destroyed /
  0 errors, all 3 phases (S3 -> Lambda notification fired end-to-end). Run after
  the round-4 fixes, because touching the provider file again staled the marker
  the first run had set. Post-run scan clean both times: 0 `state.json` objects
  account-wide, no matching IAM roles / Lambdas / S3 buckets / DynamoDB tables.
  Both recorded in `docs/_generated/integ-last-run.tsv`; the second refreshes the
  `integ-destroy` marker this PR needs (`src/provisioning/providers/**`).
- **No integ covers the changed lines, and this is said plainly**: the provider
  diff is comments only, and the integ harness runs in `us-east-1`, which is the
  one region that takes the `LocationConstraint`-omitted branch — so no fixture
  exercises the cast at all. The integ is here because the gate requires a clean
  real-AWS destroy, not because it verifies this change; the unit rows and the
  mutation table above are what verify it.

## Not run

`/pick-integ` ranked eight stale S3 fixtures as P0 (changed-area + stale). Two
were run (`s3-vectors`, `s3-event-notification`). The other six —
`s3-replication-and-filter` (29d), `s3-subconfig-removal` (28d),
`s3-directory-bucket` (27d), `s3-analytics-inventory` (27d), `s3-cloudfront`
(20d), `s3-tables` (17d) — are staleness hygiene rather than coverage of this
change, for the reason in the bullet above. Named here rather than silently
dropped.
