### PR TITLE
docs(architecture): say what "Zero External CDK Dependencies" is actually true of

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -990,8 +990,31 @@ Each layer has clear responsibilities
 ### 5. Zero External CDK Dependencies
 
 - Synthesis, assembly reading, and asset publishing are all implemented internally
-- No dependency on `@aws-cdk/toolkit-lib`, `@aws-cdk/cloud-assembly-api`, or `@aws-cdk/cdk-assets-lib`
-- Only `aws-cdk-lib` is required as the user's CDK app dependency
+- cdkd's own source imports no `@aws-cdk/*` package — not `@aws-cdk/toolkit-lib`, `@aws-cdk/cloud-assembly-api`, nor `@aws-cdk/cdk-assets-lib`
+- Only `aws-cdk-lib` is required as the user's CDK app dependency, and cdkd does not declare it either — it is a `devDependency` used by the test suite, never imported by the shipped code
+
+Read those bullets as statements about cdkd's CODE, not about your
+`node_modules`. Installing cdkd does bring `@aws-cdk/*` packages in, all of
+them through [`cdk-local`](https://www.npmjs.com/package/cdk-local) — the
+local-emulation engine cdkd depends on at runtime. It depends on
+`@aws-cdk/toolkit-lib` and `@aws-cdk/cloud-assembly-api` directly, reaches
+`@aws-cdk/cdk-assets-lib` through the former, and declares `aws-cdk-lib` /
+`constructs` as non-optional peers, which npm and pnpm install automatically.
+So a tree inspected after `npm install @go-to-k/cdkd` contains all four, and
+`npm explain <package>` names `cdk-local` at the root of every chain.
+
+Re-derive the set rather than trusting this paragraph — it moves with
+cdk-local's own dependencies, and the hop count is what goes stale first:
+
+```bash
+ls node_modules/@aws-cdk/
+npm explain @aws-cdk/cdk-assets-lib   # prints the whole chain, not just the parent
+```
+
+Note that a strict-layout `pnpm` checkout of THIS repo shows none of them,
+because they are cdk-local's dependencies rather than cdkd's; `ls
+node_modules/@aws-cdk/` here is not the user's view and cannot settle this
+question.
 
 ## Performance Characteristics
 


### PR DESCRIPTION
## Summary

`docs/architecture.md`'s design principle 5 claimed:

> - No dependency on `@aws-cdk/toolkit-lib`, `@aws-cdk/cloud-assembly-api`, or `@aws-cdk/cdk-assets-lib`

All three are in every user's installed tree.

Closes #2864

## Measured

Against the published `@go-to-k/cdkd@0.288.2` in an empty npm project
(2026-09-09), `ls node_modules/@aws-cdk/` lists all three. Every chain roots at
`cdk-local`, a runtime dependency of cdkd — directly for `toolkit-lib` and
`cloud-assembly-api`, one hop further for `cdk-assets-lib`:

```
@aws-cdk/cdk-assets-lib@1.5.0
  @aws-cdk/cdk-assets-lib@"^1" from @aws-cdk/toolkit-lib@1.40.1
    @aws-cdk/toolkit-lib@"^1.28.0" from cdk-local@0.147.22
      cdk-local@"^0.147.7" from @go-to-k/cdkd@0.288.2
```

That two-hop detail is a correction to my own first draft, which said cdk-local
"depends on them directly" — true of two of the three.

## What the claim was true of, and is kept

`grep -rn "from '@aws-cdk/" src/` is **0**, so the bullet's real content —
cdkd's own source imports none of them — survives, now stated as such. The
third bullet gains the `aws-cdk-lib` half settled by go-to-k/cdkd#2861: cdkd
does not declare that either; it is a `devDependency` the unit suite reads,
never imported by shipped code.

## The trap that made this hard to see

A strict-layout `pnpm` checkout of THIS repo lists **none** of the three, since
they are cdk-local's dependencies rather than cdkd's — so `ls
node_modules/@aws-cdk/` run in a cdkd worktree *supports the wording it
disproves*. The new paragraph says so explicitly, so the next reader does not
close this as invalid off the local check. It also points at
`npm explain @aws-cdk/cdk-assets-lib` rather than its parent, because the hop
count is the part that goes stale first.

## Test plan

- `vp check --fix` + `vp run check`, `vp run typecheck:test`, `vp run build` — pass.
- `vp test run` — 956 files / 20825 tests passed, 1 skipped, no type errors.
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — no artifact went stale.
- Every claim in the new text re-derived against the tree rather than carried
  from the issue: the `src/` grep, `package.json`'s devDependencies vs
  peerDependencies, and cdk-local's own `dependencies` / `peerDependencies`.
- Diff is `docs/architecture.md` only — no `src/**`, so no integ gate is
  implicated. Review tier `inline` (docs-only down-bias).
