### PR TITLE
test(local): pin the websocket drain against its own mechanism, not the wall clock

### DIFF
--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -782,21 +782,52 @@ describe('per-connection dispatch serialization (M1)', () => {
 
 // Issue #527 M3: graceful shutdown drains in-flight $disconnect
 // dispatches with a bounded ceiling. A hung handler pre-fix would leak
-// its rieTimeoutMs (60s+) past close()'s 5s socket-close timeout.
+// its rieTimeoutMs (60s+) past close()'s 5s socket-close timeout. Note that
+// `close()` has TWO 5s timers and they are unrelated: the socket-close
+// path's defensive per-socket timeout, and `SHUTDOWN_DRAIN_MS`, the drain
+// ceiling this block is about. Everything below turns on the second.
 describe('graceful shutdown bounded drain (M3)', () => {
+  // The hung `$disconnect` outlasts `SHUTDOWN_DRAIN_MS`, and the per-case
+  // timeout outlasts BOTH. That ordering is what lets an assertion do the
+  // reporting: a drain that lost its ceiling finishes when this handler
+  // does, and is named rather than killed by the runner at a deadline the
+  // handler was still racing.
+  //
+  // The socket-close phase runs BEFORE the drain and carries its own 5s
+  // timer, so the effective margin is
+  // `HUNG_DISCONNECT_MS - (that phase + SHUTDOWN_DRAIN_MS)` -- about 5s at
+  // these values once a slow phase is allowed for, against the 2.5s the
+  // removed wall-clock bound had.
+  //
+  // What it is bought with, scoped to the shape that pays it: a mutant that
+  // leaves the drain BLOCKED on the hung handler cannot report until that
+  // handler settles, so its failure arrives at roughly `HUNG_DISCONNECT_MS`.
+  // Widening this constant delays that one report by the same amount. The
+  // other mutants probed against this case fail at their own ceilings
+  // instead, and no cost lands on the passing path at all, which never
+  // awaits this handler.
+  const HUNG_DISCONNECT_MS = 15_000;
+  const CASE_TIMEOUT_MS = 25_000;
+
   beforeEach(() => {
     rieModule.__resetQueue();
     rieModule.invokeRie.mockClear();
   });
   it('logs a warn naming the leaking $disconnect count when drain times out', async () => {
     rieModule.__resetQueue();
-    rieModule.__queueInvokeResult({ statusCode: 200 }); // $connect for the live conn
+    // Flips only when the hung `$disconnect` finally returns — the thing the
+    // drain must NOT wait for. `close()` races `Promise.allSettled` of the
+    // in-flight handlers against a `SHUTDOWN_DRAIN_MS` timer, so "the drain
+    // gave up" IS "that allSettled had not settled", which this observes
+    // directly.
+    let disconnectSettled = false;
     // $disconnect hangs longer than the 5s drain window.
     rieModule.invokeRie.mockImplementation(async (_id: string, _meta: unknown, event: any) => {
       const routeKey = event?.requestContext?.routeKey;
       if (routeKey === '$connect') return { payload: { statusCode: 200 }, raw: '{}' };
       // Sleep past the drain window — exact value doesn't matter past 5s.
-      await new Promise((r) => setTimeout(r, 10_000).unref?.());
+      await new Promise((r) => setTimeout(r, HUNG_DISCONNECT_MS).unref?.());
+      disconnectSettled = true;
       return { payload: {}, raw: '{}' };
     });
 
@@ -821,22 +852,109 @@ describe('graceful shutdown bounded drain (M3)', () => {
     try {
       const ws = await openWebSocket(port, '/prod');
       await waitFor(() => attached.registry.size() === 1, 1000);
-      // Closing the WebSocket fires the close listener, which kicks off
-      // $disconnect. Then immediately call attached.close() which awaits
-      // the drain. The drain hits the 5s ceiling and the warn fires.
-      // We do NOT await ws's close event here because attached.close
-      // itself drives the close to completion.
+      // `ws.close()` only starts the handshake -- the close frame is an
+      // async write, so the server-side listener that dispatches
+      // `$disconnect` runs INSIDE `attached.close()`'s socket-close loop,
+      // one loopback round-trip later. We do not await ws's close event
+      // here because `attached.close()` drives it to completion. The drain
+      // then hits the ceiling and the warn fires.
+      //
+      // Calling `attached.close()` in the SAME tick is load-bearing twice
+      // over: `close()` snapshots `wss.clients` synchronously, and calling
+      // it synchronously is what GUARANTEES that snapshot is non-empty --
+      // sufficient rather than necessary, since an intervening await need
+      // not let the socket actually close; and the `$disconnect` promise is added to
+      // `inFlightDisconnects` synchronously inside the connection-time
+      // `close` listener, which was registered BEFORE `close()`'s own
+      // `ws.once('close', ...)`, so registration always wins the race
+      // against `Promise.all(closes)` rather than winning it by timing.
       ws.close();
       const t0 = Date.now();
       await attached.close();
       const elapsed = Date.now() - t0;
-      // Drain ceiling = 5000ms; some scheduler jitter accepted.
+      // The drain really waited rather than returning at once. Kept as a
+      // wall-clock bound because a LOWER one cannot fail from a slow host,
+      // only from one running faster than real time.
+      //
+      // It is also what stops the next assertion passing VACUOUSLY. If no
+      // `$disconnect` ever registered, `inFlightDisconnects` would be empty,
+      // `close()` would skip the drain block entirely and return in ~5 ms
+      // with `disconnectSettled` still false -- which reads identical to a
+      // correct give-up. This line is the guard that fails there, so the
+      // two are a pair rather than one bound plus a leftover.
       expect(elapsed).toBeGreaterThanOrEqual(4_500);
-      expect(elapsed).toBeLessThan(7_500);
+      // ...and it gave up before the handler. This and the `drained for
+      // 5000ms` assertion below together replace an `elapsed < 7_500` upper
+      // bound that went red twice under a concurrent suite with no defect
+      // present (issue #2795): a host stall inflates `elapsed` against a
+      // fixed constant, where this compares two timers that a stall delays
+      // together. Measured, not assumed to be absolute, across separate
+      // runs: the old bound red at 7751 / 7815 ms when the issue was filed,
+      // and again at 7907 ms in a run carrying BOTH bounds where the new
+      // assertions passed; the fixed case then went 5/5 at load average 35
+      // on 16 cores. It is not an INVARIANT -- the two timers are armed at different
+      // moments (the handler's when the close listener dispatches
+      // `$disconnect`, the drain's after the socket closes settle), so a
+      // stall between those two moments does move their deadlines relative
+      // to each other. What makes it hold in practice is the margin between
+      // the ceiling and the handler, where the removed bound had 2.5s
+      // against a fixed constant.
+      //
+      // This half alone would NOT: it only says the drain quit somewhere
+      // short of `HUNG_DISCONNECT_MS`, so a ceiling raised to 8s still
+      // passes it -- and the wider that constant is set, the wider this
+      // undisclosed window gets, which is the cost side of the sizing above.
+      // The removed bound did catch that, which is why the ceiling's VALUE
+      // is pinned below rather than left to this.
+      //
+      // What the trio does NOT recover: `close()` is still bounded, but at
+      // the handler's settle point rather than at 7500, so latency added between
+      // those two figures is invisible where the removed bound saw it. That
+      // is UNRELATED latency -- awaiting `drainComplete` itself is caught
+      // (measured), because the mock sets the flag before returning, so it
+      // is already true when `allSettled` resolves. A drain scheduling a
+      // delay other than the constant it logs is the reachable case. The
+      // removed bound did not see all of that class either, only the part
+      // pushing the total past its own 7500, so an extra 1s passed it too;
+      // what it had was 2.5s of slack where this has the ceiling-to-handler
+      // margin. Narrowing
+      // that needs a duration bound, the instrument this case drops on
+      // purpose, having measured it red twice with nothing wrong. A
+      // `setTimeout` spy is not a way back: the socket-close path above
+      // schedules its own 5s timer, so the delays are not separable by
+      // value, and separating them by count or order would pin the socket
+      // loop's shape instead of the drain's.
+      // The message says only what the flag OBSERVES. `disconnectSettled`
+      // being true means the handler settled before `close()` RETURNED, and
+      // `close()` still awaits `wss.close()` after the drain, so a long
+      // enough stall there flips it without the drain having waited at all.
+      // Blaming the drain in the message would be the same misreporting
+      // this case was rewritten to stop doing.
+      expect(
+        disconnectSettled,
+        'the in-flight $disconnect settled before close() returned'
+      ).toBe(false);
       const drainWarns = warnSpy.mock.calls.filter(
         (c) => typeof c[0] === 'string' && c[0].includes('graceful shutdown drained for')
       );
       expect(drainWarns).toHaveLength(1);
+      // The ceiling CONSTANT, pinned off the message rather than the clock:
+      // the warn interpolates `SHUTDOWN_DRAIN_MS`, so moving it to 8s
+      // rewrites this string where `disconnectSettled` sees nothing. It pins
+      // the constant, NOT the delay actually scheduled -- see the residual
+      // noted above.
+      expect(drainWarns[0]![0]).toContain('drained for 5000ms');
+      // The COUNT this case is named for. It was named and not asserted, so
+      // a warn reporting the wrong number of leaked handlers satisfied every
+      // other line here. What it pins is the MAGNITUDE and not the two
+      // POSITIONS: one connection makes numerator and denominator both 1, so
+      // swapping them in the message would still pass. Separating them needs
+      // a second connection whose `$disconnect` settles after the
+      // socket-close loop but before the drain snapshots its count -- and
+      // the width of that window is the load-dependent quantity this case is
+      // being rewritten to stop depending on. Left as the magnitude check
+      // deliberately; the stronger fixture is filed instead.
+      expect(drainWarns[0]![0]).toContain('1/1 $disconnect handlers');
       expect(drainWarns[0]![0]).toContain('still in flight');
     } finally {
       warnSpy.mockRestore();
@@ -846,5 +964,5 @@ describe('graceful shutdown bounded drain (M3)', () => {
         server.closeAllConnections?.();
       });
     }
-  }, 10_000);
+  }, CASE_TIMEOUT_MS);
 });


### PR DESCRIPTION
Closes #2795

## What was wrong

The bounded-drain case asserted a wall-clock window around the server's 5 s `SHUTDOWN_DRAIN_MS`:

```ts
expect(elapsed).toBeGreaterThanOrEqual(4_500);
expect(elapsed).toBeLessThan(7_500);
```

The upper bound went red twice under a concurrent suite with no defect present, at 7751 ms and 7815 ms, each costing a full-suite re-run of 6 to 11 minutes. It also misreports: the two assertions the case exists for sit AFTER it and never run, so the failure reads as a `$disconnect` drain defect when what overran was the measurement.

## The decision the issue left open

Whether that bound is a behavioural limit or a hang guard. **It is a behavioural limit, and a wall-clock constant is the wrong instrument for one.** A host stall inflates `elapsed` while the constant stays put, so the comparison moves on one side only. Three assertions replace it, each reading the property off the mechanism instead.

- **The drain gave up before the handler.** The hung `$disconnect` records when it settles; the drain must return first. `close()` races `Promise.allSettled` of the in-flight handlers against the ceiling timer, so "the drain gave up" IS "that `allSettled` had not settled".
- **The ceiling CONSTANT is still 5 s.** Pinned off the warn, which interpolates `SHUTDOWN_DRAIN_MS`, so moving it to 8 s rewrites the string where the settled flag sees nothing.
- **The leaked-handler COUNT the case is named for.** It was named and not pinned, so a warn reporting the wrong number satisfied every other line. New coverage rather than a restatement. It pins the MAGNITUDE and not the two positions: with one connection the numerator and denominator are both 1, so a swap would still pass. Separating them needs a second handler pending at the drain's count snapshot, released on a signal rather than a sleep, so it is filed as go-to-k/cdkd#2904 rather than built here on a timing window.

`elapsed >= 4_500` stays. A lower bound cannot fail from a slow host, only from one running faster than real time, so it was never part of this defect.

The hung sleep and the per-case timeout become named constants, and the timeout goes `10_000` to `20_000` so the ordering is timeout > handler > ceiling. A drain that lost its ceiling is then reported by an assertion rather than killed by the runner at a deadline the handler was still racing.

## Verification

Every mutant restored from a byte-exact copy. Each is the SOLE failing assertion for its row.

| Mutation | Red on | Previously caught by |
|---|---|---|
| warns at the ceiling, then still blocks on the handler | the settled flag | the removed bound |
| ceiling constant `5_000` to `8_000` | `drained for 5000ms` | the removed bound |
| leaked-handler count reported wrong | `1/1 $disconnect handlers` | nothing |

Deleting the settled-flag assertion lets its own mutant pass 18/18, so it is load-bearing rather than decorative.

**The reported failure, reproduced and compared side by side.** Under a deliberate 16-way CPU load, one run carrying BOTH the old bound and the new assertions red the OLD bound at `elapsed=7907` while the new ones passed in the same run, on the same host, in the same process. The fixed case then went 5/5 at load average 35. That is the closest thing to a controlled comparison this defect allows, and it is also the live test of the changed behaviour: the behaviour here IS the case's response to load.

Full `vp test run`, vitest root asserted to this worktree: 969 files / 21,135 passed / 1 skipped, clean. `vp check --fix` / `run check` / `typecheck` / `typecheck:test` / `build` / `gen:all-matrices` / `audit:coverage:check`: 0 errors, nothing regenerated dirty.

No integ, and the gates agree: the diff is `tests/unit/local/websocket-server.test.ts` alone with zero `src/` changes, so the cross-cutting, deletion and local-execution detections in `/verify-pr` step 6 all report not-touched. `tests/unit/local/**` is not in the `integ-local` scope, which is `src/local/**`, `src/cli/commands/local-*.ts` and `tests/integration/local-*/**`. No changelog entry, under the rule that only a user-visible behaviour delta writes one.

## What review changed, since it was not cosmetic

- The first cut asserted only the settled flag. That WEAKENED the case: a ceiling regressed from 5 s to 8 s left the flag false, the lower bound passing and the warn assertions indifferent, where the removed bound caught it. Hence the constant is pinned separately.
- The second cut claimed pinning the constant recovered "the one thing" the old bound caught. It does not. A drain scheduling a delay other than the constant it logs waits 8 s and passes everything.
- The residual then named only that one shape. The honest statement is the class: **nothing here bounds how long `close()` takes any more**, so any added latency under the handler's 10 s is invisible. The removed bound did not see all of that either, only the part pushing the total past its own 7500, so an extra 1 s passed it too.
- The same-loop argument is recorded as MEASURED resilience, not as an invariant. The two timers are armed at different moments, the handler's when the close listener dispatches `$disconnect` and the drain's after the socket closes settle, so a stall between those moments does move their deadlines relative to each other. What makes it hold is the ceiling-to-handler margin, `HUNG_DISCONNECT_MS - (socket-close phase + SHUTDOWN_DRAIN_MS)`, where the removed bound had 2.5 s against a fixed constant. (Corrected after merge: this line still carried the pre-resize `10 s` figure. It never reached `main` — the commit message uses the derivation form — and the maintainer had already noted it and merged over it rather than spend a round on it.)

All four are written into the case rather than left here, so the next reader of that file gets them without finding this PR.

An independent test-adequacy reviewer then found four more, and its measurement overturned one of my own claims. The residual said an extra await after the race was invisible; awaiting `drainComplete` is in fact CAUGHT, because the mock sets its flag before returning, so the flag is already true when `allSettled` resolves. It also showed the residual contradicted itself (the settled flag IS a duration bound, at the handler's 10 s rather than at 7500), that the slack is about 5 s and not 10, and that the comment describing `ws.close()` as firing `$disconnect` was wrong — the dispatch happens inside `close()`'s own socket-close loop, one loopback round-trip later, which makes the margin argument stronger than I had sold it. All corrected in the case.

## Filed, not fixed here

go-to-k/cdkd#2904 covers two coverage gaps the same reviewer found, bundled because both need one missing fixture mechanism: the degenerate `1/1` count above, and the drain's COMPLETION arm, which is never asserted.

**Corrected after review.** I first published that the completion arm "is never executed", because dropping `drainComplete.then(() => 'complete')` from the race left the file green here. That was a claim about one host stated as a property of the suite. The close listener that registers a disconnect promise is installed on ADMISSION, so it fires for every close of an admitted connection whether or not a `$disconnect` route is configured, and such a promise may still be pending when `close()` reaches the drain. Whether it is depends purely on scheduling: idle here the mutant is green, with the other 17 cases at 2-166 ms and only the drain case at 5003 ms, and still green at load average 25; on the maintainer's run it was `7 failed | 11 passed`, all `Test timed out in 5000ms`. The arm is therefore reached unpredictably and simply never asserted, and that mutant's colour is not a usable baseline. The commit message and go-to-k/cdkd#2904 both carry the corrected premise, the issue's verification plan no longer rests on it, and the fix is required to red BY NAME rather than by a runner timeout.

Pre-existing, no user-visible defect, `severity:low` / `effort:medium`.


