### PR TITLE
chore(work-issues): fold back the integ-fixture sweep, the refusal-premise rule, and the per-lane scratch name

### DIFF
--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -35,17 +35,29 @@ started: no branch exists yet and no file is held. If you want this issue, take 
 it and say so here; I will stand down."
 ```
 
-And when the run ends before reaching one, **stand it down rather than leaving
-the claim standing** — a QUEUED claim that outlives its session is the stale
-lock §9 makes a mechanical step of releasing. Say it is unclaimed, and carry the
-four classification fields so the next session inherits the triage instead of
-redoing it:
+And when the run ends before reaching one — or a lane never becomes RUNNABLE
+because another SESSION's open PR holds its file, §2's off-limits rule reaching
+across sessions — **stand it down rather than leaving the claim standing**: a
+QUEUED claim that outlives its session is the stale lock §9 makes a mechanical
+step of releasing. Say it is unclaimed, carry the four classification fields so
+the next session inherits the triage instead of redoing it, and **when the
+blocker is EXTERNAL, name the query that clears it** — "the session ended" has
+nothing to watch, "PR #N holds `<file>`" has `gh pr view <N> --json state`
+(2026-09-10: go-to-k/cdkd#2847 / go-to-k/cdkd#2885 stood down on open
+go-to-k/cdkd#2911). **Pass it via `--body-file`**: the resume query is
+BACKTICKED, and inside `--body "..."` the shell executes it and substitutes
+empty output — §9 has the same defect for the commit message.
 
 ```bash
-gh issue comment <n> --body "Standing this down UNCLAIMED — the session that \
-queued it ended first. Session-fit: next (not this session) — <reason>. \
-Severity: <v> — <what stays broken>. Effort: <v> — <cycle>. Estimate: <t> — \
-<what eats it>."
+cat > "$SCRATCH/standdown-<n>.md" <<'EOF'
+Standing this down UNCLAIMED — <the session that queued it ended first | open
+PR #N holds <file>>. <Resume query, when the blocker is external.>
+Session-fit: next (not this session) — <reason>.
+Severity: <v> — <what stays broken>.
+Effort: <v> — <cycle>.
+Estimate: <t> — <what eats it>.
+EOF
+gh issue comment <n> --body-file "$SCRATCH/standdown-<n>.md"
 ```
 
 For EACH issue you will start:

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -62,11 +62,15 @@ after any refusal.
   the full suite, passing alone) reads as cross-file pollution. **Verify a
   restore rather than assuming it, in the same call**:
   `cp <snap> <file> && grep -c '<a marker of the fixed state>' <file>`.
-- **Its next-worst is a STALE file from an earlier session** — `/tmp/pr-body.md`
-  is conventional and shared, so a gate can report violations this session
-  never wrote. If a gate names text you do not recognise, check the file's
-  mtime. Give body files a per-session name (the scratchpad directory plus a
-  suffix), as §5 does for probe files.
+- **Its next-worst is a STALE file left by an earlier LANE** — `/tmp/pr-body.md`
+  and a squash `commit-msg.txt` are conventional and shared, and a session's
+  lanes run serially through one scratchpad, so the post-refusal retry consumes
+  whatever the last writer left. A gate naming text you do not recognise is the
+  lucky case: usually NOTHING names it and a plausible file of the right shape
+  ships (2026-09-10: lane 2 committed lane 1's message after `check-gate`
+  discarded the write). Name consumable files per LANE — not per session, the
+  granularity that fails here — as §5 does for probe files and §9 for the
+  squash message, and re-read the file where you consume it.
 
 **"All green" is the EXIT CODE, not the summary.** A run can report every test
 passing and still exit non-zero, printing the two facts on adjacent lines

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -16,10 +16,9 @@ Never edit in the main checkout (`main-tree-branch-gate` blocks branching
 there). Per lane:
 
 ```bash
-# MAIN-CHECKOUT only; CLAUDE.md holds this recipe and why IN-PLACE (in a
-# linked worktree) creates NO worktree. IN-PLACE skips these two and branches
-# by the unconditional recipe below. (Mode probe: references/launch-mode.md,
-# its only copy.)
+# MAIN-CHECKOUT only (CLAUDE.md holds it, and why IN-PLACE creates NO
+# worktree; mode probe: references/launch-mode.md, its only copy).
+# IN-PLACE skips these two and branches by the recipe below.
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 cd .claude/worktrees/<branch>
 mise trust && mise install   # untrusted .mise.toml: vp / markgate will not resolve
@@ -28,10 +27,10 @@ vp run build                 # ...and no dist/ — see below
 ```
 
 **IN-PLACE: confirm the tree is YOURS before adopting it** — a stray `cd` into
-a peer's live lane looks exactly like a workspace handed to you. Read every
-probe below under §9's rule that every ownership signal establishes LIFE and
-never absence: any one saying "someone is here" means STOP and report — never
-nest a worktree inside a peer's lane to get out of it.
+a peer's live lane looks like a workspace handed to you. Under §9's rule that
+an ownership signal establishes LIFE and never absence, any probe below saying
+"someone is here" means STOP and report — never nest a worktree in a peer's
+lane to get out of it.
 
 ```bash
 # The FIRST line is the anchor: every probe under it describes THIS shell's
@@ -49,18 +48,16 @@ is the only signal the probes above cannot see.
 
 The rule is SYMMETRIC: **the orchestrator does not edit a live lane's tree
 either.** An uncommitted parent edit there is wiped without a trace by the
-lane's next amend + force-push — the lane never sees it and no conflict is
-reported (measured 2026-09-05: a parent-side `.claude/rules` trim vanished
-into go-to-k/cdkd#2620's fix round, and both parties were trimming the same
-cumulative budget). Hand the edit to the lane as an instruction and let the
-lane own the write.
+lane's next amend + force-push — no conflict is reported (2026-09-05: a
+parent-side `.claude/rules` trim vanished into go-to-k/cdkd#2620's fix round,
+both parties trimming the same cumulative budget). Hand the edit to the lane as
+an instruction; the lane owns the write.
 
 **Take a fresh branch here — ALWAYS, and WITHOUT leaving the tree.** The
 branch this tree arrived on is `LAUNCH_BRANCH`: the OUTER TOOL's, not this
 run's, and §9 puts it back untouched at the end (`references/launch-mode.md`
 carries the rule and why committing onto it would DELETE the outer tool's
-branch). The ALWAYS is deliberate: the rule was conditional until
-go-to-k/cdkd#2417 and the condition was wrong in the common case.
+branch, and why the ALWAYS is unconditional — go-to-k/cdkd#2417).
 
 ```bash
 git status --porcelain   # must be empty FIRST -- `git switch` carries
@@ -105,23 +102,20 @@ named, grep the shape across the repo. Rules, each bought by a measured miss:
   ```
 
   go-to-k/cdk-local (2026-08-27): the remedy-shaped grep saw 5 of 12 eligible
