### PR TITLE
chore(ci): drop the runner's Google Chrome apt repository before playwright --with-deps

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -53,6 +53,45 @@ jobs:
       # og:image/twitter:image meta tags ("Chromium not available" warning).
       # The guard step below turns that silent degradation into a hard failure.
       # Direct .bin path: setup-vp does not put pnpm on PATH.
+      #
+      # The Google Chrome apt repository is dropped first because
+      # `--with-deps` runs `apt-get update`, which fails WHOLESALE when any
+      # single configured repository is unhealthy -- and the runner image
+      # ships that one by default. This job reads no package from it:
+      # Playwright manages its own Chromium build, and `--with-deps` is here
+      # only for the shared OS libraries that build needs.
+      #
+      # Measured 2026-09-09 (issue #2879): Google served a `Packages.gz` whose
+      # hash did not match the `Release` file beside it, so the step died with
+      # `Hash Sum mismatch` for ~90 minutes. `main` went red at 17:26:41Z and
+      # every docs-touching PR became unmergeable behind `ci-green-gate`;
+      # seven retries over that window reproduced it before the mirror
+      # recovered on its own.
+      #
+      # This removes the COUPLING, not the class: another configured
+      # repository going unhealthy would still red this step, because
+      # `apt-get update` has no per-repository tolerance.
+      #
+      # Matched by CONTENT rather than by filename: the runner image's name
+      # for this list is not something this workflow can verify, and a
+      # filename that stops matching would make the step a silent no-op --
+      # green until the next outage. The receipt is printed for the same
+      # reason, so a future run shows whether it removed anything.
+      - name: Drop the Google Chrome apt repository (issue #2879)
+        run: |
+          set -euo pipefail
+          before=$(grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null || true)
+          if [ -n "${before}" ]; then
+            echo "removing: ${before}"
+            printf '%s\n' "${before}" | xargs -r sudo rm -f
+          else
+            echo "no dl.google.com repository configured -- nothing to remove"
+          fi
+          if grep -rq 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null; then
+            echo "still configured after removal:" >&2
+            grep -rn 'dl\.google\.com' /etc/apt/sources.list.d/ >&2
+            exit 1
+          fi
       - run: ./node_modules/.bin/playwright install --with-deps chromium
       - run: vp run docs:build
       - name: Assert OG images were generated


### PR DESCRIPTION
## Summary

`docs-deploy`'s `playwright install --with-deps chromium` step runs `apt-get update`, which fails **wholesale** when any single configured repository is unhealthy. The `ubuntu-latest` image ships `https://dl.google.com/linux/chrome-stable/deb` by default, and this job reads no package from it — Playwright manages its own Chromium build, and `--with-deps` is here only for the shared OS libraries that build needs.

This drops that repository from the sources before the step runs.

## What made it worth fixing rather than waiting out

Measured 2026-09-09 (go-to-k/cdkd#2879): Google served a `Packages.gz` whose hash did not match the `Release` file beside it, so the step died with `Hash Sum mismatch`. `main` went red at 17:26:41Z — **before** either PR run that hit it — and every docs-touching PR became unmergeable behind `ci-green-gate`. Seven retries over roughly ninety minutes reproduced the identical hash pair before the mirror recovered on its own.

The recovery removed the urgency, not the defect. The coupling is still there and fires again whenever any third party's index is briefly inconsistent.

## Matched by content, not by filename

The runner image's name for that list is not something this workflow can verify, and a filename that stopped matching would make the step a **silent no-op** — green until the next outage, which is the failure mode worth avoiding in a step whose whole job is to prevent one.

So the step greps `/etc/apt/sources.list.d/` for `dl.google.com`, removes what it finds, prints the receipt, and **fails if anything still references the repository afterwards**. A future run shows whether it did anything.

## What this does NOT do

It removes the **coupling**, not the class. Another configured repository going unhealthy would still red the step, because `apt-get update` has no per-repository tolerance. That is stated in the workflow comment rather than left for a reader to discover.

## Test plan

- **Self-verifying**: `docs-deploy.yml`'s own `pull_request` paths include `.github/workflows/docs-deploy.yml`, so this PR runs the workflow it changes. The `build` check on this PR IS the test.
- **Step logic exercised in three cases before committing**, each restored between runs:

  | case | result |
  | --- | --- |
  | the real runner shape (`google-chrome.list` present alongside others) | removes the Google list, leaves siblings, rc 0 |
  | absent | prints `nothing to remove`, rc 0 — a no-op, not a failure |
  | a differently-**named** file carrying the same repository | removed — the case a filename match would have missed |

- YAML parsed and the step's `run` block checked with `bash -n`; the new step sits immediately before `playwright install`, at index 3 of 8.
- `vp run check` 0 errors, `typecheck:test` clean, build green, full suite 967 files / 21,066 tests.

No changelog entry: CI-only, no delta in what the shipped binary does.

Closes #2879
