### PR TITLE
docs(rules): record that a provider's returned attributes REPLACE the record

### DIFF
--- a/.claude/rules/provider-replay-and-refusals.md
+++ b/.claude/rules/provider-replay-and-refusals.md
@@ -267,6 +267,15 @@ Carrying the values matters beyond capacity: the #1160 absent-field RESET is
 derived from the PREVIOUS side, so an identity-only baseline silently disables
 every removal for as long as the record stays junk.
 
+**`attributes` REPLACES the record rather than merging into it** —
+`deploy-engine.ts` reads `result.attributes ?? (wasReplaced ? undefined : current)`
+— so a partial map ERASES every key it omits. That makes a HEAL the dangerous
+shape: `ApiGatewayV2Provider` gated its `ExecuteApiArn` re-record on the endpoint
+alone, so a transient `fabricated: true` from `getAccountInfo` wrote
+`{ApiId, ApiEndpoint}` over a correct ARN and a same-deploy `Fn::GetAtt`
+hard-threw with the loss persisted — worse than not healing at all. Gate the
+write on EVERY member being in hand; return nothing otherwise.
+
 **`effectiveProperties` is the OTHER half of that remedy, and the two answer
 different questions** (issue #1591). Seeding the comparison baseline from the
 live read fixes the case where STATE is already junk; `effectiveProperties`


### PR DESCRIPTION
## Summary

Closes go-to-k/cdkd#2880.

`deploy-engine.ts` reads `result.attributes ?? (result.wasReplaced ? undefined : currentResource.attributes)`, so what a provider returns in `attributes` **replaces** the record rather than merging into it — a partial map erases every key it omits. That contract was documented in **no rule file** (grepped across `.claude/rules/`).

It is what made `ApiGatewayV2Provider`'s `ExecuteApiArn` heal a data-destroying change in go-to-k/cdkd#2843: gated on the endpoint alone, a transient `fabricated: true` from `getAccountInfo` — which does not reject when STS is unreachable — wrote `{ApiId, ApiEndpoint}` over a map already holding a correct ARN, and a consumer's `Fn::GetAtt` in the same deploy then hard-threw non-retryably with the loss persisted. Before the heal existed the update returned nothing and the create-time value survived, so the fix was worse than not healing.

`provider-replay-and-refusals.md` is the home because it already owns `ResourceUpdateResult` and the properties-side analogue `effectiveProperties`. One rule sentence plus the measured anchor, ~590 B.

## Why the issue's other two additions are not here

The issue proposed two mutation-probe lessons for `testing.md`. They are dropped on **budget**, not on doubt, and the numbers are worth recording because they say the agent-instruction corpus is currently saturated:

| home | headroom | needed |
| --- | --- | --- |
| `testing.md` (binding path budget 52,000 B) | 542 B | 568 B |
| `tests/setup.ts` path (56,000 B) | 1,122 B | co-loads, also over |
| `.claude/skills/verify-pr/SKILL.md` (23,000 B) | 24 B | not even a pointer line |

The satellite the payload fence prescribes does not fit content that applies **wherever you probe**: a `paths:` glob wide enough to reach that moment co-loads with `testing.md` and blows the same budget — measured by trying it, 53,764 B and 57,184 B on the two budgeted paths — while a glob narrow enough to avoid them does not reach the moment. Picking the narrow one would be routing around the fence rather than respecting it.

Funding it by trimming text my own change did not make stale is what the fence explicitly forbids. And on the repo's own hook > skill > memory ladder these two are judgement lessons, the weakest rung, in a section that already carries the family doctrine ("Do not report a mutation result you did not run"). They stay in per-machine agent memory, recorded on the issue with these figures so a future budget revision has them.

## Test plan

- 967 files / 21,061 tests green, including the rule-file payload fences that rejected the larger version of this change.
- The contract quoted is read off `deploy-engine.ts`, and the incident off go-to-k/cdkd#2843's own review round.

## Notes

- **No changelog entry**: agent instructions only; no behaviour delta in the shipped binary.
- No integ gate scope touched; no AWS call involved.