-  sites. This repo's defects are often missing entries (an absent
-  `handledProperties` row, a provider with no validation arm) — invisible to a
-  grep for what they lack.
-- **A count from the instance you happened to hit is not a count** — one run
-  sized a residue "one site, ~30 min"; the class was seven. `Effort` /
-  `Estimate` are what a future session budgets from.
-- **A FIX ROUND owes the same sweep, and that is where it gets skipped**: the
-  fix lands on one call site while a sibling keeps the defect, usually shipping
-  a comment claiming completeness. Measured on two lanes in one day: the 2-arg
+  sites — this repo's defects are often MISSING entries (an absent
+  `handledProperties` row), invisible to a grep for what they lack.
+- **A FIX ROUND owes the same sweep, and a sibling takes the same REMEDY only
+  when it takes the same PREMISE — for a REFUSAL, what refusing COSTS there.**
+  The sweep half is what gets skipped: the fix lands on one call site while a
+  sibling keeps the defect, usually shipping a comment claiming completeness.
+  Measured on two lanes in one day: the 2-arg
   `Fn::Sub` check missing the bare-string arm one line over; a redaction fixing
   update/delete but not create; one enumeration fixed while a second in the
   same file — and a third on the same LINE — kept the defect. All found by
-  enumerating readers with grep, none by re-reading the diff. **So does a SWEEP, over its OWN
-  output** — re-run the predicate on the
-  diff the sweep produced (go-to-k/cdkd#2662: three of a run's ten
-  false-guarantee comments were added or left by a sweep meant to end that
-  class). After writing a fix:
+  enumerating readers with grep, none by re-reading the diff. **So does a
+  SWEEP, over its OWN output** — re-run the predicate on the diff the sweep
+  produced (go-to-k/cdkd#2662: three of a run's ten false-guarantee comments
+  were added or left by a sweep meant to end that class). After writing a fix:
 
   ```bash
   # Derive the population from the CODE, not the files your diff touched.
@@ -129,7 +123,16 @@ named, grep the shape across the repo. Rules, each bought by a measured miss:
   ```
 
   Cheap tell: a diff touching ONE site whose message says "every", "all",
-  "never" or "only" — derive the population or drop the quantifier.
+  "never" or "only" — derive the population or drop the quantifier. The PREMISE
+  half is worse because it looks done: enumerate the DESTINATIONS a refusal
+  reaches before round one and key on the destination, never on the EVIDENCE
+  (an empty map — the near-miss that survived two rounds). It kept returning
+  as a blocker across go-to-k/cdkd#2882 / go-to-k/cdkd#2912 in two residual
+  flavours: a mask written where refusing is a REGRESSION (`export` blocks the
+  record), and a pairing floor whose refusal WRITES a token over a live value
+  in the arm that borrowed it while safely DROPPING THE RESOURCE in the arm it
+  came from (`drift.ts`'s `acceptForcedSingleton` doc states it at the site
+  that paid).
 - **Grep for the SHAPE, not a NAME — then close the set from the READERS,
   because a literal shape is defeatable too.** A name finds only the copies you
   knew about (go-to-k/cdkd#2176: `maskDeep` found four and shipped "four";
@@ -139,7 +142,10 @@ named, grep the shape across the repo. Rules, each bought by a measured miss:
   structural line every copy must share, confirm by name second, take the COUNT
   from an enumeration of the readers.
 - **Count the population BEFORE you fix, assert it afterwards** — the post-fix
-  tree cannot show a copy the sweep never saw. A fix REMOVING a behaviour owes
+  tree cannot show a copy the sweep never saw, and a count taken from the
+  instance you happened to hit is what a future session's `Effort` /
+  `Estimate` is wrong by (one run sized a residue at one site; the class was
+  seven). A fix REMOVING a behaviour owes
   a SECOND population: the assertions that it happens, which do not go red when
   it stops (`references/verify.md` §8-d).
 - **A sweep's number is unearned until you paste the command that produced
@@ -147,9 +153,9 @@ named, grep the shape across the repo. Rules, each bought by a measured miss:
   13 files"; the reviewer's grep returned 47. A count RELAYED from a subagent
   is the same failure without a command (FOUR published in one run, all wrong),
   and AGREEING with one is not corroboration: on go-to-k/cdkd#2719 a subagent
-  and I both published "five sites" where `grep -c` said seven. The tell is grammatical — a number
-  arriving as a WORD was counted by an agent, as OUTPUT by a machine. Give it
-  one of `references/verify.md` §8-g's three dispositions before shipping.
+  and I both said "five sites" where `grep -c` said seven. The tell is
+  grammatical — a number arriving as a WORD was counted by an agent, as OUTPUT
+  by a machine. Give each one of `references/verify.md` §8-g's dispositions.
 - **Grep the SYMPTOM before deriving a fix** — the same QUESTION may already
   be answered (a lane spent a real-AWS round trip rediscovering the SDK
   region-redirect mechanism sitting verbatim in `src/utils/aws-region-resolver.ts`).
@@ -157,14 +163,13 @@ named, grep the shape across the repo. Rules, each bought by a measured miss:
   comment CITING it; the dangerous ones are deliberate NON-assertions carrying
   neither shape nor symptom
   (`git grep -n "<issue number>" -- src tests docs .claude`). Measured on
-  go-to-k/cdkd#2466 closing go-to-k/cdkd#2421: four live citations, including
-  a "deliberately NOT asserted" bullet in a fixture that already synthesized —
-  adding the assertion cost nothing and found a SECOND failure mode. Such a
-  non-assertion is usually the cheapest high-value test in the change.
+  go-to-k/cdkd#2466 closing go-to-k/cdkd#2421: four live citations, one a
+  "deliberately NOT asserted" bullet in a fixture that already synthesized —
+  adding the assertion cost nothing and found a SECOND failure mode, usually
+  the cheapest high-value test in the change.
 
-**A defect the sweep turns up that this lane is NOT fixing gets FILED —
-`references/filing.md` (§5-f)**: N sites of one root cause is ONE issue, the
-dup-check window, the `Severity` / `Effort` labels.
+**A defect the sweep turns up that this lane is NOT fixing gets FILED** —
+`references/filing.md` (§5-f) owns those rules.
 
 ### 5-c. The fix itself
 
@@ -179,55 +184,51 @@ suites run by `run-tests.sh`, not visible from `tests/unit/**`.
   every suite resolves the hook under test from its own script path, so a
   copy fails everything with exit 127. For a before/after comparison, write
   the old copy beside the real one as `.claude/hooks/_old-<name>.test.sh` and
-  delete it after. §8's scratch-copy idiom is right for a data file, wrong
-  for a runnable harness, and wrong for a WORKTREE in a way that WRITES to
-  the live tree (§8 carries the mechanism).
+  delete it after. §8's scratch-copy idiom is right for a data file, wrong for
+  a runnable harness and wrong for a WORKTREE (§8 carries both mechanisms).
 - **When the issue reports a stale ENTRY in an enumerated list, audit the
   whole list in BOTH directions** — every entry still resolves AND everything
   that belongs is present; the second half is the one skipped
-  (go-to-k/cdkd#1972: the issue named one dead path; the audit found a second
-  plus four live surfaces never added). Then make the recurrence mechanical:
-  a list that must stay in sync with the repo is a test, not a sentence.
+  (go-to-k/cdkd#1972: the issue named one dead path, the audit found a second
+  plus four live surfaces never added). A list that must stay in sync with the
+  repo is a test, not a sentence.
 - **Adding a HANDLER to a slot that already has one REPLACES it.** Bash
   `trap` does not chain: a second `trap ... EXIT` silently disarms the first,
   which in an integ fixture is the AWS teardown (a reviewer-nit fix would
   have traded a leaked temp file for live AWS resources on every failure
-  path). Put the work inside the EXISTING handler or re-install one that
-  CALLS the original. Fenced by
-  `tests/unit/scripts/integ-single-exit-trap.test.ts`. Generalize: before
-  adding to any single-slot registration, count what is already there.
+  path). Put the work inside the EXISTING handler or re-install one that CALLS
+  the original (fenced by `tests/unit/scripts/integ-single-exit-trap.test.ts`);
+  before adding to ANY single-slot registration, count what is there.
 
 ### 5-d. Measurement audits
 
 **When the audit is a MEASUREMENT, the shape of the sample is the finding — a
 clean result from the wrong shape is indistinguishable from a clean subject.**
