### PR TITLE
chore(verify-pr): stop exempting a prose-only fix round from re-review

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -195,16 +195,17 @@ Run each check and report pass/fail:
      fixes introduced). Scope round 2 to the delta and say the original
      design is accepted.
    - **The rule RECURSES — "review every fix round", not "the second round".**
-     Keep going while the round just applied contains anything beyond prose;
-     a TEST rewrite counts (PR #2420: a round-2 fix replacing a crude
+     Keep going while the round changed anything, PROSE INCLUDED — a fix's
+     rationale is its least-probed text (4 false ones, PRs #2913 / #2916); a
+     TEST rewrite counts too (PR #2420: a round-2 fix replacing a crude
      assertion with a derived one dropped a wire fact the crude form had been
      pinning by accident — only a third round found it). When a round
      REPLACES an assertion rather than adding one, KEEP BOTH unless you can
      NAME, in the commit message, the mutation the old one could not catch.
      "More precise" is not that name: precision is not a superset of what it
      replaces, and if you cannot name the mutation the replacement is a
-     deletion (issue #2606: four rounds on one PR, each fix blind on a
-     different axis than the assertion it dropped, every one measured green).
+     deletion (issue #2606: four rounds, each fix blind on a different axis
+     than the assertion it dropped).
    - Corollary for mutation probes: **enumerate the branches the diff ADDS
      and probe each one** — a new `if`, a new token in a rendered string, a
      new early return and a new gate condition are four probes, not one.


### PR DESCRIPTION
## What

The `/verify-pr` recursion rule said:

> Keep going while the round just applied contains anything **beyond prose**

That exempts exactly the text the defects turned out to live in. This inverts it.

## The measurement

Across the two lanes of one session — go-to-k/cdkd#2913 and go-to-k/cdkd#2916 — **four rounds shipped a rationale that was false about the code beside it**, and every one was caught only by the next round:

| claim | what was true |
|---|---|
| "anchored on the same reasoning as `is unable to assume the role`" | that entry drops its service anchor because AWS emits none; this one drops an anchor that exists — the opposite trade |
| "3 attempts (7s)" | three attempts is two sleeps, 1s + 2s = 3s. Copied out of the subject file's own stale comment, which was also wrong |
| "a replacement collision never reaches this catch" | it does; the `ProvisioningError` check is what refuses it. Three of four reviewers found this independently |
| "SUPPRESS covers what quoting cannot make safe to PRINT" | the prose beside it printed the raw value in both branches |

go-to-k/cdkd#2916's fourth round was **prose-only** and still found one.

## Why the asymmetry

A fix gets probed; the sentence explaining it does not — because agreeing with the finding *feels* like the verification. And the rationale is precisely the text a later reader trusts instead of re-deriving, which is what makes a wrong one durable.

So the exemption is inverted rather than narrowed.

## Byte budget

`skill-file-payload.test.ts` caps this file at 23000 B and it sat at 22921 — 79 B of headroom, which is the mechanical stop on the growth loop working as intended. The addition is paid for by tightening the issue-2606 parenthetical, which restated the sentence above it rather than adding to it. Net: 22964 B, so the next edit is not born red.

The operational half — open the file a claim names rather than recalling it, compute any number from the code, and DELETE a guard you are about to call unreachable — lives in the memory rule, so this file stays a pointer and not a corpus.

## Verification

- 972 files / 21256 tests green, `skill-file-payload` included
- no `src/` change; this is agent instructions only
