### PR TITLE
chore(integ): record the two merge-gate integ runs for #2740

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -151,7 +151,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-09T04:59:36Z	PASS	83	verify.sh	rc ok, orph clean
+lambda	2026-09-09T15:52:00Z	PASS	102	verify.sh	2740 merge-gate broad-set arm (deploy-engine in scope); 9 deleted 0 err, deployments/ logs swept, 0 orph
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans
@@ -220,7 +220,7 @@ nlb-source-nat	2026-09-05T22:46:07Z	PASS	355	verify.sh	PR2662 gate run; destroy 
 nodejs-function	2026-08-10T05:29:23Z	PASS	50	verify.sh	0810 P2 sweep b8; rc ok, 0 orph
 opensearch-domain-getatt	2026-08-10T08:05:51Z	PASS	1798	verify.sh	0810 P2 sweep b13; 60m CC delete floor ok, 0 err 0 orph
 orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
-output-never-resolved-diff	2026-09-09T14:16:24Z	PASS	160	verify.sh	2740 review round 7: re-run on the final fixture (trap note only); destroy 0 err 0 orph 0 versions
+output-never-resolved-diff	2026-09-09T15:44:00Z	PASS	163	verify.sh	2740 merge-gate re-run on the merge head; all 6 phases, destroy 0 err 0 orph 0 versions
 outputs-only-export	2026-08-18T06:09:14Z	PASS	160	verify.sh	13 checks; #1921 preview + no-phantom arms; re-run after review round 3; destroy clean
 parameters	2026-07-26T18:04:53Z	PASS	24	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 propagation-races-2	2026-07-26T18:57:55Z	PASS	169	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean


### PR DESCRIPTION
Two real-AWS runs from the maintainer merge of #2773 that had nowhere to land at the time.

That merge ran the gates from the reviewing worktree, after the PR branch was
frozen at its final head, so neither run could be committed to it:

- `output-never-resolved-diff` on the merge head — all six phases, destroy 0
  errors / 0 orphans / 0 surviving state-object versions.
- `lambda` for the `integ-broad` arm (`src/deployment/deploy-engine.ts` is in
  that gate's scope) — 9 deleted / 0 errors, and its accumulated
  `cdkd/LambdaStack/us-east-1/deployments/` event logs (21 files, from this and
  earlier runs) swept back to zero.

Both rows carry the later timestamps and the observed durations. Ledger-only
change; the one-row-per-test invariant is preserved by
`vp run integ-ledger-normalize`.