### PR TITLE
chore(integ): record the lambda merge-gate run for PR 2797

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -151,7 +151,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-10T03:31:17Z	PASS	93	verify.sh	PR for issue 2563 review round 9: re-verified after the rebase onto main (resolveOutputs gained a digestSource parameter, scrub gained the exports-index repair); broad gate for deploy-engine.ts + intrinsic-function-resolver.ts; 9 deleted 0 errors 0 orphans; deployments/ versions swept
+lambda	2026-09-10T06:38:25Z	PASS	74	verify.sh	merge-gate run for PR 2797 from the reviewer's worktree at e7f9cd9c: 9 deleted, 0 errors, 0 orphans; state.json and lock.json gone, deployments/ is the separate key family destroy does not delete
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans


### PR DESCRIPTION
Records the `lambda` run that satisfied the `integ-broad` / `integ-destroy` gates for go-to-k/cdkd#2797.

## Why it is a separate PR

Those gates read markgate markers from the worktree that runs `gh pr merge`, and go-to-k/cdkd#2797 came from a fork — the contributor's own runs set markers in their worktree, which cannot travel with the PR. So the gate run had to happen here, and the ledger row it produced had nowhere to be committed on the fork branch. This is the shape the `feedback_fork_pr_markers_need_a_local_head_branch` rule prescribes: land the row on `main` afterwards.

## The run

`/run-integ lambda` from this worktree, against a `dist/` built from go-to-k/cdkd#2797's head `e7f9cd9c`:

- PASS in 74 s, 9 resources deleted, 0 errors
- pre-flight orphan scan clean (state, IAM roles, Lambda functions, DynamoDB tables)
- post-run: `state.json` and `lock.json` gone; IAM / Lambda / DynamoDB / SQS scans for `LambdaStack` all empty
- the surviving `deployments/` prefix is the deployment-events key family `cdkd destroy` deliberately does not delete, self-bounded at 20 runs by the writer

One row changes: the ledger is update-type, one row per test, so this replaces the previous `lambda` row rather than adding one.

## Test plan

- `vp run check` / `vp run typecheck` / `vp run typecheck:test` / `vp run build`: 0 errors
- `vp run integ-ledger-normalize` run before committing; `git status --porcelain -- docs/_generated/` clean afterwards
- Full `vp test run`, root-asserted to this worktree: 969 files, 21,135 passed (1 skipped)
