### PR TITLE
docs(diff): ground the resolveBestEffort clone in the ownership contract, not the retired resolver write-back

### DIFF
--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -159,14 +159,18 @@ export class DiffCalculator {
 
     // Snapshot each resource's `Fn::GetAtt` / `Fn::Sub`-`${X.Attr}` references
     // from the RAW template, in one pass, for promoteInPlaceAttributeDependents
-    // below: it needs the references a property declared, while the comparison
-    // loop reads the RESOLVED values, where a GetAtt to an
+    // below: it needs the references a property DECLARED, while the comparison
+    // loop works on RESOLVED values, where a GetAtt to an
     // in-place-referenceable resource has already been replaced by its resolved
-    // current value.
-    // (This said the loop "mutates in place" the desired property intrinsics.
-    // It never has: go-to-k/cdkd#939 added the clone in the same change that
-    // wrote the note, and the loop collects into a fresh bag, so the RAW
-    // template keeps its intrinsics and this snapshot reads them either way.)
+    // current value. A PRECOMPUTATION rather than a rescue — that function also
+    // receives `desiredTemplate` and could re-extract from it, since the raw
+    // template survives the loop (`resolveBestEffort` clones, and collects into
+    // a fresh bag).
+    // (This note used to say the loop "mutates in place" the desired property
+    // intrinsics. It has not since go-to-k/cdkd#939 added the clone in the same
+    // change that wrote the note; BEFORE that commit the loop ran the real
+    // resolver over the template leaf itself, and `resolveSub` wrote its
+    // resolved values back into the caller's `Fn::Sub` variable map.)
     const rawGetAttRefs = new Map<string, Map<string, Map<string, Set<string>>>>();
     for (const [logicalId, desiredResource] of Object.entries(desiredResources)) {
       if (desiredResource.Type === 'AWS::CDK::Metadata') continue;
@@ -789,18 +793,24 @@ export class DiffCalculator {
     for (const [key, value] of Object.entries(properties)) {
       try {
         // Resolve a CLONE. The reason is the OWNERSHIP contract, not any
-        // resolver's behaviour: this value is a leaf of the SHARED desired
-        // template, which the deploy phase re-resolves later against the
-        // in-flight state, so nothing here may let a resolver write through it.
-        // A resolved current-state value baked in here would still be read as a
+        // resolver's behaviour: this value is a leaf of a template its CALLER
+        // still shares with other consumers, so nothing here may let a resolver
+        // write through it. Both call sites share it — `cdkd diff` hands the
+        // same object on to the Outputs resolution that follows, and `cdkd
+        // deploy` re-resolves it against the in-flight state and provisions
+        // from it. The deploy one is the consequence with teeth: a
+        // resolved current-state value baked in here would still be read as a
         // literal then, and a genuinely-changed dependent of an in-place-updated
         // upstream would be skipped. Cloning makes that impossible whatever the
         // resolver does.
-        // (It is not true that the resolver mutates its input today: `resolveSub`
-        // wrote back into the caller's `Fn::Sub` variable map until
-        // go-to-k/cdkd#2764 retired it, and this comment named that write-back.
-        // Kept as history so the clone is not deleted as dead weight, which is
-        // exactly what the contract forbids.)
+        // (The resolver does not mutate its input today: `resolveSub` wrote back
+        // into the caller's `Fn::Sub` variable map until go-to-k/cdkd#2764
+        // retired it, and this comment named that write-back. Kept as history so
+        // the clone is not read as dead weight. Both directions are fenced:
+        // `tests/unit/deployment/intrinsic-sub-variables-not-mutated.test.ts`
+        // holds the resolver to it, and deleting this `structuredClone` reds
+        // `does NOT mutate the desired template (resolveBestEffort resolves a
+        // clone)` in `tests/unit/analyzer/diff-calculator.test.ts`.)
         resolved[key] = await resolveFn(structuredClone(value));
       } catch {
         resolved[key] = value;

--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -158,11 +158,16 @@ export class DiffCalculator {
     const processedLogicalIds = new Set<string>();
 
     // Snapshot each resource's `Fn::GetAtt` / `Fn::Sub`-`${X.Attr}` references
-    // from the RAW template, BEFORE the comparison loop below resolves (and
-    // mutates in place) the desired property intrinsics. Used by
-    // promoteInPlaceAttributeDependents — once `resolveBestEffort` runs, a
-    // GetAtt to an in-place-referenceable resource has been replaced by its
-    // resolved current value and can no longer be detected.
+    // from the RAW template, in one pass, for promoteInPlaceAttributeDependents
+    // below: it needs the references a property declared, while the comparison
+    // loop reads the RESOLVED values, where a GetAtt to an
+    // in-place-referenceable resource has already been replaced by its resolved
+    // current value.
+    // (This said the loop "mutates in place" the desired property intrinsics
+    // and that a GetAtt "can no longer be detected" once `resolveBestEffort`
+    // runs. Both were false from the commit that wrote them — go-to-k/cdkd#939
+    // added the clone in the same change, so the template keeps its raw
+    // intrinsics.)
     const rawGetAttRefs = new Map<string, Map<string, Map<string, Set<string>>>>();
     for (const [logicalId, desiredResource] of Object.entries(desiredResources)) {
       if (desiredResource.Type === 'AWS::CDK::Metadata') continue;
@@ -784,14 +789,19 @@ export class DiffCalculator {
     const resolved: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(properties)) {
       try {
-        // Resolve a CLONE: the intrinsic resolver mutates its input in place
-        // (e.g. it rewrites an `Fn::Sub` variable map's `Fn::GetAtt` to the
-        // resolved current-state value). Mutating the shared desired template
-        // here would bake the OLD value into the template, so the deploy phase's
-        // later re-resolution (against the in-flight state, where an in-place-
-        // updated upstream now holds its NEW value) would still see the stale
-        // literal and skip a genuinely-changed dependent. Cloning keeps the raw
-        // intrinsics intact for the deploy phase.
+        // Resolve a CLONE. The reason is the OWNERSHIP contract, not any
+        // resolver's behaviour: this value is a leaf of the SHARED desired
+        // template, which the deploy phase re-resolves later against the
+        // in-flight state, so nothing here may let a resolver write through it.
+        // A resolved current-state value baked in here would still be read as a
+        // literal then, and a genuinely-changed dependent of an in-place-updated
+        // upstream would be skipped. Cloning makes that impossible whatever the
+        // resolver does.
+        // (It is not true that the resolver mutates its input today: `resolveSub`
+        // wrote back into the caller's `Fn::Sub` variable map until
+        // go-to-k/cdkd#2764 retired it, and this comment named that write-back.
+        // Kept as history so the clone is not deleted as dead weight, which is
+        // exactly what the contract forbids.)
         resolved[key] = await resolveFn(structuredClone(value));
       } catch {
         resolved[key] = value;

--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -164,8 +164,8 @@ export class DiffCalculator {
     // in-place-referenceable resource has already been replaced by its resolved
     // current value. A PRECOMPUTATION rather than a rescue — that function also
     // receives `desiredTemplate` and could re-extract from it, since the raw
-    // template survives the loop (`resolveBestEffort` clones, and collects into
-    // a fresh bag).
+    // template survives the loop: the `try` arm clones, and the `catch` arm
+    // only aliases the leaf into a bag no consumer mutates.
     // (This note used to say the loop "mutates in place" the desired property
     // intrinsics. It has not since go-to-k/cdkd#939 added the clone in the same
     // change that wrote the note; BEFORE that commit the loop ran the real

--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -163,11 +163,10 @@ export class DiffCalculator {
     // loop reads the RESOLVED values, where a GetAtt to an
     // in-place-referenceable resource has already been replaced by its resolved
     // current value.
-    // (This said the loop "mutates in place" the desired property intrinsics
-    // and that a GetAtt "can no longer be detected" once `resolveBestEffort`
-    // runs. Both were false from the commit that wrote them — go-to-k/cdkd#939
-    // added the clone in the same change, so the template keeps its raw
-    // intrinsics.)
+    // (This said the loop "mutates in place" the desired property intrinsics.
+    // It never has: go-to-k/cdkd#939 added the clone in the same change that
+    // wrote the note, and the loop collects into a fresh bag, so the RAW
+    // template keeps its intrinsics and this snapshot reads them either way.)
     const rawGetAttRefs = new Map<string, Map<string, Map<string, Set<string>>>>();
     for (const [logicalId, desiredResource] of Object.entries(desiredResources)) {
       if (desiredResource.Type === 'AWS::CDK::Metadata') continue;

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -1541,10 +1541,13 @@ describe('DiffCalculator - replacement propagation to dependents (issue #807)', 
       },
     };
 
-    // A MUTATING resolver: it rewrites the Fn::Sub variable map's GetAtt in
-    // place. NOT what the real resolver does — go-to-k/cdkd#2764 retired that
-    // write-back — and injected here precisely because the clone must hold
-    // against ANY resolver. It is what keeps this case discriminating.
+    // A MUTATING resolver, and deliberately a BLUNTER one than any real
+    // resolver: every object it descends into has each key written back in
+    // place (a node carrying `Fn::GetAtt` is terminal — replaced whole, its
+    // members never walked; arrays it rebuilds). So it stands for ANY
+    // `IntrinsicResolveFn`, not for the narrow `resolveSub` write-back
+    // go-to-k/cdkd#2764 retired — that generality is the comment's own
+    // argument, and it is what keeps this case discriminating.
     const mutatingResolver = async (value: unknown): Promise<unknown> => {
       const walk = (v: unknown): unknown => {
         if (v === null || typeof v !== 'object') return v;

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -1541,13 +1541,13 @@ describe('DiffCalculator - replacement propagation to dependents (issue #807)', 
       },
     };
 
-    // A MUTATING resolver, and deliberately a BLUNTER one than any real
-    // resolver: every object it descends into has each key written back in
-    // place (a node carrying `Fn::GetAtt` is terminal — replaced whole, its
-    // members never walked; arrays it rebuilds). So it stands for ANY
-    // `IntrinsicResolveFn`, not for the narrow `resolveSub` write-back
-    // go-to-k/cdkd#2764 retired — that generality is the comment's own
-    // argument, and it is what keeps this case discriminating.
+    // A MUTATING resolver, and deliberately not a faithful one: every object it
+    // descends into has each key written back in place (a node carrying
+    // `Fn::GetAtt` is terminal — replaced whole, its members never walked;
+    // arrays it rebuilds). That COVERS the narrow `resolveSub` write-back
+    // go-to-k/cdkd#2764 retired — the `Fn::Sub` variable map above is one of
+    // the objects it rewrites — and goes wider along the OBJECT axis. What it
+    // does NOT model is a resolver mutating array ELEMENTS in place.
     const mutatingResolver = async (value: unknown): Promise<unknown> => {
       const walk = (v: unknown): unknown => {
         if (v === null || typeof v !== 'object') return v;

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -1511,9 +1511,13 @@ describe('DiffCalculator - replacement propagation to dependents (issue #807)', 
   });
 
   it('does NOT mutate the desired template (resolveBestEffort resolves a clone)', async () => {
-    // The intrinsic resolver mutates its input in place; resolveBestEffort must
-    // clone first so the raw Fn::GetAtt survives for the deploy phase to
-    // re-resolve against the in-flight (new) upstream value.
+    // resolveBestEffort is handed a leaf of the SHARED desired template, so it
+    // must clone before passing it to an `IntrinsicResolveFn` — whatever that
+    // function does with what it is given — and the raw Fn::GetAtt must survive
+    // for the deploy phase to re-resolve against the in-flight (new) upstream
+    // value. The resolver this case injects mutates in place; the real one no
+    // longer does (go-to-k/cdkd#2764 retired `resolveSub`'s write-back), which
+    // is why the mutation is injected rather than relied upon.
     const state = baseState();
     state.resources['Base'] = {
       physicalId: 'base',
@@ -1537,8 +1541,10 @@ describe('DiffCalculator - replacement propagation to dependents (issue #807)', 
       },
     };
 
-    // A MUTATING resolver: it rewrites the Fn::Sub variable map's GetAtt in place
-    // (as the real intrinsic resolver does).
+    // A MUTATING resolver: it rewrites the Fn::Sub variable map's GetAtt in
+    // place. NOT what the real resolver does — go-to-k/cdkd#2764 retired that
+    // write-back — and injected here precisely because the clone must hold
+    // against ANY resolver. It is what keeps this case discriminating.
     const mutatingResolver = async (value: unknown): Promise<unknown> => {
       const walk = (v: unknown): unknown => {
         if (v === null || typeof v !== 'object') return v;


### PR DESCRIPTION
## Summary

Four comments in `src/analyzer/diff-calculator.ts` and its test explained the `structuredClone` in `resolveBestEffort` by a mechanism that no longer exists — "the intrinsic resolver mutates its input in place". That was `resolveSub`'s write-back into the caller's `Fn::Sub` variable map, retired by go-to-k/cdkd#2764.

The clone is correct and stays. Only its stated reason was wrong, and in the direction that gets a guard deleted: a reader who checks the claim finds no in-place write in the resolver and concludes the clone is dead weight. Each site is re-grounded on the OWNERSHIP contract — `resolveBestEffort` is handed a leaf of the SHARED desired template, so no `IntrinsicResolveFn` may write through it, whatever that function does. Shared is checked, not assumed: `DeployEngine.deploy` hands `calculateDiff` the same `effectiveTemplate` it then provisions from. The retired write-back is kept as labelled history, which is the shape `src/analyzer/outputs-diff.ts` took in go-to-k/cdkd#2773.

**The sweep found a fourth site the issue did not name**, in the same file and added by the same commit: the `rawGetAttRefs` snapshot note, which said the comparison loop "mutates in place" the desired property intrinsics. `git blame` puts that note and the `resolveBestEffort` one in the same commit, 772dd03f (go-to-k/cdkd#939), which is also where the clone arrived — `git show 772dd03f^:src/analyzer/diff-calculator.ts` has the bare `resolved[key] = await resolveFn(value)`. So the loop never mutated the template: it collects into a fresh object, and nothing in the file assigns to `.Properties` at all (`grep -nE '\.Properties\s*=' src/analyzer/diff-calculator.ts` is empty). The raw intrinsics survive the loop, which is what made the old note's ordering rationale wrong.

The second commit narrows that same note. Its first version also called the old text's "a GetAtt can no longer be detected" false, which over-claims — that IS true of the resolved bag, as the paragraph above it says — so only the unqualified half is kept.

Comments only — **0 non-comment changed lines**, measured on the diff rather than asserted:

```
git diff origin/main -U0 -- src tests | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | sed 's/^[+-]//;s/^[[:space:]]*//' | grep -vE '^//|^$' | wc -l
0
```

## Test plan

No new test: the behaviour under discussion is already fenced by `does NOT mutate the desired template (resolveBestEffort resolves a clone)`, and this PR's job is to stop that fence reading as dead weight. The verification the issue prescribes, plus a probe that the fence still discriminates:

- **Verification grep** — `grep -rniE 'resolver (mutates|rewrites)[^.]*in place|as the real intrinsic resolver does' src/ tests/` returns nothing (before, it returned the three lines the issue names).
- **Mutation probe on the committed tree** — `resolved[key] = await resolveFn(structuredClone(value))` -> `resolveFn(value)` (receipt: bytes 51079 -> 51062, anchor 1 -> 0), then `vp test run tests/unit/analyzer/diff-calculator.test.ts`: `1 failed | 34 passed (35)`, the single failure being `does NOT mutate the desired template (resolveBestEffort resolves a clone)`. Restored from a byte-exact copy; `git diff` clean afterwards. The injected mutating resolver therefore stays mutating — it is what keeps the case discriminating.
- **Full suite** — 968 files, 21109 passed | 1 skipped, no type errors, rc=0, RUN root asserted as this worktree, re-run after the second commit. (One earlier run of the same tree reported the same 968/21109 with rc=1 and a single `Worker exited unexpectedly`; a peer session's suite was on the host. rc=0 on a quiet one.)
- `vp check --fix` + `vp run check` + `vp run typecheck:test` + `vp run build` + `vp run gen:all-matrices` / `audit:coverage:check` — all clean, nothing regenerated dirty.
- **Docs / rules**: nothing to update. `grep -rniE 'resolver (mutates|rewrites)|mutates? (its|the) (input|caller|argument)' .claude/rules/ docs/ CLAUDE.md README.md changelog.d/` returns zero hits, and neither `.claude/rules/analyzer.md` nor `.claude/rules/layout-analyzer.md` mentions `diff-calculator.ts`, `resolveBestEffort` or the clone.

**Review round 1** (go-to-k/cdkd#2896 review of 2026-09-10, commit `9563177c`) — five items, all taken:

- **M0** (blocker): the previous text said the loop "never" mutated the desired property intrinsics. False, and in this PR's own defect class: at `772dd03f^` `resolveBestEffort` called `resolveFn(value)` with no clone, `DeployEngine` handed it the real resolver, and `resolveSub` bound the caller's `Fn::Sub` variable map by destructuring and wrote into it. The note was TRUE when written and go-to-k/cdkd#939 falsified it in the same commit. The sentence is temporal now.
- **m1**: the clone note names both fences — `tests/unit/deployment/intrinsic-sub-variables-not-mutated.test.ts` for the resolver side, and `does NOT mutate the desired template (resolveBestEffort resolves a clone)` for the clone side. Probed rather than cited: reinstating the write-back in `resolveSub` reds exactly the two cases the comment names (`2 failed | 5 passed (7)`), restored byte-exact.
- **m2**: the ownership rationale covers both `calculateDiff` callers; `cdkd diff` never reaches a deploy phase. (It shares the template with the Outputs resolution, but not with the skipped-output digests — `outputsDigestSource` is a `structuredClone`.)
- **m3**: the `rawGetAttRefs` snapshot is named a precomputation, with no cost claim attached (none was derivable).
- **m4**: the restating clause is gone, and the test comment describes the injected resolver's actual walk.

Verification for the round: full suite 968 files / 21109 passed / 1 skipped, rc=0, root asserted; the greps above still return nothing; still 0 non-comment changed lines. Codex on the delta: 2 rounds (r1 found the walk description overstated) plus a maintainer-checklist proxy pass, NO ISSUES.

`main` advanced by go-to-k/cdkd#2797 and go-to-k/cdkd#2898 during the round; neither touches `diff-calculator.ts` or its test, so no rebase. The three cross-module facts these comments assert were re-derived against `origin/main` as it stands after that merge.

**Review round 2** (commit `4a592670`) — two required items, both taken:

- **M1**: "the raw template survives the loop (`resolveBestEffort` clones, and collects into a fresh bag)" did not cover the `catch` arm, where `resolved[key] = value` aliases the raw leaf by identity. The sentence now names the real reason — the `try` arm clones, the `catch` arm only aliases into a bag no consumer mutates — after re-walking those consumers (`withoutAcceptedSilentDropProperties` and all four live `canonicalizeDesiredProperties` implementations either return their input unchanged or build a fresh object).
- **M2**: "stands for ANY `IntrinsicResolveFn`" was unearned — the injected resolver rebuilds arrays, so array-ELEMENT mutation is outside what the case exercises. The finding is taken; the maintainer's proposed wording ("does not stand in for the narrow write-back") is not, because it overshoots the other way: that resolver DOES perform the retired write-back on the `Fn::Sub` variable map. Probed — a resolver doing ONLY the narrow write-back passes with the clone (`35 passed`) and reds the case without it (`1 failed | 34 passed`), so the narrow shape alone is what discriminates. The text now says the walk covers that write-back, goes wider along the OBJECT axis, and names the axis it does not model.

`diff-calculator.ts`'s sentence about `cdkd diff` sharing the template is left as written, per the maintainer's own ruling on that item.

Verification for the round: full suite 968 files / 21109 passed / 1 skipped, rc=0, root asserted (re-run on the amended tree); every gate command rc=0; still 0 non-comment changed lines. Codex on the delta: NO ISSUES; the maintainer-checklist proxy pass caught the M2 overshoot, then NO ISSUES. Three Codex rounds on the reply itself caught a "below" that should read "above" (fixed in the comment too) and a claim that `outputs-diff.ts` reads `Outputs` only (it walks the whole template, read-only).

No integ: the diff touches no `integ-destroy` / `integ-broad` / `integ-local` / `integ-schema-migration` scope, and changes no executable line.

Closes #2832
