### PR TITLE
test(resolver): make the drain-budget fence per-CALL rather than per-loop, and fence the cross-stack pre-pass by its call sites

### DIFF
--- a/tests/unit/deployment/intrinsic-resolver-concurrent-drain.test.ts
+++ b/tests/unit/deployment/intrinsic-resolver-concurrent-drain.test.ts
@@ -1236,6 +1236,7 @@ describe('the callers that must wrap a resolve LOOP do (issue #2563)', () => {
     ['src/deployment/deploy-engine.ts', 'resolveOutputs', 2],
     ['src/cli/commands/import.ts', 'resolveImportedProperties', 2],
     ['src/cli/commands/export.ts', 'buildResolvedParametersPerStack', 1],
+    ['src/cli/commands/scrub.ts', 'resolveCrossStackReads', 3],
   ])('every %s call to %s is inside a shared drain budget', (file, callee, atLeast) => {
     // The wraps are this round's whole deliverable and nothing held them:
     // deleting either engine one left `tests/unit/deployment` and then the
@@ -1248,11 +1249,23 @@ describe('the callers that must wrap a resolve LOOP do (issue #2563)', () => {
     // does not -- its justification is the lock plus the CFn import
     // parameters it builds.
     //
-    // `scrub.ts` wraps its loops with ONE INLINE budget rather than at a
-    // callee, so it does not fit this callee-keyed table -- it gets the
-    // OWNER-KEYED case below instead. Calling it "not expressible" here was
-    // wrong, and that sentence is what let a third, unwrapped loop sit in
-    // that file for a round while both narratives said it was done.
+    // `scrub.ts` wraps its three resolve LOOPS with ONE INLINE budget rather
+    // than at a callee, so THOSE do not fit this callee-keyed table -- they
+    // get the OWNER-KEYED case below instead. Calling it "not expressible"
+    // here was wrong, and that sentence is what let a third, unwrapped loop
+    // sit in that file for a round while both narratives said it was done.
+    //
+    // Its cross-stack pre-pass DOES fit, and is the last row (issue
+    // go-to-k/cdkd#2895). `resolveCrossStackReads` is built by
+    // `makeCrossStackPrePass` at module scope and returned as a closure, so
+    // its own per-leaf `resolver.resolve` sits OUTSIDE `scrubStack`'s subtree
+    // and the owner-keyed case below cannot see it -- while its CALL SITES
+    // are inside `scrubStack` and are the property worth holding. Correct
+    // today because `withSharedDrainBudget` INHERITS, so a call already
+    // inside the hoisted budget spends that one. Before this row a fourth
+    // call site added above the wrap would have opened a budget per leaf with
+    // nothing reddening; that mutation is what this row now catches (measured:
+    // it reports the added line).
     //
     // Syntactic, like the fences above, and with the same limits: it asks
     // whether the call sits lexically inside a `withSharedDrainBudget(...)`
@@ -1317,6 +1330,147 @@ describe('the callers that must wrap a resolve LOOP do (issue #2563)', () => {
  * Uses the REAL resolver — `deploy-engine-outputs-export-name-collision.test.ts`
  * replaces it wholesale and so pins the copy's SEQUENTIAL shape only.
  */
+/**
+ * The owner-keyed walk, extracted so its CLAUSES can be pinned against
+ * synthetic sources as well as against the real `scrub.ts`.
+ *
+ * Both clauses issue go-to-k/cdkd#2894 added are invisible to a real-tree-only
+ * case, which is the same shape as the hole they close: deleting
+ * `ts.isFunctionLike` from the barrier, or stopping the barrier walk at the
+ * owner's DECLARATION rather than at its function, left the whole repository
+ * green while the cases below did not exist, because today's `scrubStack` is a
+ * function declaration whose wrapper sits directly in its body. The three
+ * cases below carry the shapes that tell the mutants apart, and the real-tree
+ * case stays GREEN under every one of them — which is the point.
+ */
+function analyseSharedBudget(
+  sourceText: string,
+  owner: string
+): {
+  resolveCount: number;
+  unwrappedLines: number[];
+  distinctWrappers: number;
+  perCallBarriers: string[];
+  ownerFound: boolean;
+} {
+  const sf = ts.createSourceFile('probe.ts', sourceText, ts.ScriptTarget.Latest, true);
+
+  // Find the OWNER's declaration and walk its whole subtree, rather than
+  // asking each call which function encloses it: the innermost-enclosing
+  // reading assigns a nested arrow's calls to the arrow, so an unwrapped
+  // `const fourth = async () => { await resolver.resolve(...) }` inside
+  // `scrubStack` walked straight past the first cut of this case
+  // (measured). `makeCrossStackPrePass` is a separate top-level function,
+  // so it stays out for free.
+  let ownerBody: ts.Node | undefined;
+  const findOwner = (node: ts.Node): void => {
+    if (ownerBody !== undefined) return;
+    const named =
+      (ts.isFunctionDeclaration(node) && node.name?.text === owner) ||
+      ((ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === owner &&
+        node.initializer !== undefined &&
+        (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)));
+    if (named) {
+      ownerBody = node;
+      return;
+    }
+    ts.forEachChild(node, findOwner);
+  };
+  findOwner(sf);
+  if (ownerBody === undefined) {
+    return {
+      resolveCount: 0,
+      unwrappedLines: [],
+      distinctWrappers: 0,
+      perCallBarriers: [],
+      ownerFound: false,
+    };
+  }
+
+  // The barrier walk below stops at the owner's FUNCTION node, not at its
+  // declaration: for `const scrubStack = async () => {...}` the arrow sits
+  // BETWEEN the wrapper and the VariableDeclaration, so stopping at the
+  // declaration would count the owner itself as a callback barrier and red a
+  // correct tree. Today `scrubStack` is a function declaration and the two
+  // coincide; the `const` arm of the const-arrow case below is what keeps this
+  // honest, because the real tree cannot exercise it.
+  const ownerDecl: ts.Node = ownerBody;
+  const ownerFn: ts.Node =
+    (ts.isVariableDeclaration(ownerDecl) || ts.isPropertyDeclaration(ownerDecl)) &&
+    ownerDecl.initializer !== undefined
+      ? ownerDecl.initializer
+      : ownerDecl;
+
+  const owned: { line: number; wrapped: boolean; wrapper: ts.Node | undefined }[] = [];
+  const walk = (node: ts.Node): void => {
+    // Any receiver spelling, deliberately: `const r = resolver; r.resolve()`
+    // and `resolver['resolve']()` both escaped a receiver-name filter
+    // (measured). Inside this subtree a `.resolve(` call is the resolver's
+    // until shown otherwise, and a false positive here is a loud test
+    // rather than a silent hole.
+    if (
+      ts.isCallExpression(node) &&
+      ((ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.getText() === 'resolve') ||
+        (ts.isElementAccessExpression(node.expression) &&
+          ts.isStringLiteralLike(node.expression.argumentExpression) &&
+          node.expression.argumentExpression.text === 'resolve'))
+    ) {
+      // KNOWN LIMIT, and deliberate (issue go-to-k/cdkd#2894): the wrapper
+      // is matched by identifier TEXT, so a local
+      // `const withSharedDrainBudget = async (fn) => await fn()` shadowing
+      // the import would satisfy this walk while opening nothing. Closing it
+      // means introducing symbol resolution, which this fence does not use
+      // anywhere -- a new instrument for a shape nobody writes by accident.
+      // Named here rather than chased.
+      let wrapper: ts.Node | undefined;
+      for (let n: ts.Node | undefined = node.parent; n; n = n.parent) {
+        if (
+          ts.isCallExpression(n) &&
+          ts.isIdentifier(n.expression) &&
+          n.expression.text === 'withSharedDrainBudget'
+        ) {
+          wrapper = n;
+          break;
+        }
+      }
+      owned.push({
+        line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+        wrapped: wrapper !== undefined,
+        wrapper,
+      });
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(ownerBody);
+
+  // An iteration statement is only ONE way to lose "opened once per call of
+  // the owner". A wrapper inside a CALLBACK --
+  // `await Promise.all(xs.map(async () => withSharedDrainBudget(...)))` --
+  // opens one budget per element while matching no `ts.isIterationStatement`,
+  // and the earlier version of this clause passed it (issue
+  // go-to-k/cdkd#2894). So the barrier is any function boundary too: in the
+  // shape this fence exists to hold, the wrapper sits directly in the owner's
+  // own body, and a function-like node between the two means the budget is
+  // opened once per call of THAT function rather than of the owner.
+  const perCallBarriers: string[] = [];
+  for (let n: ts.Node | undefined = owned[0]?.wrapper?.parent; n && n !== ownerFn; n = n.parent) {
+    if (ts.isIterationStatement(n, false) || ts.isFunctionLike(n)) {
+      perCallBarriers.push(ts.SyntaxKind[n.kind]);
+    }
+  }
+
+  return {
+    resolveCount: owned.length,
+    unwrappedLines: owned.filter((c) => !c.wrapped).map((c) => c.line),
+    distinctWrappers: new Set(owned.map((c) => c.wrapper?.getStart(sf))).size,
+    perCallBarriers,
+    ownerFound: true,
+  };
+}
+
 describe('an INLINE budget is fenced by its OWNER, not by a callee (issue #2563)', () => {
   it('every `resolver.resolve` inside `scrubStack` is under a shared drain budget', () => {
     // `cdkd scrub` hoists ONE budget over its three resolve loops rather than
@@ -1326,104 +1480,122 @@ describe('an INLINE budget is fenced by its OWNER, not by a callee (issue #2563)
     // the `resolver.resolve` in the resources loop sits in `scrubStack` and
     // outside the wrap, and every other test in the repo stayed green.
     //
-    // `makeCrossStackPrePass` is deliberately out of scope: its own
+    // `makeCrossStackPrePass` is deliberately out of scope HERE: its own
     // `resolver.resolve` inherits the budget at RUNTIME from whichever loop
     // called it, which is not a lexical property and not this walk's
-    // business.
+    // business. Its CALL SITES are held by the callee-keyed table above
+    // instead (issue go-to-k/cdkd#2895).
     const file = join(import.meta.dirname, '../../../src/cli/commands/scrub.ts');
-    const sf = ts.createSourceFile(file, readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
-
     const OWNER = 'scrubStack';
-    // Find the OWNER's declaration and walk its whole subtree, rather than
-    // asking each call which function encloses it: the innermost-enclosing
-    // reading assigns a nested arrow's calls to the arrow, so an unwrapped
-    // `const fourth = async () => { await resolver.resolve(...) }` inside
-    // `scrubStack` walked straight past the first cut of this case
-    // (measured). `makeCrossStackPrePass` is a separate top-level function,
-    // so it stays out for free.
-    let ownerBody: ts.Node | undefined;
-    const findOwner = (node: ts.Node): void => {
-      if (ownerBody !== undefined) return;
-      const named =
-        (ts.isFunctionDeclaration(node) && node.name?.text === OWNER) ||
-        ((ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) &&
-          ts.isIdentifier(node.name) &&
-          node.name.text === OWNER &&
-          node.initializer !== undefined &&
-          (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)));
-      if (named) {
-        ownerBody = node;
-        return;
-      }
-      ts.forEachChild(node, findOwner);
-    };
-    findOwner(sf);
-    expect(ownerBody, `${OWNER} not found — this case is asserting nothing`).toBeDefined();
+    const found = analyseSharedBudget(readFileSync(file, 'utf8'), OWNER);
 
-    const owned: { line: number; wrapped: boolean; wrapper: ts.Node | undefined }[] = [];
-    const walk = (node: ts.Node): void => {
-      // Any receiver spelling, deliberately: `const r = resolver; r.resolve()`
-      // and `resolver['resolve']()` both escaped a receiver-name filter
-      // (measured). Inside this subtree a `.resolve(` call is the resolver's
-      // until shown otherwise, and a false positive here is a loud test
-      // rather than a silent hole.
-      if (
-        ts.isCallExpression(node) &&
-        ((ts.isPropertyAccessExpression(node.expression) &&
-          node.expression.name.getText() === 'resolve') ||
-          (ts.isElementAccessExpression(node.expression) &&
-            ts.isStringLiteralLike(node.expression.argumentExpression) &&
-            node.expression.argumentExpression.text === 'resolve'))
-      ) {
-        let wrapper: ts.Node | undefined;
-        for (let n: ts.Node | undefined = node.parent; n; n = n.parent) {
-          if (
-            ts.isCallExpression(n) &&
-            ts.isIdentifier(n.expression) &&
-            n.expression.text === 'withSharedDrainBudget'
-          ) {
-            wrapper = n;
-            break;
-          }
-        }
-        owned.push({
-          line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
-          wrapped: wrapper !== undefined,
-          wrapper,
-        });
-      }
-      ts.forEachChild(node, walk);
-    };
-    walk(ownerBody!);
-
+    expect(found.ownerFound, `${OWNER} not found — this case is asserting nothing`).toBe(true);
     expect(
-      owned.length,
+      found.resolveCount,
       `fewer than three resolve calls found in ${OWNER} — the walk is matching nothing`,
     ).toBeGreaterThanOrEqual(3);
     expect(
-      owned.filter((c) => !c.wrapped).map((c) => c.line),
-      `a resolver.resolve in ${OWNER} outside withSharedDrainBudget — that loop then spends ` +
-        'one cap per iteration with the scrub lock held and `saveState` downstream',
+      found.unwrappedLines,
+      `a \`.resolve(\` call in ${OWNER} outside withSharedDrainBudget — that loop then spends ` +
+        'one cap per iteration with the scrub lock held and `saveState` downstream. This walk ' +
+        'matches ANY receiver by design, so an unrelated `.resolve(` in this function — a plain ' +
+        '`Promise.resolve()`, say — reds here too: a loud false positive chosen over a silent ' +
+        'hole, not a claim that the line is a resolver call (issue go-to-k/cdkd#2894)',
     ).toEqual([]);
 
     // "Each call wrapped" is NOT the property: wrapping every `resolve`
     // individually passes the assertion above and restores exactly the
     // per-iteration budget the hoist removed (measured). What must hold is
-    // ONE wrapper shared by all of them, with no loop between it and the
-    // owner -- a wrapper inside a loop is per-iteration by another spelling.
-    const wrappers = new Set(owned.map((c) => c.wrapper?.getStart(sf)));
+    // ONE wrapper shared by all of them, with no loop or callback between it
+    // and the owner.
     expect(
-      wrappers.size,
+      found.distinctWrappers,
       'the resolve calls sit under DIFFERENT budgets — one wrapper each is one cap each',
     ).toBe(1);
-    const loopsBetween: string[] = [];
-    for (let n: ts.Node | undefined = owned[0]?.wrapper?.parent; n && n !== ownerBody; n = n.parent) {
-      if (ts.isIterationStatement(n, false)) loopsBetween.push(ts.SyntaxKind[n.kind]);
-    }
     expect(
-      loopsBetween,
-      'the shared budget is opened INSIDE a loop, so it is one budget per iteration',
+      found.perCallBarriers,
+      'the shared budget is opened inside a loop or a callback, so it is one budget per ' +
+        'iteration rather than one per call of the owner',
     ).toEqual([]);
+  });
+
+  // The cases below pin the CLAUSES the case above cannot: the real tree has
+  // none of these shapes, so every mutant stays green against IT. Measured on
+  // the tree WITHOUT them, each mutant left the full suite green; with them,
+  // of 30 cases in this file — deleting `ts.isFunctionLike` from the barrier
+  // reds the callback case alone; stopping the barrier walk at the owner's
+  // DECLARATION reds both arrow-owner cases; dropping
+  // `ts.isPropertyDeclaration` from the normalisation reds the class-field
+  // case alone. The real-tree case above survives all three.
+  it('a wrapper opened inside a CALLBACK is a per-invocation budget, not a shared one', () => {
+    const source = `
+      async function scrubStack(ids: string[]) {
+        await Promise.all(
+          ids.map(async (id) =>
+            withSharedDrainBudget(async () => {
+              await resolver.resolve(id);
+            })
+          )
+        );
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    // Syntactically ONE wrapper and no iteration statement, which is why the
+    // pre-go-to-k/cdkd#2894 clause passed this shape.
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.distinctWrappers).toBe(1);
+    expect(found.perCallBarriers).toContain('ArrowFunction');
+  });
+
+  it('a const-arrow owner whose wrapper sits in its own body reports NO barrier', () => {
+    // The negative control for the clause above, and one of the two shapes
+    // that exercise the owner-FUNCTION normalisation (the class-field case
+    // below carries the other arm): stop the barrier walk at the declaration
+    // instead and the owner's own arrow is counted as a callback barrier,
+    // reddening a correct shape.
+    const source = `
+      const scrubStack = async (ids: string[]) => {
+        await withSharedDrainBudget(async () => {
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      };
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.distinctWrappers).toBe(1);
+    expect(found.perCallBarriers).toEqual([]);
+  });
+
+  it('a class-FIELD arrow owner reports NO barrier either', () => {
+    // The owner finder accepts a `PropertyDeclaration` as well as a
+    // `VariableDeclaration`, so the normalisation above has two arms and the
+    // case before this one pins only one of them: drop
+    // `ts.isPropertyDeclaration` from it and a class-field owner reports
+    // `['ArrowFunction']` for a correct shape — measured: that mutant reds
+    // this case alone, 1 failed of 30.
+    const source = `
+      class Scrubber {
+        scrubStack = async (ids: string[]) => {
+          await withSharedDrainBudget(async () => {
+            for (const id of ids) {
+              await resolver.resolve(id);
+            }
+          });
+        };
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.distinctWrappers).toBe(1);
+    expect(found.perCallBarriers).toEqual([]);
   });
 });
 

--- a/tests/unit/deployment/intrinsic-resolver-concurrent-drain.test.ts
+++ b/tests/unit/deployment/intrinsic-resolver-concurrent-drain.test.ts
@@ -1267,6 +1267,15 @@ describe('the callers that must wrap a resolve LOOP do (issue #2563)', () => {
     // nothing reddening; that mutation is what this row now catches (measured:
     // it reports the added line).
     //
+    // The row is NAME-KEYED, and the claim is bounded to match (issue
+    // go-to-k/cdkd#2895's own "state the limit in the fix rather than discover
+    // it after"): it holds every call SPELLED `resolveCrossStackReads`. A
+    // differently named binding for the factory's return value --
+    // `const alias = resolveCrossStackReads; await alias(...)` above the wrap
+    // -- passes, measured. Tracking the binding needs symbol resolution, the
+    // same instrument the wrapper-shadow KNOWN LIMIT below declines, so the
+    // sentence is narrowed instead of the fence widened.
+    //
     // Syntactic, like the fences above, and with the same limits: it asks
     // whether the call sits lexically inside a `withSharedDrainBudget(...)`
     // argument, not whether it runs inside one.
@@ -1313,35 +1322,17 @@ describe('the callers that must wrap a resolve LOOP do (issue #2563)', () => {
 });
 
 /**
- * The engine-level consequence, on the path the issue actually reports: an
- * `Export.Name` built by `Fn::Join` from a secret reference and a sibling that
- * THROWS. The engine resolves that name into a PRIVATE `nameSecrets` map and
- * copies it into the pass map in a `finally`; pre-drain the sibling's
- * recording landed after that copy and the pass map never learned the
- * plaintext.
- *
- * THE DISCRIMINATOR IS A LATER EXPORT NAME, not the failing one. A name whose
- * literal text carries a plaintext the pass knows is REFUSED and not keyed
- * (the exposure guard); one whose plaintext the pass does NOT know is
- * published, putting the secret in the export key space and in state. So the
- * drain is observable as "the later name was refused", which is exactly what
- * the missing needle would have allowed through.
- *
- * Uses the REAL resolver — `deploy-engine-outputs-export-name-collision.test.ts`
- * replaces it wholesale and so pins the copy's SEQUENTIAL shape only.
- */
-/**
  * The owner-keyed walk, extracted so its CLAUSES can be pinned against
  * synthetic sources as well as against the real `scrub.ts`.
  *
- * Both clauses issue go-to-k/cdkd#2894 added are invisible to a real-tree-only
- * case, which is the same shape as the hole they close: deleting
- * `ts.isFunctionLike` from the barrier, or stopping the barrier walk at the
- * owner's DECLARATION rather than at its function, left the whole repository
- * green while the cases below did not exist, because today's `scrubStack` is a
- * function declaration whose wrapper sits directly in its body. The three
- * cases below carry the shapes that tell the mutants apart, and the real-tree
- * case stays GREEN under every one of them — which is the point.
+ * Every clause here is invisible to a real-tree-only case, which is the same
+ * shape as the hole issue go-to-k/cdkd#2894 reports: today's `scrubStack` is a
+ * function declaration with no iteration or function boundary between the
+ * wrapper and itself, so deleting EITHER barrier clause, stopping the barrier
+ * walk at the owner's DECLARATION, or narrowing the receiver match left the
+ * whole repository green while the cases below did not exist. Those cases
+ * carry the shapes that tell the mutants apart, and the real-tree case stays
+ * GREEN under every one of them — which is the point.
  */
 function analyseSharedBudget(
   sourceText: string,
@@ -1362,24 +1353,39 @@ function analyseSharedBudget(
   // `scrubStack` walked straight past the first cut of this case
   // (measured). `makeCrossStackPrePass` is a separate top-level function,
   // so it stays out for free.
-  let ownerBody: ts.Node | undefined;
+  // The BODY test is what makes this find the IMPLEMENTATION: without it a
+  // `declare function scrubStack(...)`, or an overload signature sitting
+  // above its implementation, matches first, the walk covers an empty
+  // subtree, and the result reads "owner found, no resolve calls" (issue
+  // go-to-k/cdkd#2915 review, m1). For the `declare` shape the `>= 3` floor
+  // reds either way and only the report was a lie; for the OVERLOAD shape the
+  // floor reds a tree that is perfectly correct, which is the worse half.
+  //
+  // The name must be an IDENTIFIER: a `PropertyName` can be a string literal
+  // or computed, and `"scrubStack"() {}` carries `.text === 'scrubStack'`
+  // without being a declaration this fence understands.
+  let ownerDecl: ts.Node | undefined;
   const findOwner = (node: ts.Node): void => {
-    if (ownerBody !== undefined) return;
+    if (ownerDecl !== undefined) return;
     const named =
-      (ts.isFunctionDeclaration(node) && node.name?.text === owner) ||
+      ((ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
+        node.name !== undefined &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === owner &&
+        node.body !== undefined) ||
       ((ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) &&
         ts.isIdentifier(node.name) &&
         node.name.text === owner &&
         node.initializer !== undefined &&
         (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)));
     if (named) {
-      ownerBody = node;
+      ownerDecl = node;
       return;
     }
     ts.forEachChild(node, findOwner);
   };
   findOwner(sf);
-  if (ownerBody === undefined) {
+  if (ownerDecl === undefined) {
     return {
       resolveCount: 0,
       unwrappedLines: [],
@@ -1396,7 +1402,6 @@ function analyseSharedBudget(
   // correct tree. Today `scrubStack` is a function declaration and the two
   // coincide; the `const` arm of the const-arrow case below is what keeps this
   // honest, because the real tree cannot exercise it.
-  const ownerDecl: ts.Node = ownerBody;
   const ownerFn: ts.Node =
     (ts.isVariableDeclaration(ownerDecl) || ts.isPropertyDeclaration(ownerDecl)) &&
     ownerDecl.initializer !== undefined
@@ -1444,19 +1449,33 @@ function analyseSharedBudget(
     }
     ts.forEachChild(node, walk);
   };
-  walk(ownerBody);
+  walk(ownerDecl);
 
   // An iteration statement is only ONE way to lose "opened once per call of
   // the owner". A wrapper inside a CALLBACK --
   // `await Promise.all(xs.map(async () => withSharedDrainBudget(...)))` --
   // opens one budget per element while matching no `ts.isIterationStatement`,
   // and the earlier version of this clause passed it (issue
-  // go-to-k/cdkd#2894). So the barrier is any function boundary too: in the
-  // shape this fence exists to hold, the wrapper sits directly in the owner's
-  // own body, and a function-like node between the two means the budget is
-  // opened once per call of THAT function rather than of the owner.
+  // go-to-k/cdkd#2894). Both clauses are needed and neither subsumes the
+  // other: a `for` written directly in the owner has the owner as its
+  // enclosing function, so the boundary test alone goes green on it.
+  //
+  // KNOWN LIMIT, and deliberate: this is an OVER-approximation. A wrapper
+  // inside a helper arrow the owner calls exactly once -- or an IIFE -- opens
+  // the budget once per owner call and is still reported, because from the
+  // syntax alone the fence can no longer tell how many times it is opened, so
+  // it reds. In the shape `scrub.ts` actually has, the wrapper reaches the
+  // owner with no iteration or function boundary between the two (a `try` is
+  // neither), and that is the property held here.
+  //
+  // Driven by the ONE shared wrapper rather than by `owned[0]`: with the
+  // distinct-wrapper count asserted at 1, source order is irrelevant, and an
+  // unwrapped FIRST call no longer makes this walk vacuous by starting it at
+  // `undefined` (issue go-to-k/cdkd#2915 review, m3).
+  const wrapperNodes = owned.map((c) => c.wrapper).filter((w): w is ts.Node => w !== undefined);
+  const sharedWrapper: ts.Node | undefined = wrapperNodes[0];
   const perCallBarriers: string[] = [];
-  for (let n: ts.Node | undefined = owned[0]?.wrapper?.parent; n && n !== ownerFn; n = n.parent) {
+  for (let n: ts.Node | undefined = sharedWrapper?.parent; n && n !== ownerFn; n = n.parent) {
     if (ts.isIterationStatement(n, false) || ts.isFunctionLike(n)) {
       perCallBarriers.push(ts.SyntaxKind[n.kind]);
     }
@@ -1465,7 +1484,11 @@ function analyseSharedBudget(
   return {
     resolveCount: owned.length,
     unwrappedLines: owned.filter((c) => !c.wrapped).map((c) => c.line),
-    distinctWrappers: new Set(owned.map((c) => c.wrapper?.getStart(sf))).size,
+    // UNWRAPPED calls do not contribute: counting `undefined` as a member
+    // reported `1` for an owner with no wrapper at all, which reads as "one
+    // shared wrapper" (issue go-to-k/cdkd#2915 review, m2). Masked today by
+    // `unwrappedLines` asserting first; a count should not need a bodyguard.
+    distinctWrappers: new Set(wrapperNodes.map((w) => w.getStart(sf))).size,
     perCallBarriers,
     ownerFound: true,
   };
@@ -1514,8 +1537,10 @@ describe('an INLINE budget is fenced by its OWNER, not by a callee (issue #2563)
     ).toBe(1);
     expect(
       found.perCallBarriers,
-      'the shared budget is opened inside a loop or a callback, so it is one budget per ' +
-        'iteration rather than one per call of the owner',
+      'a loop or a function boundary sits between the shared budget and the owner, so how ' +
+        'many times the budget is opened is no longer readable from the syntax — a loop ' +
+        'spelling opens one per iteration, and a helper called once does not, but this fence ' +
+        'refuses both rather than guessing',
     ).toEqual([]);
   });
 
@@ -1568,7 +1593,6 @@ describe('an INLINE budget is fenced by its OWNER, not by a callee (issue #2563)
     expect(found.ownerFound).toBe(true);
     expect(found.resolveCount).toBe(1);
     expect(found.unwrappedLines).toEqual([]);
-    expect(found.distinctWrappers).toBe(1);
     expect(found.perCallBarriers).toEqual([]);
   });
 
@@ -1594,11 +1618,258 @@ describe('an INLINE budget is fenced by its OWNER, not by a callee (issue #2563)
     expect(found.ownerFound).toBe(true);
     expect(found.resolveCount).toBe(1);
     expect(found.unwrappedLines).toEqual([]);
-    expect(found.distinctWrappers).toBe(1);
     expect(found.perCallBarriers).toEqual([]);
+  });
+
+  it('a method owner is accepted like the other three declaration shapes', () => {
+    // Symmetry, not a shape `scrub.ts` has: once a class-FIELD arrow owner is
+    // accepted, a method of the same name reporting `ownerFound: false` makes
+    // the finder's coverage look arbitrary (issue go-to-k/cdkd#2915 review,
+    // m6). It reds loudly on the first assertion either way, so this pins the
+    // report rather than closing a hole.
+    const source = `
+      class Scrubber {
+        async scrubStack(ids: string[]) {
+          await withSharedDrainBudget(async () => {
+            for (const id of ids) {
+              await resolver.resolve(id);
+            }
+          });
+        }
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.perCallBarriers).toEqual([]);
+  });
+
+  it('a wrapper inside a LOOP written directly in the owner is still per-iteration', () => {
+    // The clause the boundary check does NOT subsume, and the probe issue
+    // go-to-k/cdkd#2894's Proposed fix asked for by name: here the wrapper's
+    // enclosing function IS the owner, so `ts.isFunctionLike` never fires on
+    // the upward path and only `ts.isIterationStatement` reports. Measured on
+    // the tree BEFORE this case existed, deleting
+    // `ts.isIterationStatement(n, false) ||` left all 30 cases green — the
+    // clause was unpinned entirely. With this case and the source-order one
+    // below, that mutant reds the two of them and nothing else.
+    const source = `
+      async function scrubStack(ids: string[]) {
+        for (const id of ids) {
+          await withSharedDrainBudget(async () => {
+            await resolver.resolve(id);
+          });
+        }
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.perCallBarriers).toContain('ForOfStatement');
+  });
+
+  it('an unrelated `.resolve(` OUTSIDE the wrapper reds, and INSIDE it does not', () => {
+    // The any-receiver match is deliberate and the failure message now says
+    // so; both arms of that sentence are pinned here (issue go-to-k/cdkd#2894
+    // item 3, and its verification plan's fifth bullet). Measured: narrowing
+    // the matcher to `resolver.resolve` — which also drops the element-access
+    // arm — left every case green before this one and the element-access case
+    // below existed, since every other source under test spells it that way;
+    // with them, that mutant reds exactly those two.
+    const outside = `
+      async function scrubStack(ids: string[]) {
+        await Promise.resolve();
+        await withSharedDrainBudget(async () => {
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      }
+    `;
+    const outsideFound = analyseSharedBudget(outside, 'scrubStack');
+    expect(outsideFound.resolveCount).toBe(2);
+    expect(outsideFound.unwrappedLines).toHaveLength(1);
+
+    const inside = `
+      async function scrubStack(ids: string[]) {
+        await withSharedDrainBudget(async () => {
+          await Promise.resolve();
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      }
+    `;
+    const insideFound = analyseSharedBudget(inside, 'scrubStack');
+    expect(insideFound.resolveCount).toBe(2);
+    expect(insideFound.unwrappedLines).toEqual([]);
+  });
+
+  it('an ELEMENT-ACCESS resolve call outside the wrapper reds too', () => {
+    // The second half of the any-receiver match, and the arm a narrowing
+    // mutant removes wholesale: `resolver['resolve']()` escaped a
+    // receiver-name filter during go-to-k/cdkd#2797's review, and nothing
+    // pinned it until here.
+    const source = `
+      async function scrubStack(ids: string[]) {
+        await resolver['resolve'](ids[0]);
+        await withSharedDrainBudget(async () => {
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.resolveCount).toBe(2);
+    expect(found.unwrappedLines).toHaveLength(1);
+  });
+
+  it('a bodyless owner declaration is not reported as the owner', () => {
+    // `ownerFound` must describe what was found, not what was named (issue
+    // go-to-k/cdkd#2915 review, m1): an overload signature or a `declare`
+    // used to match, giving `{ownerFound: true, resolveCount: 0}` — the floor
+    // reds either way, but the report was a lie about which case it was.
+    const source = `
+      declare function scrubStack(ids: string[]): Promise<void>;
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(false);
+    expect(found.resolveCount).toBe(0);
+  });
+
+  it('an owner with no wrapper at all reports ZERO shared wrappers', () => {
+    // `distinctWrappers` counted `undefined` as a member, so "no wrapper
+    // anywhere" reported 1 — indistinguishable from "one shared wrapper"
+    // (issue go-to-k/cdkd#2915 review, m2).
+    const source = `
+      async function scrubStack(ids: string[]) {
+        for (const id of ids) {
+          await resolver.resolve(id);
+        }
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.resolveCount).toBe(1);
+    expect(found.distinctWrappers).toBe(0);
+    expect(found.unwrappedLines).toHaveLength(1);
+  });
+
+  it('an OVERLOAD signature does not capture the owner from its implementation', () => {
+    // The half of the body test that matters: a `declare` only made the report
+    // lie, but an overload sitting above its implementation makes the finder
+    // stop at the signature and red a tree that is entirely correct (issue
+    // go-to-k/cdkd#2915 review). Pinning "reject `declare`" alone would leave
+    // this shape broken, which is why the test is written against the
+    // invariant — the owner is the declaration that HAS a body.
+    const source = `
+      async function scrubStack(ids: string[]): Promise<void>;
+      async function scrubStack(ids: string[]) {
+        await withSharedDrainBudget(async () => {
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.perCallBarriers).toEqual([]);
+  });
+
+  it('an ANONYMOUS function declaration in the same file does not break the walk', () => {
+    // The name-PRESENCE half of the guard, which the quoted-name case does not
+    // reach: `FunctionDeclaration.name` is optional, so `export default
+    // function () {}` gives `node.name === undefined` and an unguarded
+    // `ts.isIdentifier(node.name)` throws on it before the real owner is ever
+    // seen (issue go-to-k/cdkd#2915 review). A negative control: the owner
+    // below must still be found, with the anonymous declaration walked past.
+    const source = `
+      export default function () {
+        return 1;
+      }
+      async function scrubStack(ids: string[]) {
+        await withSharedDrainBudget(async () => {
+          for (const id of ids) {
+            await resolver.resolve(id);
+          }
+        });
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(true);
+    expect(found.resolveCount).toBe(1);
+    expect(found.unwrappedLines).toEqual([]);
+    expect(found.perCallBarriers).toEqual([]);
+  });
+
+  it('a QUOTED method name is not the owner', () => {
+    // `PropertyName` covers string literals and computed names, and
+    // `"scrubStack"() {}` carries `.text === 'scrubStack'`. Accepting it would
+    // widen the finder past the declaration shapes this fence understands, so
+    // the identifier test is what this pins (issue go-to-k/cdkd#2915 review).
+    const source = `
+      class Scrubber {
+        async "scrubStack"(ids: string[]) {
+          await withSharedDrainBudget(async () => {
+            for (const id of ids) {
+              await resolver.resolve(id);
+            }
+          });
+        }
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.ownerFound).toBe(false);
+    expect(found.resolveCount).toBe(0);
+  });
+
+  it('the barrier walk does not depend on which resolve comes FIRST in source order', () => {
+    // Driving the walk from `owned[0]` made it vacuous whenever the first
+    // `.resolve(` in source order was unwrapped: the start point is
+    // `undefined`, so no barrier is ever reported, and the loop below goes
+    // unseen (issue go-to-k/cdkd#2915 review, m3). Safe in practice only
+    // because `unwrappedLines` reds first — a check that needs a bodyguard is
+    // not a check.
+    const source = `
+      async function scrubStack(ids: string[]) {
+        await resolver.resolve(ids[0]);
+        for (const id of ids) {
+          await withSharedDrainBudget(async () => {
+            await resolver.resolve(id);
+          });
+        }
+      }
+    `;
+    const found = analyseSharedBudget(source, 'scrubStack');
+    expect(found.resolveCount).toBe(2);
+    expect(found.unwrappedLines).toHaveLength(1);
+    expect(found.perCallBarriers).toContain('ForOfStatement');
   });
 });
 
+/**
+ * The engine-level consequence, on the path the issue actually reports: an
+ * `Export.Name` built by `Fn::Join` from a secret reference and a sibling that
+ * THROWS. The engine resolves that name into a PRIVATE `nameSecrets` map and
+ * copies it into the pass map in a `finally`; pre-drain the sibling's
+ * recording landed after that copy and the pass map never learned the
+ * plaintext.
+ *
+ * THE DISCRIMINATOR IS A LATER EXPORT NAME, not the failing one. A name whose
+ * literal text carries a plaintext the pass knows is REFUSED and not keyed
+ * (the exposure guard); one whose plaintext the pass does NOT know is
+ * published, putting the secret in the export key space and in state. So the
+ * drain is observable as "the later name was refused", which is exactly what
+ * the missing needle would have allowed through.
+ *
+ * Uses the REAL resolver — `deploy-engine-outputs-export-name-collision.test.ts`
+ * replaces it wholesale and so pins the copy's SEQUENTIAL shape only.
+ */
 describe('the engine Export.Name copy sees a concurrent sibling record (issue #2563)', () => {
   const stackName = 'drain-export-name-stack';
 


### PR DESCRIPTION
## Summary

Two follow-ups from go-to-k/cdkd#2797's review (m18 / m19), filed as go-to-k/cdkd#2894 and go-to-k/cdkd#2895 and taken together because both land in the same fence in one file. Tests only — no `src/**` change.

**go-to-k/cdkd#2894 — the owner-keyed case counted the wrong barrier.** It asserted "one shared wrapper, and no ITERATION STATEMENT between it and the owner", and `ts.isIterationStatement` does not match a callback. So

```ts
await Promise.all([1].map(async () => withSharedDrainBudget(async () => { /* the loops */ })));
```

passed while opening one budget per element — exactly the per-iteration budget the hoist removed. The barrier is now any function boundary as well: in the shape the case exists to hold, the wrapper sits directly in the owner's own body, so a function-like node between the two means the budget is opened once per call of THAT function rather than once per call of the owner. The walk stops at the owner's FUNCTION node rather than its declaration, so a `const` or class-field owner is not counted as its own barrier.

Its false-positive message is corrected too. The walk matches ANY receiver's `resolve` by design, so a plain `Promise.resolve()` in `scrubStack` reds it — deliberate, but previously reported as "a resolver.resolve … outside withSharedDrainBudget", naming a call that need not be there.

**go-to-k/cdkd#2895 — the cross-stack pre-pass is fenced by its call sites.** `resolveCrossStackReads` carries the per-leaf multiplier and is invisible to the owner-keyed walk: it is built by `makeCrossStackPrePass` at module scope and returned as a closure, so its own `resolver.resolve` sits outside `scrubStack`'s subtree. Its CALL SITES are inside `scrubStack`, which is the property worth holding, so it becomes a row in the callee-keyed table — the shape that already fences `resolveOutputs`, `resolveImportedProperties` and `buildResolvedParametersPerStack`.

**One part of go-to-k/cdkd#2894 is deliberately NOT closed**, and is recorded as a KNOWN LIMIT at the wrapper match: the wrapper is matched by identifier TEXT, so a local `const withSharedDrainBudget = async (fn) => await fn()` shadowing the import satisfies the walk while opening nothing. Closing it means introducing symbol resolution — a mechanism this fence uses nowhere else — for a shape nobody writes by accident. Chasing one spelling per round is what made the parent PR need nine of them; the limit is named instead.

## Test plan

The walk is extracted into `analyseSharedBudget(sourceText, owner)` so the two NEW clauses are pinned by synthetic sources, not only by the real tree — which carries neither shape, and so leaves both mutants green. Every number below is measured, of 30 cases in this file:

| mutation | reds |
| --- | --- |
| `scrubStack`'s wrap rewritten as `Promise.all([1].map(async () => withSharedDrainBudget(...)))` | the owner-keyed real-tree case, `['ArrowFunction']` — and the PRE-change fence stayed green on the same mutation (`26 passed`), which is the hole go-to-k/cdkd#2894 reports |
| a fourth `resolveCrossStackReads` call added above the wrap | the new callee row, naming the added line |
| the callee renamed at its three sites | the row's floor (`expected 0 to be >= 3`) |
| `ts.isFunctionLike` deleted from the barrier | the callback case alone (`1 failed \| 29 passed`) |
| the barrier walk stopped at the owner's DECLARATION | both arrow-owner cases (`2 failed \| 28 passed`, reproduced three times) |
| `ts.isPropertyDeclaration` dropped from the normalisation | the class-field case alone (`1 failed \| 29 passed`) |

The real-tree case survives all three of the last group — which is why the synthetic ones exist. Production files were restored byte-exact after every probe (`git diff` clean).

Full suite 971 files / 21246 passed / 1 skipped, rc=0, run root asserted; `vp check --fix` + `vp run check` + `typecheck:test` + `build` + `gen:all-matrices` + `audit:coverage:check` all rc=0.

**No docs or changelog entry**, deliberately: CLAUDE.md writes an entry only for a user-visible behavior delta, and this changes no shipped behavior. `.claude/rules/layout-deployment.md` describes which src loops wrap in `withSharedDrainBudget`, which this PR does not change.

Codex: 3 delta rounds and 4 maintainer-checklist proxy rounds. The proxy pass is what found both defects worth having — a comment claiming "nothing reddens" for a mutation this PR's own new row catches, and the two new clauses being asserted rather than pinned.

**Review round 1** (commit `4e338e7d`) — all five required items and all six optional ones. The blocker was mine: with the function boundary added, `ts.isIterationStatement` became unreachable in every shape under test, so deleting it left all 30 cases green. go-to-k/cdkd#2894's Proposed fix warned about exactly that ("the boundary check alone is not a replacement ... both are needed") in a part of the issue body I had truncated away; two more required items were bullets in the same tail.

The fence now has 40 cases and every clause has a mutant that reds it and nothing else:

| mutation | reds |
| --- | --- |
| `ts.isIterationStatement(n, false) \|\|` deleted | loop case + source-order case |
| `ts.isFunctionLike(n)` deleted | callback case |
| barrier walk stopped at the DECLARATION | both arrow-owner cases |
| `ts.isPropertyDeclaration` dropped | class-field case |
| body test replaced by a `declare`-only rejection | overload case |
| `ts.isIdentifier(node.name)` dropped | quoted-method case |
| `node.name !== undefined` dropped | anonymous-declaration case |
| `distinctWrappers` counting `undefined` | no-wrapper case |
| barrier walk driven by `owned[0]` | source-order case |
| receiver match narrowed to `resolver.resolve` | Promise.resolve case + element-access case |
| a fourth `resolveCrossStackReads` above the wrap / the callee renamed | the new row / its floor |

Also in the round: the `scrub.ts` wrapper is inside a `try`, so "sits directly in the owner's body" was wrong; the function-boundary clause is an OVER-approximation (a helper called once reds) and is now labelled `KNOWN LIMIT` in both the comment and the failure message; the go-to-k/cdkd#2895 row's claim is narrowed to calls SPELLED `resolveCrossStackReads`, since an aliased binding passes.

One bullet of go-to-k/cdkd#2894's verification plan is deliberately unmet: the local-shadow mutant still passes. That is the KNOWN LIMIT documented at the wrapper match — closing it needs symbol resolution, which the issue itself offers as a branch to weigh rather than a requirement.

Full suite 971 files / 21256 passed / 1 skipped, rc=0, root asserted. Codex: 2 delta rounds and 3 maintainer-checklist proxy rounds on the round's delta, plus 3 rounds on the reply itself.

Closes #2894
Closes #2895
