### PR TITLE
chore(skills): make /verify-pr actually run the checks it claims to supersede

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -22,9 +22,12 @@ Run each check and report pass/fail:
    `pnpm-lock.yaml` mtime ≤ `node_modules/.modules.yaml` mtime. Do not start
    step 1 until this passes, or every check below silently no-ops.
 
-1. **Code quality**
-   - `vp run typecheck`, `vp run lint` (`lint:fix` first if needed),
-     `vp run build` all pass.
+1. **Code quality** — `/check` steps 1-3, which this skill supersedes.
+   - `vp run check` (CI's exact command: typecheck + lint + Prettier; `lint`
+     alone skips Prettier, PR #363), `vp run typecheck:test` (the ONLY gate
+     covering `tests/**` — `tsconfig.json` excludes `**/*.test.ts` and
+     `vp test run`'s `Type Errors` line covers only `*.test-d.ts`; issue
+     #1133, go-to-k/cdkd#2929), `vp run build` — all pass.
    - When piping to `tail` / `head` / `grep`, **check the output content** for
      `Error` / `Command failed` — `$?` after a pipeline reflects the LAST
      stage, and a background-task notification's `exit code 0` is the chained
@@ -65,7 +68,9 @@ Run each check and report pass/fail:
      PRs #548, #1104, #1231, #1416 — so do NOT re-list). Regenerate everything:
      ```bash
      # Regenerates every artifact CI guards (offline static analysis).
-     vp run gen:all-matrices
+     # `format` is in the chain, not a tidy-up: CI's guard formats before
+     # diffing, so skipping it renders a formatting-only diff as real drift.
+     vp run gen:all-matrices && vp run format
 
      # Offline CRITIC (~0.5s), not part of the aggregate. If it fails, run
      # `vp run audit:coverage:regenerate` (heavy ~15 min, needs AWS creds with
@@ -179,12 +184,12 @@ Run each check and report pass/fail:
    `src/index.ts` exports consistent.
 
 8. **Code review**
-   - **First, run `/review-pr <N>`** for the size-appropriate plan: inline
-     spot-check (< 300 LOC or < 5 files), 1 reviewer (300–1000 LOC), 3-axis
-     parallel (≥ 1000 LOC or ≥ 10 files), plus the ADDITIVE
-     `pr-security-reviewer` at ANY tier when a security surface or fix is
-     involved. Trust the recommendation; override only with a concrete reason,
-     noted here.
+   - **First, run `/review-pr <N>`** for the size-appropriate plan, plus the
+     ADDITIVE `pr-security-reviewer` at ANY tier when a security surface or
+     fix is involved. Thresholds are NOT restated here — `pr-review-gate.sh`
+     computes the tier that gates the merge; a copy can only drift from it.
+     Trust the recommendation; override only with a concrete reason, noted
+     here.
    - Synthesize the reports into a verdict; any blocker → fix-back loop.
    - **Then re-review the FIX DELTA, not just re-run the tier heuristic.**
      Fixes are code no reviewer has seen, written under the momentum of
@@ -260,15 +265,10 @@ Run each check and report pass/fail:
       - (a) **Fixed in this PR** — point at the fix commit / file:line.
       - (b) **TODO (issue #N)** — an issue exists AND the PR body references
         it. The issue body MUST carry the four classification lines, one
-        field per line (CLAUDE.md → "The four TODO fields"), plus the
-        `Dup-check:` line `/work-issues` §5-f requires:
-
-        ```text
-        Session-fit: now (do it in this session) | next (not this session) — <reason>
-        Severity: high | medium | low — <what stays broken while it is undone>
-        Effort: small (S) | medium (M) | large (L) — <which verification cycle it drags>
-        Estimate: <duration, e.g. ~1-3 h -- never a bare letter> — <what eats the time>
-        ```
+        field per line, spelled exactly as `.claude/rules/session-report.md`
+        gives them (CLAUDE.md → "The four TODO fields") — NOT restated here,
+        because a second copy of a template is a second thing to drift — plus
+        the `Dup-check:` line `/work-issues` §5-f requires.
 
         **Reviewers grade on a DIFFERENT scale — translate, do not copy**:
         `nit` → `low`, `minor` → `medium`. There is deliberately no `blocker`
@@ -327,8 +327,8 @@ Present results as a table:
 
 | Check | Result |
 |-------|--------|
-| typecheck | pass/fail |
-| lint | pass/fail |
+| check — typecheck + lint + format (`vp run check`) | pass/fail |
+| test-project typecheck (`vp run typecheck:test`) | pass/fail |
 | build | pass/fail |
 | tests (N files, M tests) (`vp test run`) | pass/fail |
 | test coverage for changes | pass/fail |
@@ -353,18 +353,13 @@ If all pass, confirm "PR is ready to merge." If any fail, list the issues.
 only `CLAUDE.md`, which the harness injects rather than reads, so it never
 auto-loads in an ordinary session.
 
-Then add the **State** line CLAUDE.md's wrap-report rule requires — "ready
-to merge" is rarely the end of the turn:
-
-- A check merely *pending* (CI running, an integ in flight, a reviewer not
-  back) is **WAITING** — say what you wait on, the signal that re-invokes
-  you, and that you will merge on green. Never go quiet on "ready to merge".
-- A check that legitimately **cannot** pass (no AWS credentials, a
-  maintainer-only decision) is not WAITING — no signal is coming. Resolve
-  it, or ask through `AskUserQuestion`; never end the turn with the question
-  in prose.
-- Report **STOPPED** only when the PR is merged (or the user explicitly owns
-  the next step) and nothing is pending.
+Then add the **State** line CLAUDE.md's wrap-report rule requires. That file
+gives the field semantics and is not restated here; what is specific to THIS
+skill is that "ready to merge" is rarely the end of the turn. A merely
+*pending* check (CI, an integ, a reviewer not back) is **WAITING** and you
+merge on green — never go quiet on it; a check that legitimately cannot pass
+is not WAITING at all; and **STOPPED** is only for a PR already merged, or one
+whose next step the user explicitly owns.
 
 ## Final Step
 
@@ -389,17 +384,11 @@ git add -A \
   && mise exec -- markgate set verify-pr
 ```
 
-**Anything that moves HEAD afterwards invalidates the binding, by design.** After
-a rebase or force-push (which `ship.md` prescribes), repeat the BIND -- still
-chained -- once the tree is final:
-
-```bash
-git rev-parse --verify HEAD > "$(git rev-parse --show-toplevel)/.markgate-verify-pr-sha" \
-  && mise exec -- markgate set verify-pr
-```
-
-That suffices only if the tree is UNCHANGED; with changes to commit, re-run the
-full chain with `--force-with-lease`. hooks.md: why it is named, not counted.
+**Anything that moves HEAD afterwards invalidates the binding, by design.**
+After a rebase or force-push (which `ship.md` prescribes), repeat the BIND once
+the tree is final -- still chained: the last two lines of the chain above when
+the tree is UNCHANGED, the whole chain with `--force-with-lease` when there is
+anything to commit. hooks.md: why it is named, not counted.
 
 **The sentinel is the binding, `markgate verify` does not enforce it, and the
 ORDER above is forced from two directions** — the marker is bound to a COMMIT,


### PR DESCRIPTION
## Summary

`/verify-pr`'s Final Step says it supersets `/check` and `/check-docs` — that claim is what makes running it alone reasonable before a merge. Step 1 did not honour it, and the gap is exactly the shape of PR that cannot afford it.

`vp run typecheck` is `tsc --project tsconfig.json`, whose `exclude` drops `**/*.test.ts`. `vp test run` does not cover them either: `vite.config.ts` scopes vitest's typecheck to `*.test-d.ts`, so its `Type Errors  no errors` line is silent about every `.test.ts` in the diff. A `/verify-pr` run following step 1 literally never type-checked the tree a **tests-only PR consists of**, while reporting a `typecheck | pass` row.

Found while reviewing go-to-k/cdkd#2928, which was tests-only.

## The probe

Not reasoned — measured on this branch, by giving `HUNG_DISCONNECT_MS` a `: string` annotation in `tests/unit/local/websocket-server.test.ts`:

| command | result |
| --- | --- |
| `vp run typecheck` (old step 1) | **rc=0**, zero errors |
| `vp test run <file>` | **rc=0**, `Type Errors  no errors` |
| `vp run typecheck:test` (new step 1) | **rc=1** — `TS2322` and `TS2345`, named at file:line |

The file was restored byte-exactly afterwards (`git diff` empty for it; restored from a copy rather than `git checkout --`, which would have taken the uncommitted skill edit with it).

## What changed

- **Step 1** now runs `vp run check`, `vp run typecheck:test`, `vp run build` — `/check` steps 1-3. `vp run lint` alone also skips Prettier, so a lint-only pass still fails CI's `Formatting issues found` (go-to-k/cdkd#363), and `vp check --fix` is not a substitute for `vp run check` (go-to-k/cdkd#1372).
- **The output table** reports those two instead of `typecheck` / `lint`.
- **Step 5's regeneration chain** gains `vp run format`, which `/check` step 3 has and this one did not: the matrices are committed Prettier-formatted and CI's guard formats before diffing, so regenerating without it renders a formatting-only diff as real drift.

CI (`ci.yml:45`) and `/check` (step 2) already ran `typecheck:test`, so nothing shipped broken — the gap was that only two of the three prescribed it, and the third is the one you run before a merge.

## The deletions, and why they are in this diff

The file was **60 bytes** under `MAX_SKILL_MD_BYTES` (23,000, `skill-file-payload.test.ts:48`), and section 10-c forbids raising a cap. So every addition here is funded by a deletion. I picked only restatements that sit next to their own pointer:

1. step 11's four-field code block — two lines below `CLAUDE.md → "The four TODO fields"`; `.claude/rules/session-report.md` is authoritative;
2. the State-line bullets — directly below "Read `session-report.md` first", keeping the two clauses that are specific to this skill;
3. the Final Step's second bind snippet — the literal tail of the chain printed above it;
4. step 8's reviewer-tier thresholds.

**4 was also wrong.** It read `1 reviewer (300–1000 LOC)`, dropping `pr-review-gate.sh`'s `AND 5 <= fc < 10` conjunct — so a 303-LOC single-file PR classified as `1-reviewer` where the hook that actually gates the merge says `inline`. That is not hypothetical: go-to-k/cdkd#2928 was 303 LOC in 1 file, and I had to derive its tier from CLAUDE.md because this line disagreed. Replaced with a pointer at the hook rather than a corrected copy, so it cannot drift again.

I flag these because a reviewer seeing a step-1 fix touch steps 5, 8 and 11 should know they are funding, not scope creep.

## Test plan

- `vp run check`, `vp run typecheck:test`, `vp run build` — all rc=0.
- `vp run gen:all-matrices && vp run format && vp run audit:coverage:check` — all rc=0, tree clean afterwards.
- Full suite, run root asserted: **974 files / 21415 passed / 1 skipped**, rc=0.
- **Zero test cases retired**, which is the risk when a diff deletes prose a fence might be reading: `tests/unit/scripts/` is **98 files / 3634 tests both with and without this diff**, measured by stashing it rather than by inspection.
- The five fences that read this file — `skill-file-payload`, `cross-cutting-list-sync`, `matrix-regen-coverage`, `claude-md-size`, `verification-depth-rule` — all green. The cross-cutting bullet list and detection regex, which `cross-cutting-list-sync.test.ts` reads by anchor text, are untouched.
- 22,985 B, 15 bytes under the cap.

No integ: the diff is outside every integ gate's scope. No changelog entry: agent instructions produce no user-visible behavior delta.

## Residual

At 15 bytes of headroom the file is effectively full, so the next addition to it becomes someone else's unrelated deletion. Filed as go-to-k/cdkd#2930 (split into orchestrator + `references/`, the pattern `/work-issues` already uses) — `next`, since it is a restructuring plus repointing three anchor-reading fences, not an edit.

One check I did not run: the `lint`-skips-Prettier half of step 1's rationale is `/check`'s existing already-cited claim (go-to-k/cdkd#363), carried over rather than re-probed. The `typecheck:test` half, which is what this PR is actually about, is the probe above.

Closes #2929