-Auditing go-to-k/cdkd#2096 produced SIX confident wrong answers, each from a
+go-to-k/cdkd#2096's audit produced SIX confident wrong answers, each from a
 plausible sampling shape, each hiding a real secret: newest-N (the newest
-versions come from the run most likely already fixed — sample across the
-range); one global needle (each fixture spells its own literal — derive the
-needle per subject or assert a needle-independent observable); a name derived
-from convention (read the identifier from the subject's own `STACK=` line); a
-silent parse failure inside a pipe (a parse that can fail must report
-failing, not fall through to a count); a per-page aggregate (`--query
-'length(...)'` applies PER PAGE — count rows of a projection); and grepping
-the layer the subject does not use (a type registered to NO provider takes
-the Cloud Control readback, invisible in `src/provisioning/providers/**`).
-The through-line: every one FAILED CLEAN. Run the shape against a case you
-KNOW is dirty first; only then trust a zero.
+versions come from the run likeliest already fixed — sample the range); one
+global needle (each fixture spells its own literal — derive it per subject, or
+assert a needle-independent observable); a name from convention (read it from
+the subject's own `STACK=` line); a silent parse failure in a pipe (a parse
+that can fail must report failing, not fall through to a count); a per-page
+aggregate (`--query 'length(...)'` applies PER PAGE — count rows of a
+projection); and grepping a layer the subject does not use (a type registered
+to NO provider takes the Cloud Control readback, invisible in
+`src/provisioning/providers/**`). Every one FAILED CLEAN: run the shape against
+a case you KNOW is dirty first; only then trust a zero.
 
 ### 5-e. Mutation probes
 
 **COMMIT the round's real fixes BEFORE running any mutation probe** — a probe
