### PR TITLE
docs(schemas): say what to do when the refresh job produces nothing to read

### DIFF
--- a/.github/workflows/backfill-umbrella-sync.yml
+++ b/.github/workflows/backfill-umbrella-sync.yml
@@ -31,6 +31,12 @@ on:
   # untouched and asks a human to fix the label or the markers, and this is how
   # the sync is retried afterwards without waiting for the next coverage-map
   # change — which, on a quiet week, may not come.
+  #
+  # How and when to use it, and what it will NOT fix:
+  # https://github.com/go-to-k/cdkd/blob/main/docs/schema-refresh-runbook.md
+  # (linked HERE because this file is what a person opens when the job
+  # misbehaves — and the runbook's only other inbound links are written by a
+  # pull request that, in exactly that case, does not exist)
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -88,6 +88,9 @@ on:
   # property mid-cycle, the recovery path if GitHub suspends the schedule on an
   # inactive repo, and the only way to exercise this job before its first
   # scheduled fire.
+  #
+  # How and when to use it, and what it will NOT fix:
+  # https://github.com/go-to-k/cdkd/blob/main/docs/schema-refresh-runbook.md
   workflow_dispatch:
 
 # Deny by default, grant per job — the house style set by release.yml.

--- a/docs/provider-rules.md
+++ b/docs/provider-rules.md
@@ -2040,7 +2040,13 @@ This dumps every unaccounted property per type into `tests/fixtures/cfn-schemas/
 
 AWS adds properties to existing resource types fairly regularly — measured at roughly **3 writable properties per month** across the whole Tier 1 surface. Until a property is in the fixture, cdkd does not merely leave it unwired: it **silently drops it**, because the SDK-vs-Cloud-Control routing table is derived offline from these fixtures and a property absent from them produces no `silentDrop` entry to auto-route on. That is the issue [#614](https://github.com/go-to-k/cdkd/issues/614) failure class arriving through the one input the #614 machinery cannot see (issue [#2718](https://github.com/go-to-k/cdkd/issues/2718)).
 
-Two mechanisms cover it.
+Two mechanisms cover it. The operator's side of the first — what arrives, what
+to do with each class, and what to do when NOTHING arrives because the job
+failed or never fired — is the
+[CFn schema refresh runbook](schema-refresh-runbook.md). That page is `unlisted`
+and is linked from the pull requests the job opens, so this is the pointer that
+still works when there is no pull request to read.
+
 
 **Daily, automatically.** `.github/workflows/cfn-schema-refresh.yml` runs `vp run gen:cfn-schemas-from-zip` every day and, on drift, opens a PR carrying the mechanical regeneration. A day with no drift opens nothing — the job stops at the drift check — and the open-PR guard bounds concurrency at one, so the cadence costs a short run per quiet day rather than a review cycle. It reads AWS's **public** schema bundle, so no AWS credentials and no CI IAM role are involved — the prerequisite that kept this manual. Only fixtures that actually changed are rewritten (`generatedAt`-only churn is excluded from the comparison), so the PR diff is the real drift.
 

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -32,7 +32,7 @@ tell you anything the title has not already said.
 
 | What you see | What to do |
 | --- | --- |
-| No pull request | Nothing. Most days are this. |
+| No pull request | Usually nothing — most days are this. But it also looks like this when the job FAILED or never fired: see [When there is nothing to read](#when-there-is-nothing-to-read). |
 | A pull request with a plain title, no label | Nothing needs a decision. Read the diff, squash merge. |
 | `— N decisions needed` in the title, `needs-decision` label, assigned to you | N things need your call. They are labelled **D1**–**DN** in the body. |
 | A pull request saying the nested-key check failed unreadably | Read that job's log; the other sections still hold. |
@@ -325,6 +325,77 @@ The open-pull-request guard matches on the branch prefix
 branch under that prefix reads as the open refresh PR, and the job will push its
 drift onto your branch. Fork PRs are excluded, so this only applies to branches
 here.
+
+## When there is nothing to read
+
+Every other section of this page starts from a pull request. These are the two
+states where none exists, and from the outside they look identical to a quiet
+day.
+
+**Tell them apart from the run list, not from the absence.**
+
+```bash
+gh run list --workflow cfn-schema-refresh.yml --limit 5
+gh run list --workflow backfill-umbrella-sync.yml --limit 5
+```
+
+- a `schedule` run, `success`, no pull request → **no drift**. Nothing to do.
+  The run log says `0 drifted, N unchanged` and `No fixture drift — nothing to do.`
+- a run with `failure` → the job broke. Read its log; the failing step names the
+  cause.
+- **no run at all for today** → see the cadence below before concluding anything.
+
+### The schedule runs late, and that is normal
+
+The cron is `04:37 UTC`, deliberately off the hour because the top of the hour
+is contended on GitHub's shared pool. Both scheduled fires measured so far
+landed hours after it:
+
+| Scheduled for | Actually ran | Late by |
+| --- | --- | --- |
+| 2026-09-08 04:37 UTC | 09:00:10 UTC | 4h 23m |
+| 2026-09-09 04:37 UTC | 09:06:43 UTC | 4h 30m |
+
+Two points, so read them as "the delay is real and has been about four and a
+half hours", not as a bound. An absence at the nominal time means nothing; an
+absence late in the day is worth a look.
+
+### Running either job by hand
+
+Both carry `workflow_dispatch` for this, and it is the documented recovery path
+rather than a convenience.
+
+```bash
+gh workflow run cfn-schema-refresh.yml      # capture, compare, open or update the PR
+gh workflow run backfill-umbrella-sync.yml  # re-render the umbrella issue's checklist from main
+```
+
+`cfn-schema-refresh` behaves exactly as a scheduled run: no drift means no pull
+request. It is also the only way to exercise the job before its first scheduled
+fire, and the reactive path when someone reports a dropped property mid-cycle
+rather than waiting for tomorrow.
+
+`backfill-umbrella-sync` normally fires only on a push to `main` that touches
+`src/provisioning/property-coverage.generated.ts`, so on a quiet week it may not
+run for days — and if it failed on the last such push, the umbrella issue keeps
+its previous checklist until the next one. A dispatch closes that gap. It
+rewrites only the block between its markers; the human-written provenance
+outside them is never touched. Measured on 2026-09-09: a dispatch took the
+issue from 285 rows to 288 in under a minute, leaving 7,655 characters of
+provenance intact.
+
+### What a dispatch will not fix
+
+- **A schedule GitHub has suspended.** GitHub stops running scheduled workflows
+  on a repository that has gone inactive, and a manual run does not re-enable
+  them — a push to the default branch does. (The inactivity threshold is
+  GitHub's and is not restated here; check their docs rather than a number
+  copied into this page, which would go stale silently.)
+- **A wrong answer.** A dispatch re-runs the job; it does not re-decide
+  anything. If a pull request already carries a decision you disagree with,
+  the sections above are the path, not another run.
+- **A closed refresh pull request.** Re-running reuses the branch name and
+  replaces it, which is the same-day-replacement case described above.
 
 ## Related
 

--- a/scripts/refresh-cfn-schemas.mjs
+++ b/scripts/refresh-cfn-schemas.mjs
@@ -4,6 +4,12 @@
 /**
  * Refresh CFn schema property-name fixtures for the SDK Provider coverage test.
  *
+ * The OPERATOR's side of the daily job that runs this — what arrives, what to do
+ * with each class, and what to do when nothing arrives because the job failed or
+ * never fired — is `docs/schema-refresh-runbook.md`. Linked here because that
+ * page is `unlisted` and its other inbound links are written by a pull request
+ * which, in exactly the failure case, does not exist.
+ *
  * For each resource type registered via `registerAllProviders` in
  * `src/provisioning/register-providers.ts`, this script:
  *   1. Calls `cloudformation:DescribeType` (RESOURCE) to fetch the canonical


### PR DESCRIPTION
## Summary

Closes go-to-k/cdkd#2876.

Every section of `docs/schema-refresh-runbook.md` starts from a pull request. The two states where none exists — the job **failed**, or it **never fired** — look identical from the outside to a quiet day, and the page said nothing about either.

Walked into rather than imagined: `backfill-umbrella-sync.yml` failed on both of the only two runs it ever had (go-to-k/cdkd#2858) and nobody noticed for a day. After the fix landed it still could not run, because it fires only on a push touching `property-coverage.generated.ts` — so the umbrella issue sat at 285 rows while `main` said 288, with three properties invisible to anyone working that backlog. A `workflow_dispatch` fixed it in under a minute (run 34375335108).

## What the new section says

- **Tell "no drift" from "did not run" off the run list**, not off the absence — with the log line each state produces.
- **The schedule runs late, and that is normal.** Stated as TWO measurements rather than a rule: both scheduled fires so far landed 4h23m and 4h30m after the `04:37 UTC` cron. That establishes the delay is real and roughly four and a half hours; it does not establish a bound, and the page says so.
- **`gh workflow run` for each job**, what each does when dispatched, and that a `cfn-schema-refresh` dispatch still opens nothing when there is no drift.
- **What a dispatch will NOT fix**: a schedule GitHub has suspended for inactivity (a push re-enables it, a run does not), a decision you disagree with, or a closed refresh PR whose branch a re-run replaces.

The GitHub inactivity threshold is deliberately not restated as a number — a figure copied into this page would go stale with nothing watching it.

## The page was also unreachable in the case it is for

Its only inbound links are the ones the JOB writes: the PR preamble (`.github/refresh-pr-preamble.md:39`) and the diagnosis footer (`scripts/diagnose-schema-refresh.mjs:1506`). Finding it required a pull request to exist — and the states it is most needed for are the ones where none does.

**Adding it to a docs index is not the fix.** It carries `unlisted: true` in its frontmatter, so its absence from the site index is a decision, and its own description says who it is for: "what a maintainer does when it opens a pull request". Not user documentation, not general contributor documentation — so `docs/cli-reference.md` would be the wrong home for the same reason.

The pointers went where someone actually looks when the job misbehaves:

- both workflows' `workflow_dispatch` comments;
- `scripts/refresh-cfn-schemas.mjs`'s header — the one file in the chain that named the runbook nowhere;
- a back-link from `docs/provider-rules.md`, which the runbook already linked one way.

`.claude/rules/layout-scripts.md` was the obvious fourth home and is deliberately **not** used: it sits 28 bytes under its payload cap, and a script header reaches an agent editing this chain more precisely than that file's `paths:` glob would.

## Test plan

- 963 files / 20,982 tests green; `vp run check` clean.
- The dispatch claim is measured, not asserted: run 34375335108 took the umbrella issue from 285 rows to 288, leaving the 7,655 characters of human-written provenance outside the markers untouched.
- The cadence figures are read off the two `schedule` runs in the workflow's history.

## Notes

- **No changelog entry**: docs and comments only; no behaviour delta in the shipped binary.
- No integ gate scope touched; no AWS call involved.
