### PR TITLE
test(local): pin the websocket drain's completion arm, and separate the two positions of its leaked-count message

### DIFF
--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -808,6 +808,11 @@ describe('graceful shutdown bounded drain (M3)', () => {
   // awaits this handler.
   const HUNG_DISCONNECT_MS = 15_000;
   const CASE_TIMEOUT_MS = 25_000;
+  // How long the `1/2` case waits for `close()` before reporting that the
+  // drain never gave up. Above the 5s ceiling by the same margin
+  // `HUNG_DISCONNECT_MS` carries, and below `CASE_TIMEOUT_MS` so the
+  // assertion reports rather than the runner.
+  const CEILING_REPORT_MS = 15_000;
 
   beforeEach(() => {
     rieModule.__resetQueue();
@@ -948,15 +953,301 @@ describe('graceful shutdown bounded drain (M3)', () => {
       // a warn reporting the wrong number of leaked handlers satisfied every
       // other line here. What it pins is the MAGNITUDE and not the two
       // POSITIONS: one connection makes numerator and denominator both 1, so
-      // swapping them in the message would still pass. Separating them needs
-      // a second connection whose `$disconnect` settles after the
-      // socket-close loop but before the drain snapshots its count -- and
-      // the width of that window is the load-dependent quantity this case is
-      // being rewritten to stop depending on. Left as the magnitude check
-      // deliberately; the stronger fixture is filed instead.
+      // swapping them in the message would still pass. Separating them takes
+      // a second connection that is pending AT the snapshot and settles
+      // AFTER it -- settling before the snapshot leaves both counts at 1
+      // again -- and the release therefore has to be ordered against the
+      // snapshot rather than timed near it, which is what this case had no
+      // mechanism for. The magnitude check stays here; the `1/2` case below
+      // (issue go-to-k/cdkd#2904) carries the positions, on an
+      // `allSettled` signal that cannot land early.
       expect(drainWarns[0]![0]).toContain('1/1 $disconnect handlers');
       expect(drainWarns[0]![0]).toContain('still in flight');
     } finally {
+      warnSpy.mockRestore();
+      rieModule.invokeRie.mockReset();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      });
+    }
+  }, CASE_TIMEOUT_MS);
+
+  // ---------------------------------------------------------------------
+  // The two gaps issue go-to-k/cdkd#2904 filed against the case above, and
+  // the fixture both of them needed: a `$disconnect` that is RELEASED ON A
+  // SIGNAL rather than after a sleep.
+  //
+  // The signal is `Promise.allSettled`. It is called exactly once in
+  // `websocket-server.ts`, inside the drain and one line AFTER
+  // `drainStartCount` is snapshotted (`Promise.all(closes)` above it is a
+  // different method), so a spy on it says "the drain has started, and the
+  // count it will report has already been taken". Ordering, not timing: the
+  // release below can never land before the snapshot, which is what a sleep
+  // could not promise. The case above rejects a `setTimeout` spy for the
+  // same job because the socket-close loop schedules a 5s timer of its own
+  // and the two are not separable by value; `allSettled` has no such twin.
+  //
+  // It doubles as the vacuity guard the issue's plan asks for: if a case
+  // never registered a `$disconnect`, `close()` takes the `size > 0` early
+  // skip and the spy never fires. Both cases therefore RACE the signal
+  // against `close()` returning and assert which won, so that path reports
+  // itself in milliseconds by name -- a bare await would hang on a promise
+  // that never settles and be killed at `CASE_TIMEOUT_MS` naming nothing.
+  const gatedDisconnect = (): { opened: Promise<void>; release: () => void } => {
+    let release!: () => void;
+    const opened = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { opened, release };
+  };
+
+  /**
+   * Spy on the drain's own `allSettled`, returning both the promise that
+   * settles when the drain starts and the recorded argument — the array the
+   * count is taken from, which `gap 1` asserts on directly.
+   */
+  const watchDrainStart = (): {
+    started: Promise<unknown[]>;
+    restore: () => void;
+    calls: () => number;
+  } => {
+    const real = Promise.allSettled.bind(Promise);
+    let seen = 0;
+    let resolveStarted!: (items: unknown[]) => void;
+    const started = new Promise<unknown[]>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const spy = vi
+      .spyOn(Promise, 'allSettled')
+      .mockImplementation(((items: Iterable<unknown>) => {
+        const arr = Array.from(items);
+        seen += 1;
+        resolveStarted(arr);
+        return real(arr as never);
+      }) as typeof Promise.allSettled);
+    return { started, restore: () => spy.mockRestore(), calls: () => seen };
+  };
+
+  /**
+   * Whether the drain's CEILING actually fired, observed rather than timed.
+   * Wraps every `setTimeout` armed at `SHUTDOWN_DRAIN_MS` and counts the
+   * callbacks that RUN, so "close() returned through completion" becomes an
+   * ORDERING fact — the ceiling had not fired yet — instead of an elapsed
+   * measurement. An elapsed bound cannot do this job: the production timer is
+   * armed several microtasks BEFORE any clock the test can read, so a stall in
+   * between spends the ceiling without the test seeing it, and the
+   * completion-arm mutant passes an elapsed bound (measured by review).
+   *
+   * The socket-close loop above arms 5s timers too, and production never
+   * clears them — they fire ~5s after arming whether or not their socket
+   * closed, so this counter cannot tell them from the ceiling. What makes the
+   * count meaningful is WHEN it is read: at the moment `close()` returns. On
+   * the completion path that is milliseconds in, before any 5s timer has run,
+   * so the count is 0; on the mutant path the ceiling IS one of those
+   * callbacks and `close()` cannot return until it has run, so the count is
+   * non-zero (measured: 2, the ceiling plus the socket-close timer armed
+   * beside it). The residual is a case stalled past 5s before `close()`
+   * returns, where a socket timer would be counted — a false RED, never a
+   * pass.
+   */
+  const watchCeilingFire = (): { fired: () => number; restore: () => void } => {
+    const real = globalThis.setTimeout;
+    let fired = 0;
+    const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      fn: (...args: unknown[]) => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      const wrapped =
+        ms === 5_000
+          ? (...args: unknown[]): void => {
+              fired += 1;
+              fn(...args);
+            }
+          : fn;
+      return (real as unknown as (...a: unknown[]) => ReturnType<typeof setTimeout>)(
+        wrapped,
+        ms,
+        ...rest
+      );
+    }) as unknown as typeof globalThis.setTimeout);
+    return { fired: () => fired, restore: () => spy.mockRestore() };
+  };
+
+  it('returns through the drain COMPLETION arm when the $disconnect settles', async () => {
+    rieModule.__resetQueue();
+    const gate = gatedDisconnect();
+    let disconnectSettled = false;
+    rieModule.invokeRie.mockImplementation(async (_id: string, _meta: unknown, event: any) => {
+      const routeKey = event?.requestContext?.routeKey;
+      if (routeKey === '$connect') return { payload: { statusCode: 200 }, raw: '{}' };
+      await gate.opened;
+      disconnectSettled = true;
+      return { payload: {}, raw: '{}' };
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$disconnect', lambda: 'DisconnectFn' },
+    ]);
+    const server = createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end();
+    });
+    const attached = attachWebSocketServer({
+      httpServer: server,
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+      rieTimeoutMs: 60_000,
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
+    const drain = watchDrainStart();
+    const ceiling = watchCeilingFire();
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      await waitFor(() => attached.registry.size() === 1, 1000);
+      ws.close();
+      // NOT awaited: the drain has to be running for the release below to
+      // mean anything, and `close()` is what runs it.
+      const closing = attached.close();
+      // Raced against `close()` RETURNING, not awaited bare: if the drain is
+      // skipped — the `size > 0` early exit, which a case that registered no
+      // `$disconnect` takes — `drain.started` never settles and a bare await
+      // hangs until the runner kills the case at `CASE_TIMEOUT_MS` with a
+      // deadline message that names nothing. Racing makes that path report
+      // itself, in milliseconds, in this assertion (measured: the mutant
+      // `if (false)` reds here rather than timing out).
+      const reached = await Promise.race([
+        drain.started.then(() => 'drain' as const),
+        closing.then(() => 'closed' as const),
+      ]);
+      expect(reached, 'close() returned without entering the drain').toBe('drain');
+      gate.release();
+      await closing;
+
+      expect(drain.calls(), 'close() reached the drain rather than skipping it').toBe(1);
+      expect(disconnectSettled, 'the $disconnect ran to completion').toBe(true);
+      // THE discriminator, and an ORDERING one. Dropping
+      // `drainComplete.then(...)` from the race leaves only the ceiling, so
+      // `close()` can return no earlier than that timer's callback — and it
+      // returns SILENTLY, since the warn also needs handlers still in flight
+      // and this one finished. "No warn" alone therefore cannot kill that
+      // mutant, which is why this line exists.
+      //
+      // Deliberately NOT an elapsed bound. The ceiling is armed inside
+      // `close()` several microtasks before any clock this case can read, so
+      // a pause in between spends part of it uncounted and the mutant slips
+      // under a `< 5000` comparison (measured during review: a 4.5s pause let
+      // an await-the-ceiling-only path report 501ms). Counting the fired
+      // callback asks the question directly instead.
+      expect(ceiling.fired(), 'close() returned before the drain ceiling fired').toBe(0);
+      const drainWarns = warnSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('graceful shutdown drained for')
+      );
+      expect(drainWarns).toHaveLength(0);
+    } finally {
+      ceiling.restore();
+      drain.restore();
+      warnSpy.mockRestore();
+      rieModule.invokeRie.mockReset();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      });
+    }
+  }, CASE_TIMEOUT_MS);
+
+  it('names the leaked count and the snapshot SEPARATELY: 1 of 2 still in flight', async () => {
+    rieModule.__resetQueue();
+    // Two connections, both pending when the count is snapshotted; one is
+    // released after the snapshot and one is never released, so numerator
+    // and denominator differ and the message's two positions are separable.
+    // The releasable one is chosen by ORDER of dispatch, which is all the
+    // handler can see.
+    const gates = [gatedDisconnect(), gatedDisconnect()];
+    let dispatched = 0;
+    rieModule.invokeRie.mockImplementation(async (_id: string, _meta: unknown, event: any) => {
+      const routeKey = event?.requestContext?.routeKey;
+      if (routeKey === '$connect') return { payload: { statusCode: 200 }, raw: '{}' };
+      const gate = gates[dispatched] ?? gates[gates.length - 1]!;
+      dispatched += 1;
+      await gate.opened;
+      return { payload: {}, raw: '{}' };
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$disconnect', lambda: 'DisconnectFn' },
+    ]);
+    const server = createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end();
+    });
+    const attached = attachWebSocketServer({
+      httpServer: server,
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+      rieTimeoutMs: 60_000,
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
+    const drain = watchDrainStart();
+    try {
+      const first = await openWebSocket(port, '/prod');
+      const second = await openWebSocket(port, '/prod');
+      await waitFor(() => attached.registry.size() === 2, 1000);
+      first.close();
+      second.close();
+      const closing = attached.close();
+      // Raced against `close()` returning for the reason the case above
+      // spells out: a skipped drain never settles `drain.started`, and a
+      // bare await would hand that to the runner as a deadline instead of an
+      // assertion.
+      const reached = await Promise.race([
+        drain.started.then((items) => ({ kind: 'drain' as const, items })),
+        closing.then(() => ({ kind: 'closed' as const, items: [] as unknown[] })),
+      ]);
+      expect(reached.kind, 'close() returned without entering the drain').toBe('drain');
+      // The count's INPUT, asserted before the message that reports it: two
+      // handlers were in flight at the snapshot. Without this the `1/2`
+      // below could be reached by a one-connection race that happened to
+      // register twice.
+      expect(reached.items).toHaveLength(2);
+      // Released AFTER the snapshot, which is the ordering `allSettled`
+      // buys: one settles inside the window, the other never does.
+      gates[0]!.release();
+      // Bounded for the same reason the case above races: the second handler
+      // is never released, so a drain that LOST its ceiling waits on it
+      // forever and `await closing` would be killed by the runner instead of
+      // reporting. The correct path returns at the 5s ceiling, so this bound
+      // carries 10s of margin, and a stall long enough to overrun it fails
+      // RED rather than passing something broken. `CASE_TIMEOUT_MS` stays
+      // above it so this assertion is always the one that speaks.
+      const returned = await Promise.race([
+        closing.then(() => 'closed' as const),
+        new Promise<'hung'>((resolve) =>
+          setTimeout(() => resolve('hung'), CEILING_REPORT_MS).unref?.()
+        ),
+      ]);
+      expect(returned, 'close() never returned — the drain waited past its ceiling').toBe('closed');
+
+      expect(drain.calls(), 'close() reached the drain rather than skipping it').toBe(1);
+      const drainWarns = warnSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('graceful shutdown drained for')
+      );
+      expect(drainWarns).toHaveLength(1);
+      // Both POSITIONS, which one connection cannot separate: swapping the
+      // two interpolations gives `2/1` here and hard-coding `1/1` gives
+      // `1/1`, where the case above passes under either.
+      expect(drainWarns[0]![0]).toContain('1/2 $disconnect handlers');
+    } finally {
+      drain.restore();
       warnSpy.mockRestore();
       rieModule.invokeRie.mockReset();
       await new Promise<void>((resolve) => {

--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -978,15 +978,24 @@ describe('graceful shutdown bounded drain (M3)', () => {
   // the fixture both of them needed: a `$disconnect` that is RELEASED ON A
   // SIGNAL rather than after a sleep.
   //
-  // The signal is `Promise.allSettled`. It is called exactly once in
-  // `websocket-server.ts`, inside the drain and one line AFTER
-  // `drainStartCount` is snapshotted (`Promise.all(closes)` above it is a
-  // different method), so a spy on it says "the drain has started, and the
-  // count it will report has already been taken". Ordering, not timing: the
-  // release below can never land before the snapshot, which is what a sleep
-  // could not promise. The case above rejects a `setTimeout` spy for the
-  // same job because the socket-close loop schedules a 5s timer of its own
-  // and the two are not separable by value; `allSettled` has no such twin.
+  // The signal is `Promise.allSettled`. In `websocket-server.ts` it is called
+  // exactly once, inside the drain and one line AFTER `drainStartCount` is
+  // snapshotted (`Promise.all(closes)` above it is a different method), which
+  // is the ORDERING argument: the release below can never land before the
+  // snapshot, where a sleep tuned near it could. The case above rejects a
+  // `setTimeout` spy for the same job because the socket-close loop schedules
+  // a 5s timer of its own and the two are not separable by value;
+  // `allSettled` has no such twin.
+  //
+  // That file-scoped count is NOT what makes the signal trustworthy, and
+  // saying so would be describing a mechanism this case does not stand on:
+  // the spy replaces the GLOBAL `Promise.allSettled`, so any other caller
+  // reaching it inside the spy window would resolve `started` first, with a
+  // foreign array. Two things close that, and both are deliberate — the spy
+  // is installed immediately before `attached.close()` and removed in
+  // `finally`, so the window is that one call; and `drain.calls()` is
+  // asserted to be exactly 1, which a foreign call turns into 2. The
+  // assertion is doing that job as much as the drain-skip one.
   //
   // It doubles as the vacuity guard the issue's plan asks for: if a case
   // never registered a `$disconnect`, `close()` takes the `size > 0` early
@@ -1105,14 +1114,23 @@ describe('graceful shutdown bounded drain (M3)', () => {
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const port = (server.address() as AddressInfo).port;
     const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
-    const drain = watchDrainStart();
-    const ceiling = watchCeilingFire();
+    // Assigned inside the `try` rather than here: both patch GLOBALS, so a
+    // throw between two bare installs would leave one of them in place for
+    // the rest of the file (`vite.config.ts` sets neither `restoreMocks` nor
+    // `clearMocks`, so nothing else puts it back). Installed as late as
+    // possible for the same reason — the narrower the window, the less any
+    // other caller can be mistaken for the drain.
+    let drain: ReturnType<typeof watchDrainStart> | undefined;
+    let ceiling: ReturnType<typeof watchCeilingFire> | undefined;
     try {
       const ws = await openWebSocket(port, '/prod');
       await waitFor(() => attached.registry.size() === 1, 1000);
       ws.close();
-      // NOT awaited: the drain has to be running for the release below to
-      // mean anything, and `close()` is what runs it.
+      // Same tick as `ws.close()` and as the spy installs: `close()` snapshots
+      // `wss.clients` synchronously, and NOT awaited here because the drain
+      // has to be running for the release below to mean anything.
+      drain = watchDrainStart();
+      ceiling = watchCeilingFire();
       const closing = attached.close();
       // Raced against `close()` RETURNING, not awaited bare: if the drain is
       // skipped — the `size > 0` early exit, which a case that registered no
@@ -1129,7 +1147,11 @@ describe('graceful shutdown bounded drain (M3)', () => {
       gate.release();
       await closing;
 
-      expect(drain.calls(), 'close() reached the drain rather than skipping it').toBe(1);
+      // TWO jobs, both load-bearing: `close()` reached the drain rather than
+      // taking the `size > 0` skip, AND nothing but the drain called
+      // `allSettled` inside the window — a foreign call would have resolved
+      // `started` above and would show up here as 2.
+      expect(drain.calls(), 'exactly one allSettled — the drain\'s').toBe(1);
       expect(disconnectSettled, 'the $disconnect ran to completion').toBe(true);
       // THE discriminator, and an ORDERING one. Dropping
       // `drainComplete.then(...)` from the race leaves only the ceiling, so
@@ -1150,8 +1172,8 @@ describe('graceful shutdown bounded drain (M3)', () => {
       );
       expect(drainWarns).toHaveLength(0);
     } finally {
-      ceiling.restore();
-      drain.restore();
+      ceiling?.restore();
+      drain?.restore();
       warnSpy.mockRestore();
       rieModule.invokeRie.mockReset();
       await new Promise<void>((resolve) => {
@@ -1197,13 +1219,19 @@ describe('graceful shutdown bounded drain (M3)', () => {
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const port = (server.address() as AddressInfo).port;
     const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
-    const drain = watchDrainStart();
+    // Installed inside the `try`, immediately before `close()` — see the
+    // completion case for why the window is kept that narrow and why a bare
+    // install outside the `try` can leak a global patch into the rest of the
+    // file.
+    let drain: ReturnType<typeof watchDrainStart> | undefined;
+    let hungTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       const first = await openWebSocket(port, '/prod');
       const second = await openWebSocket(port, '/prod');
       await waitFor(() => attached.registry.size() === 2, 1000);
       first.close();
       second.close();
+      drain = watchDrainStart();
       const closing = attached.close();
       // Raced against `close()` returning for the reason the case above
       // spells out: a skipped drain never settles `drain.started`, and a
@@ -1231,13 +1259,19 @@ describe('graceful shutdown bounded drain (M3)', () => {
       // above it so this assertion is always the one that speaks.
       const returned = await Promise.race([
         closing.then(() => 'closed' as const),
-        new Promise<'hung'>((resolve) =>
-          setTimeout(() => resolve('hung'), CEILING_REPORT_MS).unref?.()
-        ),
+        new Promise<'hung'>((resolve) => {
+          // Handle kept so the winner can clear it: unref'd is enough to let
+          // the process exit, but a 15s timer left armed after this case has
+          // returned is still a timer the next case runs alongside.
+          hungTimer = setTimeout(() => resolve('hung'), CEILING_REPORT_MS);
+          hungTimer.unref?.();
+        }),
       ]);
       expect(returned, 'close() never returned — the drain waited past its ceiling').toBe('closed');
 
-      expect(drain.calls(), 'close() reached the drain rather than skipping it').toBe(1);
+      // Both jobs again: the drain was reached, and no foreign `allSettled`
+      // resolved `started` inside the window.
+      expect(drain.calls(), 'exactly one allSettled — the drain\'s').toBe(1);
       const drainWarns = warnSpy.mock.calls.filter(
         (c) => typeof c[0] === 'string' && c[0].includes('graceful shutdown drained for')
       );
@@ -1247,7 +1281,14 @@ describe('graceful shutdown bounded drain (M3)', () => {
       // `1/1`, where the case above passes under either.
       expect(drainWarns[0]![0]).toContain('1/2 $disconnect handlers');
     } finally {
-      drain.restore();
+      // The never-released handler is what makes the drain time out, and it
+      // would otherwise pend for the rest of the run: `inFlightDisconnects`
+      // holds it, and the dispatch chain's own `.finally` cleanup cannot run
+      // until it settles. Releasing here drains both — the assertions above
+      // are already done, so it changes nothing they saw.
+      gates[1]!.release();
+      if (hungTimer !== undefined) clearTimeout(hungTimer);
+      drain?.restore();
       warnSpy.mockRestore();
       rieModule.invokeRie.mockReset();
       await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

Closes the two coverage gaps go-to-k/cdkd#2904 filed against the bounded-drain case in `tests/unit/local/websocket-server.test.ts`, with the one fixture both of them needed: a `$disconnect` that is **released on a signal** rather than after a sleep. Tests only — no `src/**` change; `src/local/websocket-server.ts`'s drain is correct today and is untouched.

**The signal is `Promise.allSettled`.** It is called exactly once in the production file, inside the drain and one line AFTER `drainStartCount` is snapshotted (the `Promise.all(closes)` above it is a different method), so a spy on it says *the drain has started and the count it will report is already taken*. That is an ORDERING fact, not a timing one: the release can never land before the snapshot. A sleep tuned between the socket-close loop and the ceiling could not promise that — and the issue is explicit that tuning one there is how go-to-k/cdkd#2795's flake class comes back in a new place. The pre-existing case rejects a `setTimeout` spy for this job because the socket-close loop arms a 5s timer of its own; `allSettled` has no such twin.

**Gap 2 — the COMPLETION arm.** One connection, held pending until the drain is running, then released; `close()` must return through completion. The discriminator is deliberately **not elapsed time**: the ceiling is armed several microtasks before any clock the case can read, so a stall spends part of it uncounted and the mutant slips under a `< 5000` bound. That was the first draft, and the review measured it — an await-the-ceiling-only path reported `501ms` after a 4.5s pause. It is now a count of the 5s `setTimeout` callbacks that actually FIRE, read at the moment `close()` returns: zero on the completion path, non-zero on the mutant, which cannot return until the ceiling callback has run. ("No warn" alone cannot kill that mutant — the warn also needs handlers still in flight, and this one finished.)

**Gap 1 — the two positions of the message.** `1/1` from one connection passes under a swap and under a hardcoded literal. Two connections are now pending at the snapshot, one released after it and one never, so the warn reads `1/2`. The count's INPUT is asserted separately, off the array the spy recorded, so `1/2` cannot be reached by a one-connection race that registered twice.

Both cases **race** their signal against `close()` returning rather than awaiting it bare: if the drain is skipped through the `size > 0` guard the signal never settles, and a bare await is killed at the case timeout naming nothing. The pre-existing `1/1` paragraph is corrected while being superseded — it said the second connection must settle BEFORE the snapshot, which produces `1/1` again.

## Test plan

Every bullet of the issue's verification plan, measured against the final tree (baseline: 20 cases in the file, full suite 974 files / 21417 passed / 1 skipped, rc=0):

| mutation | measured |
| --- | --- |
| drop `drainComplete.then(...)` from the race | the COMPLETION case reds **by name** — `close() returned before the drain ceiling fired: expected 2 to be +0` — not a runner deadline |
| swap `${inFlightDisconnects.size}` and `${drainStartCount}` | the `1/2` case reds; the same mutant against `origin/main`'s test file is **GREEN** (18 passed), which is the measurement the issue asks for |
| hardcode `1/1` in the message | the `1/2` case reds |
| `if (inFlightDisconnects.size > 0)` -> `if (false)` | all three drain cases red **in milliseconds, by name** — the vacuity guard the plan's fifth bullet asks for |
| remove the ceiling from the race | the pre-existing case and the `1/2` case red by name (the latter at its own reporting bound, below the case timeout) |
| move `SHUTDOWN_DRAIN_MS` to 8s | only the pre-existing case reds — the new coverage adds rather than trades |

Production files were restored byte-exact after every probe (`git diff` clean).

`vp check --fix` + `vp run check` + `typecheck:test` + `build` + `gen:all-matrices` + `audit:coverage:check` all rc=0. No integ: the diff is outside every integ gate's scope and changes no shipped behaviour, so no changelog entry either.

Codex: 3 delta rounds and 2 maintainer-checklist proxy rounds. The delta review caught the elapsed bound; the proxy caught two comments describing mechanisms that were not in the code.

**Review round 1** (commit `2f2c8703`) — four items, all taken.

The blocker was a justification standing on the wrong guarantee: the header explained the `allSettled` signal by "called exactly once in `websocket-server.ts`", which is the ORDERING argument (the call sits one line after the snapshot) but is not what makes the signal trustworthy, since the spy patches the GLOBAL. `drain.calls() === 1` is what closes that — a foreign call makes it 2 — and the comment and the assertion message now say so. Both spy installs also moved to immediately before `attached.close()` and inside the `try`, which narrows the window to that one call and removes the path where a throw between two global patches leaves one in place for the rest of the file (`vite.config.ts` sets neither `restoreMocks` nor `clearMocks`). The never-released gate is released in `finally` so its handler stops pending for the rest of the run, and the reporting timer is cleared when `close()` wins.

Coverage is unchanged: every mutant above was re-measured after the round and reds exactly the same case or cases.

Closes #2904