-deliberately breaks the tree, and an interruption mid-probe leaves breakage
-and unfinished fixes in one undifferentiated dirty tree (a lane died at the
-session limit with 9 dirty files; go-to-k/cdkd#2416). With a pre-probe commit
-the separator is just `git diff`.
+deliberately breaks the tree, so an interruption leaves breakage and unfinished
+fixes in one dirty tree (a lane died at the session limit with 9 dirty files;
+go-to-k/cdkd#2416). With a pre-probe commit the separator is `git diff`.
 
 **Restore a probe from a BYTE-EXACT COPY, never an inverse string replace**
-(`cp` before, `cp` back after, proved by `git diff -- <file>` printing
-nothing). An inverse replace is a second edit; Python's `str.replace('', x)`
-matches between every character and rewrote an 11 KB file to 838 KB, scoring
-the three probes AFTER it against a corrupted subject.
+(`cp` before, `cp` back, proved by `git diff -- <file>` printing nothing). An
+inverse replace is a second edit: Python's `str.replace('', x)` matches between
+every character and rewrote an 11 KB file to 838 KB, scoring the three probes
+after it against a corrupted subject.
 
 **Probe the CALLER too — a probed callee says nothing about its wiring.**
 go-to-k/cdkd#2719: a predicate with eight probed gates, and deleting the line
@@ -312,9 +313,9 @@ real tree:**
   `Object.assign`, an object literal, a spread rebuild); the injectable
   spelling over the one a PERSON types (go-to-k/cdkd#2052); one spelling
   where the language allows several — probe each (`||` matched while four
-  sites used `??`; widening it found a real unfiled bug —
-  go-to-k/cdkd#2111); and, for GENERATED input, the
-  UPSTREAM form not the generator's output (go-to-k/cdkd#2788 injected
+  sites used `??`; widening it found a real unfiled bug, go-to-k/cdkd#2111);
+  and, for GENERATED input, the UPSTREAM form not the generator's output
+  (go-to-k/cdkd#2788 injected
   `/properties/X`, a prefix the generator strips, so the probe "proving" it
   discriminated used a shape no fixture holds). It governs any probe's VALUE
   input too — ask what property of it the defect depends on (a
@@ -404,8 +405,11 @@ You may fan out **one subagent per lane** (disjoint files): give each its
 worktree path, allowed files, "do NOT touch other lanes' files; STOP and
 report if the fix needs a forbidden one", and **the REPORT SHAPE — the
 report IS the deliverable**: a lane's tool output never reaches you, so a
-one-line "done" loses the run (2 of 3 lanes, 2026-09-05). Resume a thin one
-with "REPORT ONLY, do not touch the tree"; a plain resume re-edits.
+one-line "done" loses the run (2 of 3 lanes, 2026-09-05) — as does a lane that
+finishes with NO report reaching you (twice, 2026-09-10: only its nested
+reviewers' notifications arrived, reading as progress). Never wait on a quiet
+lane: list the agents, resume any already `completed` with "REPORT ONLY, do not
+touch the tree" — a plain resume re-edits.
 
 A subagent's Bash **bypasses the PreToolUse gate hooks** (it can `gh pr create` past `verify-pr-gate`) —
 enforce quality yourself; the orchestrator still gates the MERGE.
@@ -416,10 +420,9 @@ enforce quality yourself; the orchestrator still gates the MERGE.
   same trees were green. Each agent runs only `vp test run <its own suite>`.
 - **A PEER SESSION's suite is invisible to every probe here** — a full suite
   exited 1 with all tests passing (`Worker exited unexpectedly`, load 54, the
-  heaviest vitest belonging to another session's worktree). Before treating a
-  suite failure as a regression, read the rc AND the error section AND
-  `uptime`, and check `ps` for a vitest whose path is not yours; re-run when
-  the machine is quiet.
+  heaviest vitest in another session's worktree). Before reading a suite
+  failure as a regression, check the rc, the error section, `uptime` and `ps`
+  for a vitest whose path is not yours; re-run when the machine is quiet.
 - Budget two fan-out costs: a lane waiting inside a tool call is killed at
   600s of silence (background long runs with a log redirect, poll with
   short `tail`s), and a fix round re-touching an `integ-*` scope invalidates

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -79,9 +79,12 @@ rm -f /tmp/run-touched.$$
 - **Re-read the REASON, not just the files — and when a hit CONTRADICTS it,
   the BODY is the stale side.** A reason anchored to the filing session's own
   state goes false while the decision it justified still stands.
-  `.claude/rules/session-report.md` → Session-fit carries the shape, its
-  boundary against the PR-shaped reason that is refused outright rather than
-  merely expiring, and the incident. Correct the issue when this catches one —
+  `.claude/rules/session-report.md` → Session-fit carries the shape and the
+  incident. **A reason naming an EXTERNAL blocker is checked by RUNNING the
+  query §4 makes it name** — the file criterion above never fires for a
+  stand-down whose file this run never touched (2026-09-10:
+  go-to-k/cdkd#2847 / go-to-k/cdkd#2885 stood down on open go-to-k/cdkd#2911,
+  which merged 20 minutes later). Correct the issue when this catches one —
   and when LANES REMAIN, route a hit whose file a later lane will open into
   that lane's brief instead of noting it (go-to-k/cdkd#2604: a mid-run retro
   logged the cleared blocker as "not that run's lane"; the next lane opened
@@ -122,6 +125,16 @@ probe that reported clear while a lane was live, a stale flag/path/gate name;
 instruction, wrong place — done, but a step too late; (5) followed it and
 still paid — obeyed text, retry anyway.
 
+**Which shape RECURRED is a COUNT, not a recollection** — the tally decides
+which lesson is worth a stage file's remaining bytes, and a retro's own brief
+is prose, so §8-g applies to it (2026-09-10: a brief named one pattern "the
+single most repeated defect across both PRs" and the commit bodies did not bear
+it out). Take the tally BEFORE §9 flattens the lane branches — a merged PR shows
+far fewer commits than it had rounds, a subagent-reviewed run carries no GitHub
+review comment at all, and `--delete-branch` leaves those commit bodies
+reachable from no LOCAL ref (GitHub keeps `refs/pull/<N>/head`), so cite the
+PR, never the sha.
+
 **No evidence, no edit.** A clean run's correct output is one wrap line
 ("retrospective: no skill change — §2 / §4 / §8 held"). A skill grown from
 "this would be nice" stops being read to the bottom.
@@ -159,12 +172,18 @@ unread one.
   incident behind it cannot be re-judged or retired; a rule buried in its own
   incident report is not read.
 - **Pay for what you add**: cut a line this run proved stale, subsumed, or
-  wrong. **A retro NEVER buys room by raising a byte cap or a corpus
-  bound** — the caps in `tests/unit/scripts/skill-file-payload.test.ts` are
-  the mechanical stop on this skill's growth loop, and a retro that raises one
-  converts the stop into a ratchet (a 2026-09-02 retro raised the corpus floor
-  to fit its additions; the 2026-09-04 pass reversed it). A lesson compression
-  cannot pay for splits the stage instead; the floor moves DOWN only.
+  wrong. **A retro NEVER buys room by raising a CAP** — the per-file caps in
+  `tests/unit/scripts/skill-file-payload.test.ts` are the mechanical stop on
+  this skill's growth loop, and raising one converts the stop into a ratchet (a
+  2026-09-02 retro raised a bound to fit its additions; 2026-09-04 reversed
+  it). A lesson compression cannot pay for splits the stage instead.
+  **`MIN_REFERENCE_CORPUS_BYTES` is the one exception, and only RE-DERIVED**:
+  it must stay above `corpus - runnerUp`, so ANY growth lapses it and "moves
+  DOWN only" would make it unmaintainable (go-to-k/cdkd#2720 /
+  go-to-k/cdkd#1837 / go-to-k/cdkd#2779 each re-derived it upward). It buys no
+  room — the same assertion pins it from BELOW, so restoring a prior value
+  under a grown corpus goes RED (measured 2026-09-11). Recompute from the
+  tree, never pick.
 - Do not restate a rule living in `CLAUDE.md` or another step — point at it.
   `CLAUDE.md` is injected into every context, so a stage-file paragraph
   re-explaining a gate it documents is paid for twice in every lane.

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -100,16 +100,30 @@ squash-merges, so flattening loses nothing:
 
 ```bash
 git reset --soft "$(git merge-base origin/main HEAD)"   # one commit
-git commit -F /tmp/cdkd-squash-msg.txt                   # never -m -- see below
+# never -m, never a shared name -- both below. `--show-current` is EMPTY on a
+# detached HEAD, and without `:-$$` that yields `cdkd-squash-.txt`, shared by
+# every detached lane. DERIVE, WRITE and COMMIT in ONE call: shell state dies
+# between tool calls, so a later one recomputes `$$` and reads nothing.
+MSGREF=$(git branch --show-current | tr / -); MSGREF=${MSGREF:-$$}
+MSGFILE="${TMPDIR:-/tmp}/cdkd-squash-${MSGREF}.txt"
+cat > "$MSGFILE" <<'EOF'
+<the squashed message>
+EOF
+git commit -F "$MSGFILE"
 git rebase origin/main                                   # at most one conflict
 ```
 
-**Write the squashed message to a FILE.** It is the longest message the lane
-writes, so likeliest to hold a backtick or an apostrophe, and inside `-m "..."`
-the shell EVALUATES a backtick and drops the word while still creating the
-commit (measured 2026-09-09 on this file's own retro commit: `` `next` ``
-vanished, zsh printed `command not found: next`).
-`commit-msg-heredoc-gate` refuses only the HEREDOC spelling of that defect.
+**Write the squashed message to a FILE, named per BRANCH.** It is the longest
+message the lane writes, so likeliest to hold a backtick or an apostrophe, and
+inside `-m "..."` the shell EVALUATES a backtick and drops the word while still
+creating the commit (measured 2026-09-09 on this file's own retro commit:
+`` `next` `` vanished, zsh printed `command not found: next`).
+`commit-msg-heredoc-gate` refuses only the HEREDOC spelling of that defect. The
+per-branch name is the other half, and this step prescribed a FIXED path from
+go-to-k/cdkd#2878 (2026-09-09) until the next day, when a lane committing from
+a conventionally-named message file shipped the PREVIOUS lane's message — its
+own write having been discarded with the `check-gate` refusal that killed the
+call, caught by `git commit --amend`. §6 carries the general rule.
 
 Enforced by `.claude/hooks/flatten-before-rebase-gate.sh` (refuses `git rebase
 <upstream>` on a 2+-commit branch touching an append-shaped file).

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -48,12 +48,6 @@ by a probe or a trace, never by re-reading the diff:
   `tests/unit/local/docker-argv-redaction-fence.test.ts`, whose
   `readdirSync('src/local')` cannot reach go-to-k/cdkd#2623's `src/assets/**`
   sites).
-- **"TWO SPELLINGS of one question" → make both sites use ONE predicate
-  verbatim** — a better second spelling looks like a fix and passes its own
-  test (go-to-k/cdkd#2134: `producerRegion !== undefined` disagreed with the
-  authority's own `if (!producerRegion)` on the empty string, fail-OPEN).
-  Name the site that OWNS the question; every other site calls or copies it
-  exactly.
 - **"A PROXY for a question only another component can answer" → make that
   component REPORT.** The tell: each proxy is wrong in BOTH directions at
   once (go-to-k/cdkd#2157 / go-to-k/cdkd#2166: "it threw" and "the text
@@ -70,8 +64,6 @@ by a probe or a trace, never by re-reading the diff:
   every probe landed in argument position, never the flag prefix the change
   acted on). A zero measured in the wrong position is not weak evidence; it is
   none.
-- **Derive the reader population before patching readers** — one grep returns
-  every consumer at once; patching one per round IS the cascade.
 - **A benchmark or COST FENCE must exercise the path the change is on** — a
   lane published "+20% latency" from a run that early-returned before the new
   code; go-to-k/cdkd#2333's latency case was vacuous twice, first bailing at a
@@ -90,8 +82,8 @@ list says in one command whether anything is still outstanding.
 
 - **A rebase can stale a `hash: diff` marker on its own** — the merge base
   moves, so an incoming change to a file this branch also touches invalidates
-  it. Rebase BEFORE the integ; push first so CI runs alongside the integ
-  (they are independent — serializing them wastes wall-clock).
+  it. Rebase BEFORE the integ; push first so CI runs alongside it — they are
+  independent, so serializing them spends wall-clock and weakens neither.
 - **Under iterative review rounds, DECLARE the tree final, in words, to
   whoever is still editing it.** Every gate-scoped touch buys another
   real-AWS run — comment-only deltas included, since `hash: diff` digests the
@@ -120,10 +112,10 @@ list says in one command whether anything is still outstanding.
   escaping fix stayed green weakened to keys-only because its fixture had
   nothing to escape).
 - **Reviewer subagents spawned BY A LANE report to the MAIN session** — a lane
-  that dispatches and waits blocks forever while the parent collects verdicts
-  it did not ask for (go-to-k/cdkd#2417). Pick one shape: the lane runs them
-  synchronously, or the parent dispatches and relays verdicts down (§9's
-  queued-versus-`Resuming` rule).
+  that dispatches and waits blocks forever (go-to-k/cdkd#2417). Pick one shape:
+  the lane runs them synchronously, or the parent dispatches and relays down
+  (§9's queued-versus-`Resuming` rule); §5-g owns the rest of the plumbing,
+  including the lane whose OWN report never arrives.
 
 ### 8-c. The live-test tiers
 
@@ -187,8 +179,8 @@ each HALF of a multi-part fix separately** (a scrub lane's probes proved the
 halves independently fenced — a single all-or-nothing revert cannot). Add a
 NEGATIVE CONTROL inside the arm — a sibling case that must NOT trip the new
 behaviour — or a refusal that fires on everything satisfies every positive
-assertion. The vacuity shapes (none visible by reading the script; first,
-second and fourth measured on go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
+assertion. The vacuity shapes, none visible by reading the script
+(go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
 
 - **The host has the trigger but not the EVIDENCE, or the reverse** — a fix
   keying on recorded state needs the state AND the thing it describes in the
@@ -227,10 +219,15 @@ second and fourth measured on go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
   assertion must first require the array to exist).
 - **The inverse, when a fix REMOVES a behaviour: an assertion that it HAPPENS
   goes over-determined, not red** (three fixtures kept passing on accumulated
-  delete markers after go-to-k/cdkd#2450). Sweep the test tree by the
-  assertion's SHAPE, not the issue's wording, and RE-POINT each hit rather
-  than deleting it — a deleted negative control leaves that direction
-  unfenced.
+  delete markers after go-to-k/cdkd#2450). Sweep by the assertion's SHAPE, not
+  the issue's wording, and RE-POINT each hit rather than deleting it — a
+  deleted negative control leaves that direction unfenced. **The sweep must
+  reach `tests/integration/**/verify.sh`**: vitest's `include` is `*.test.ts`
+  under `tests/` and `src/`, which no shell fixture matches, so a `verify.sh`
+  pins a contract no suite EXECUTES (several read them as text) and no
+  diff-reading reviewer sees — go-to-k/cdkd#2882 round 8: `secrets-array-nested`
+  FAILED on a negative control still pinning the residual the PR retired, "the
+  real-AWS integ round caught what six review rounds did not".
 - **A fixture that establishes its precondition on the HAPPY path cannot test
   the arm where the FAILING path creates it** (go-to-k/cdkd#2057: the refusal
   could not fire — its evidence was persisted only by the success path — yet
@@ -248,12 +245,11 @@ second and fourth measured on go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
 Three fixture mechanics, each worth a stubbed dry run (all cost a real-AWS
 cycle on 2026-08-20): a `cleanup` that also runs pre-run must not destroy
 anything the run then needs (a `mktemp -d` at variable-definition time + `rm
--rf` in cleanup deletes the workdir before its first write); before waiting
-for a resource to disappear, verify the probe reports "still present" DURING
-deletion (else the wait is vacuous — measure the window so the budget is a
-number); and a fixture whose only `cdkd destroy` fails BY DESIGN cannot
-honestly flip `integ-destroy` — add a final phase that disables the
-injection, redeploys, and runs a genuinely clean destroy.
+-rf` in cleanup deletes the workdir before its first write); before waiting for
+a resource to disappear, verify the probe reports "still present" DURING
+deletion, else the wait is vacuous; and a fixture whose only `cdkd destroy`
+fails BY DESIGN cannot honestly flip `integ-destroy` — add a final phase that
+disables the injection, redeploys, and destroys cleanly.
 
 ### 8-e. Watching runs and pollers
 
@@ -270,9 +266,8 @@ a `Monitor` on phase lines AND on log-growth stalling.
 - **The harness's "completed, exit 0" is the exit code of the command you
   BACKGROUNDED** — `nohup <job> ... & echo started` reports success while the
   job still runs. Run the long job as the SOLE command of the backgrounded
-  call and read the log's own terminal line. Two nearby traps: a `cd` inside
-  the backgrounded compound leaves the parent's `$VAR` unset, and `grep -c`
-  exits 1 on a count of zero.
+  call and read the log's own terminal line. Nearby trap: a `cd` inside the
+  backgrounded compound leaves the parent's `$VAR` unset.
 
 ### 8-f. Fixture environment prechecks
 
@@ -289,9 +284,9 @@ aws s3 ls "s3://cdkd-state-<acct>/cdkd-bootstrap/"                       # which
 the same code without it** (on the merits, not availability). When docker is
 required (`integ-local`), verify registry reach FIRST (`docker pull
 hello-world` under a 120s cap) — `docker version` says nothing about registry
-networking. `/run-integ`'s "Important" section owns the hang diagnosis, the
-do-NOT-restart-Docker rule, what is never yours to spend, and the rule that a
-run blocked before its assertions is not a failing fix (with its ledger note).
+networking. `/run-integ`'s "Important" section owns the rest: hang diagnosis,
+the do-NOT-restart-Docker rule, and that a run blocked before its assertions is
+not a failing fix (with its ledger note).
 
 ### 8-g. Prose claims are verified to the same bar as code
 
@@ -304,11 +299,15 @@ false claim a review round had read past:
   (a later PR may already have falsified it).
 - **A correction can be a new false claim** — twice the replacement sentence
   was wrong in the other direction. Re-read a correction against the code.
-- **A round finding the SAME CLASS twice means stop fixing instances** — make
-  both sites ask ONE question. Four rounds on go-to-k/cdkd#2719 each subtracted
-  one input from a label meant to mirror a dispatch; every fix was correct and
-  incomplete. The tell: a finding differing from the last only in which input
-  it names.
+- **A round finding the SAME CLASS twice, or TWO SPELLINGS of one question,
+  means stop fixing instances** — name the site that OWNS the question and
+  make every other site call or copy ONE
+  predicate verbatim, because a better second spelling looks like a fix and
+  passes its own test (go-to-k/cdkd#2134: `producerRegion !== undefined`
+  disagreed with the authority's `if (!producerRegion)` on the empty string,
+  fail-OPEN). Four rounds on go-to-k/cdkd#2719 each subtracted one input from a
+  label meant to mirror a dispatch; every fix was correct and incomplete. The
+  tell: a finding differing from the last only in which input it names.
 - **In a FIX round, the fix invalidated your own prose** — every past-tense
   measurement is stale until re-derived (one run: one code defect, TEN false
   claims). Before a fix round is final, re-derive every
@@ -418,14 +417,13 @@ leftover check — the `deployments/` events store legitimately survives it.
 writes it, run by the ORCHESTRATOR after its dispatched reviewers report and
 every blocker is addressed — a lane setting it is the "sub-agent self-review
 is not independent review" failure arriving through the marker (two of three
-lanes on 2026-08-29, go-to-k/cdkd#2383; twice more on 2026-09-04 — the lane
-whose BRIEF named the prohibition was the one that obeyed, so put it there
-too). The merge gate cannot catch it: the sentinel is per-worktree and §9
+lanes on 2026-08-29, go-to-k/cdkd#2383; twice more on 2026-09-04 — only the
+lane whose BRIEF named the prohibition obeyed, so put it there too). The merge
+gate cannot catch it: the sentinel is per-worktree and §9
 merges from the lane's worktree, so a lane setting it after its final push
 matches. The PARENT can, and it is a named step of its own round — read the
-marker
-BEFORE running `/review-pr`, since one already fresh there can only be the
-lane's (`mise exec -- markgate verify pr-review`, then
+marker BEFORE running `/review-pr`, since one already fresh there can only be
+the lane's (`mise exec -- markgate verify pr-review`, then
 `.markgate-pr-review-sha` against `git rev-parse HEAD`; a sha that is not HEAD
 is the tell). On a hit, review from scratch.
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -227,8 +227,11 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // lists, one list went stale when a review round RESTORED a compression it
     // claimed, and the corrected list then under-counted the real ones. Three
     // wrong versions of a figure that pins nothing. `git diff --numstat`
-    // derives it on demand; the floor is NOT re-derived upward to absorb the
-    // net -- retro.md section 10-c forbids it.
+    // derives it on demand; the floor was not re-derived upward in THAT lane
+    // because its net did not lapse it -- not because upward is forbidden.
+    // Section 10-c forbids raising a CAP and requires the floor to be
+    // RE-DERIVED whenever `corpus - runnerUp` crosses it; see beside
+    // MIN_REFERENCE_CORPUS_BYTES.
     //
     // It BREACHED first, which is the useful part of this record. A review
     // round grew 8-g past the point where `corpus - runnerUp` cleared the
@@ -240,9 +243,29 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // recording it here would re-create the drift this paragraph exists to
     // stop. Read that as calibration for the assertion below: the floor is not
     // a formality, it goes red inside an ordinary editing round.
-    corpusBytes: 177_694,
-    largest: { file: 'verify.md', bytes: 29_844 },
-    runnerUp: { file: 'implement.md', bytes: 29_549 },
+    //
+    // 181,299 after the go-to-k/cdkd#2882 / go-to-k/cdkd#2912 retro. Both
+    // per-file caps were BINDING for the first time -- verify.md sat 156 B
+    // from the cap and implement.md 451 B -- so in THOSE TWO files every
+    // addition was funded by a cut in the same file (a near-duplicate bullet
+    // merged into its twin, restatements of another stage file's rule reduced
+    // to pointers, a superseded-revision history line dropped), and both still
+    // ended NET LARGER (implement.md +372, verify.md +84 -- stated by NAME
+    // because the antecedent pair above lists them in the other order).
+    // The stage files with headroom were not held to that: the corpus grew
+    // 3,605 B. Neither CAP moved; the derived corpus FLOOR was RE-DERIVED,
+    // which section 10-c requires rather than forbids -- it must stay above
+    // `corpus - runnerUp`, and the same assertion pins it from below, so the
+    // raise buys no room (probe: restoring the prior value under this corpus
+    // goes RED). The leaders SWAPPED twice across this change's review rounds,
+    // which is why `largest` / `runnerUp` are asserted rather than described.
+    // Margins are deliberately not quoted -- the largest-side one is printed by
+    // the cap's own failure message -- but the calibration to carry forward is
+    // that they are the thinnest on record in BOTH slots, so the next edit to
+    // either file opens with a compression pass, not an addition.
+    corpusBytes: 181_299,
+    largest: { file: 'verify.md', bytes: 29_928 },
+    runnerUp: { file: 'implement.md', bytes: 29_921 },
   },
 };
 
@@ -645,7 +668,26 @@ const MIN_REFERENCE_FILES = 6;
 // 176,352). Inputs now: largest implement.md 28,743, runner-up verify.md
 // 28,516, thresholds 147,609 (largest-side) and 147,836 (runner-up side,
 // binding); 148,200 clears the binding one by 364 B.
-const MIN_REFERENCE_CORPUS_BYTES = 148_200;
+// RAISED 148_200 -> 151_750 by the go-to-k/cdkd#2882 / go-to-k/cdkd#2912 retro
+// (+3,605 B, corpus 177,694 -> 181,299), which landed seven amendments across
+// six stage files. Same mechanical raise as the three above -- the growth is in
+// the non-leader files (retro.md, ship.md, gates-and-pr.md, claim.md), so it
+// pushes the derived floor up. In the two files that ARE the leaders every
+// addition was funded by a cut in the same file per retro.md section 10-c, and
+// both still ended net larger -- the CAPS are what bounded this change, not
+// this floor. A review round read the raise as defeating its own guard, on the
+// ground that a later pass could lower it back and stay green; PROBED
+// 2026-09-11 and that is false -- restoring 148_200 under this corpus fails
+// with "has lapsed ... expected 148200 to be greater than 151378", so the
+// assertion pins this constant from BELOW as well, and lowering it requires
+// compressing first. Section 10-c now states the carve-out it was missing.
+// Inputs at this
+// date: corpus 181,299, largest verify.md 29,928, runner-up implement.md
+// 29,921, so the two thresholds are 151,371 (largest-side) and 151,378
+// (runner-up side, binding); 151,750 clears the binding one by 372 B. The two
+// leaders are now 72 B and 79 B from MAX_REFERENCE_FILE_BYTES -- the binding
+// constraint for the next retro is that cap, not this floor.
+const MIN_REFERENCE_CORPUS_BYTES = 151_750;
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })


### PR DESCRIPTION
## Summary

Retrospective (`references/retro.md` §10) for the `/work-issues` run that merged
go-to-k/cdkd#2882 (issues go-to-k/cdkd#2846 / go-to-k/cdkd#2852 /
go-to-k/cdkd#2869) and go-to-k/cdkd#2912 (issues go-to-k/cdkd#2855 /
go-to-k/cdkd#2881 / go-to-k/cdkd#2893). Seven amendments across six stage files,
each to the file where the lesson fires and each an AMEND of the sentence that
was wrong rather than a sibling bullet.

### `verify.md` §8-d — the removed-behaviour sweep must reach the integ fixtures

The rule already said to sweep for assertions that a behaviour HAPPENS when a
fix removes it. What was wrong is the **population**: vitest's `include` is
`*.test.ts` under `tests/` and `src/`, which no shell fixture matches, so 255
`tests/integration/**/verify.sh` files pin contracts no suite EXECUTES (several
read them as text) and no diff-reading reviewer sees. go-to-k/cdkd#2882's own
round-8 heading is the evidence — *"the real-AWS integ round caught what six
review rounds did not"* — `secrets-array-nested` FAILED on a negative control
still pinning the residual that PR retired. A population defect, not a diligence
one.

### `implement.md` §5-b — a shared REMEDY needs the shared PREMISE re-derived

§5-b tells you to sweep sibling sites and apply the same fix; it had no dual.
For a REFUSAL the premise is what refusing COSTS at that site. The defect kept
returning as a blocker across both PRs in two residual flavours: a mask written
where refusing is a REGRESSION (`export` blocks the record), and a pairing floor
whose refusal WRITES a token over a live value in the arm that borrowed it while
safely DROPPING THE RESOURCE in the arm it came from.
`src/cli/commands/drift.ts`'s `acceptForcedSingleton` doc already states the
rule at the site that paid for it.

### `implement.md` §5-g — a lane can finish with NO report reaching the parent

The existing sentence covered a lane reporting a thin "done". Twice this run a
lane completed with no notification at all; only its nested reviewers' arrived,
reading as progress. Never wait on a quiet lane — list the agents and resume any
already `completed`.

### `ship.md` + `gates-and-pr.md` — the squash message file is named per BRANCH

…and DERIVED, WRITTEN and COMMITTED in one call: `git branch --show-current` is
empty on a detached HEAD (without `:-$$` that yields `cdkd-squash-.txt`, shared
again), and shell state dies between tool calls, so a later call recomputes a
different `$$`. go-to-k/cdkd#2878 prescribed a fixed path on 2026-09-09; the
next day a lane whose write was discarded with a `check-gate` refusal committed
the PREVIOUS lane's message from a conventionally-named file.
`gates-and-pr.md` said "per-session name" — the granularity that fails when one
session runs several lanes through one scratchpad — and its stated signal, "a
gate names text you do not recognise", is the lucky case: usually nothing names
it.

**This PR hit the same class twice while being written** — a `cat A > B` whose
branch-derived `B` resolved to `A` and truncated the source, and a
`markgate set … && git commit` chain that `gated-command-preamble-gate` refused.

### `claim.md` §4 — a stand-down whose blocker is EXTERNAL names the query

The template's reason was hard-coded to "the session that queued it ended
first". Issues go-to-k/cdkd#2847 / go-to-k/cdkd#2885 stood down on open
go-to-k/cdkd#2911 holding `src/cli/commands/import.ts` — a lane that never
became RUNNABLE, not a session that ran out. The body now goes through
`--body-file`, because that resume query is BACKTICKED and inside
`--body "..."` the shell executes it and substitutes empty output — the exact
defect §9 documents for the commit message.

### `retro.md` §10-a — which shape RECURRED is a COUNT

A retro's own handover brief is prose, so §8-g applies to it. Also records where
the tally lives: §9 flattens the lane branches, a merged PR shows far fewer
commits than it had rounds, a subagent-reviewed run carries no GitHub review
comment at all, and `--delete-branch` leaves those commit bodies reachable from
no LOCAL ref — so cite the PR, never the sha.

### `retro.md` §10-0 — the promotion check has no arm for an external blocker

It greps FILE tokens, so it never fires for a stand-down whose blocker is
another session's open PR and whose file this run never touched.
go-to-k/cdkd#2911 merged **20 minutes after** both stand-downs named it, and
nothing re-read them. The check now says to RUN the clearing query §4 makes the
stand-down name.

### `retro.md` §10-c — the DERIVED corpus floor is carved out, by measurement

§10-c forbade raising "a byte cap **or a corpus bound**" and said "the floor
moves DOWN only". That is unmaintainable as stated:
`MIN_REFERENCE_CORPUS_BYTES` must stay above `corpus - runnerUp`, so ANY growth
from ANY lane lapses it — which is why go-to-k/cdkd#2720 / go-to-k/cdkd#1837 /
go-to-k/cdkd#2779 each already re-derived it upward. It now forbids raising a
**CAP** and requires the floor to be **RE-DERIVED**.

The carve-out is safe by measurement rather than assertion. Review's stated
consequence was that a later retro could lower the floor back and stay green;
**probed, and that is false** — restoring `148_200` under this corpus fails with
`expected 148200 to be greater than 151378`. The same assertion pins the
constant from BELOW, so a later pass can only lower it by compressing first, and
the raise buys no room for prose. The stale comment that still read "the floor
is NOT re-derived upward … §10-c forbids it" is corrected.

## Review: five rounds, one shape

Tier is `1-reviewer` (410 LOC / 7 files; agent-instruction files are
deliberately not down-biased). It took five rounds, and **every finding was the
same shape — a figure or mechanism claim of mine that measurement contradicted,
in the change that codifies catching it.**

Four rounds were independent read-only reviewers. Round 4 was a **METHOD change
instead of a fourth reviewer**, per §8-i's "three rounds of that shape means
change the METHOD, not add a round": every figure the diff ADDS was enumerated
off `git diff -U0 | grep '^+'` and re-derived in one pass — which caught two the
reviewers had not reached.

Corrected across the rounds:

- a `MEASURED` comment saying "neither floor moved" forty lines above the floor
  it raised;
- "every addition was funded by a cut in the SAME file", true only of the two
  files at their caps (both still ended net larger), and left un-amended at a
  second site 400 lines away, so the file contradicted itself;
- a refusal-cost gloss that over-fit one of its two residual flavours, carrying
  first an unsupported count ("six") and then a measurably wrong one ("five
  consecutive rounds" — one of which records *"NO defect in the code"*).
  **Dropped rather than re-fixed**, per §8-g's preferred disposition;
- a compression that moved "safely DROPS **the resource**" onto "it",
  collapsing the exact distinction the bullet draws;
- **"21,184 green tests" — a figure appearing nowhere in go-to-k/cdkd#2882**
  (its body reports 21,158 and 21,170), sourced from the handover brief rather
  than the tree;
- a tally ordering taken from that same brief;
- **"a squash-merged PR shows 3 commits"** — generalized from one of the run's
  two PRs (go-to-k/cdkd#2882 has 3, go-to-k/cdkd#2912 has 6, and §9's flatten
  yields 1), inside the bullet that codifies the COUNT rule;
- a delta pair reading backwards against its own antecedents;
- the vitest `include` premise, a misattributed 90 s duration, two commit SHAs
  `--delete-branch` had made unreachable, a detached-HEAD hole in the new
  recipe, a backticked query inside `--body "..."`, and §8-b's rationale lost to
  a compression.

Two cut-audit findings were closed rather than argued: 8-g's merged bullet
regained the "TWO SPELLINGS of one question" trigger the cut bullet fired on,
and the `grep -c` rule the 8-e cut removed is still stated in
`gates-and-pr.md`.

**Won't-do, recorded:** 8-a's "patching one per round IS the cascade" phrasing
did not survive its cut. `implement.md` §5-b's FIX-ROUND bullet states the same
failure and §8-a's opening bullet already says one structural absence explains
why a path keeps generating instances. Both files sit at their caps; a third
phrasing would be the near-duplicate §10-c forbids.

## Paying for the bytes

Both per-file caps were BINDING for the first time — `verify.md` sat 156 B from
`MAX_REFERENCE_FILE_BYTES` and `implement.md` 451 B — so **in those two files
every addition is funded by a cut in the same file** per §10-c, and both still
ended net larger. The stage files with headroom were not held to that, so the
corpus grew 3,605 B, and the comment says so rather than claiming otherwise.
**Neither CAP moved.**

Final measurement, re-read from the tree after the last rebase: corpus 181,299;
largest `verify.md` 29,928; runner-up `implement.md` 29,921; thresholds 151,371
and 151,378; floor 151,750 clearing the binding one by 372 B; cap margins 72 B
and 79 B — the thinnest on record in both slots, recorded so the next retro
opens with a compression pass.

## Test plan

- `vp check --fix` + `vp run check` (rc=0), `vp run typecheck:test`,
  `vp run build`, `vp run gen:all-matrices` + `audit:coverage:check` +
  `vp run format` — no generated drift.
- `vp test run` after the final rebase: **974 files / 21,416 tests green**, run
  root asserted as this worktree.
- The fences owning this diff — `skill-file-payload.test.ts`,
  `work-issues-skill-refs.test.ts`, `work-issues-launch-mode.test.ts`,
  `rule-file-payload.test.ts` — green.
- Every figure the diff adds was enumerated and re-derived against the tree in
  one pass, on top of four independent reviewer rounds.
- The §10-c carve-out is backed by a mutation probe (floor restored to
  `148_200` → RED; byte-exact `cp` restore verified with an empty `git diff`).

## Live test

Tooling-only PR, prose arm of §8's exemption: no `src/**` change, and none of
`integ-destroy` / `integ-broad` / `integ-local`'s scopes is touched (verified by
running each gate's own regex against `git diff origin/main...HEAD
--name-only`). What this diff describes was exercised for real rather than
reasoned about: the gate-liveness probe returned a conclusive `Blocked by
check-gate`; `gated-command-preamble-gate` refused a `markgate set … && git
commit` chain in this lane; `ship.md`'s per-branch recipe was executed; and the
`verify-pr` / `pr-review` sha sentinels were found naming the PREVIOUS lane's
HEAD — the inherited-green case those sentinels exist to catch, live.

## Backlog effect of the run this retro closes

`closed 6 / filed 6 (new 6 / folded 0)` — go-to-k/cdkd#2846, go-to-k/cdkd#2869,
go-to-k/cdkd#2886, go-to-k/cdkd#2855, go-to-k/cdkd#2893, go-to-k/cdkd#2884
closed by the two PRs; go-to-k/cdkd#2885, go-to-k/cdkd#2893, go-to-k/cdkd#2897,
go-to-k/cdkd#2906, go-to-k/cdkd#2919, go-to-k/cdkd#2920 filed.
go-to-k/cdkd#2893 was filed by lane 1 and closed by lane 2 inside the run, so
the net change to the OPEN backlog is zero. `folded = 0` is the healthy reason:
each filing's dup-check searched by CONCEPT and named its neighbours, and the
one natural umbrella (go-to-k/cdkd#2881) is held by another session's work. Area
for the next `/hunt-bugs`: `src/cli/commands/drift.ts`'s revert write-back and
`src/deployment/secret-redaction.ts`'s position walks.

All five open filings hit the promotion criterion — the run-wide-hit-rate case
§10-0 names — so the REASONS were read instead. **They are not one kind**:
go-to-k/cdkd#2885's is an EXTERNAL blocker naming a clearing query,
go-to-k/cdkd#2897's is a scope / consumer-walk reason, and the rest were found
at a merge-ready point. None promotes.

**go-to-k/cdkd#2885's blocker MOVED rather than cleared.** go-to-k/cdkd#2911
merged, but go-to-k/cdkd#2924 opened one minute later and holds the same file;
the issue's clearing query has been re-pointed there.

No user-visible behavior delta, so no changelog entry (go-to-k/cdkd#2779).
