### PR TITLE
chore(work-issues): move the mutation-probe way-in rule to the testing rules, and pin a lost lane transcript

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -99,16 +99,23 @@ the trigger is a TS entry point, or several spawns in a case.
 
 ## Mutation probes: mutate every site the value reaches, not the first one
 
-- A probe that flips one use of a value proves that ONE use is pinned. PR #2010:
-  a banner read `stackUnaddressed` in a guard AND in the interpolated message;
-  the guard-flip probe failed the test, swapping the INTERPOLATION did not —
-  and the fixture's clean stack never entered the warn arm, so its
-  `not.toContain(...)` assertion was unfalsifiable by construction.
+- A probe that flips one use of a value proves that ONE use is pinned (PR #2010:
+  a guard-flip reddened the test, the same value's INTERPOLATION did not, and
+  the fixture's clean stack never entered the warn arm, so its
+  `not.toContain(...)` was unfalsifiable by construction).
 - **Enumerate the value's uses before probing** (`grep` the identifier in the
   changed hunk). One probe per use — for a GUARD the uses are its CALL SITES
   and both directions of its message, each needing its OWN negative:
   go-to-k/cdkd#2674 fenced a damage sentence in the out-of direction only, so
-  a change confined to the into text went unwatched (2026-09-05).
+  a change confined to the into text went unwatched (2026-09-05). A probed
+  callee says nothing about its WIRING, so delete each argument the call site
+  passes and assert THOSE (a deleted feeding line left 1,442 tests green,
+  go-to-k/cdkd#2719). And a case reaching the subject through an outer layer
+  inherits that layer's NORMALISATION, so it cannot exhibit what it asserts
+  while reading correct (go-to-k/cdkd#2911, four rounds: `resolveValue` rebuilt
+  a structure, un-sharing a memo's reference; `Fn::Split` returned a `string[]`
+  an object branch never enters) -- enter by a route that PRESERVES the
+  property, or call the private method directly.
 - **A negative assertion needs a case where the wrong value would actually be
   EMITTED** — e.g. two DIRTY stacks with different counts (1 and 2), asserting
   the total 3 appears in neither banner.

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -230,10 +230,9 @@ inverse replace is a second edit: Python's `str.replace('', x)` matches between
 every character and rewrote an 11 KB file to 838 KB, scoring the three probes
 after it against a corrupted subject.
 
-**Probe the CALLER too — a probed callee says nothing about its wiring.**
-go-to-k/cdkd#2719: a predicate with eight probed gates, and deleting the line
-FEEDING it one of two inputs left 1,442 tests green. Delete each argument the
-call site passes and assert the ARGUMENTS; an outcome re-tests only the callee.
+**Probe the CALLER too, and the WAY IN** — `.claude/rules/testing.md` →
+"Mutation probes" owns both: wiring, and the vacuity a normalising entrypoint
+causes.
 
 **A mutation probe proves a test discriminates only if it changes the value
 the test READS.** Four vacuous tests shipped in one day, all one shape: the
@@ -409,7 +408,9 @@ one-line "done" loses the run (2 of 3 lanes, 2026-09-05) — as does a lane that
 finishes with NO report reaching you (twice, 2026-09-10: only its nested
 reviewers' notifications arrived, reading as progress). Never wait on a quiet
 lane: list the agents, resume any already `completed` with "REPORT ONLY, do not
-touch the tree" — a plain resume re-edits.
+touch the tree" — a plain resume re-edits, and a lane whose TRANSCRIPT is gone
+(`could not be resumed`, 3x in one run) restarts only from a prompt you kept
+SELF-CONTAINED and still hold.
 
 A subagent's Bash **bypasses the PreToolUse gate hooks** (it can `gh pr create` past `verify-pr-gate`) —
 enforce quality yourself; the orchestrator still gates the MERGE.

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -269,9 +269,21 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // the cap's own failure message -- but the calibration to carry forward is
     // that they are the thinnest on record in BOTH slots, so the next edit to
     // either file opens with a compression pass, not an addition.
-    corpusBytes: 181_299,
+    //
+    // The go-to-k/cdkd#2911 / go-to-k/cdkd#2938 retro took that literally and is
+    // the first RETRO to come out net negative (the line above records the first
+    // time the corpus went down at all, which was not a retro): it added one
+    // rule to implement.md 5-g
+    // (a lost lane TRANSCRIPT restarts only from a self-contained prompt) and
+    // paid by RELOCATING 5-e's caller-probe paragraph to `.claude/rules/testing.md`
+    // ("Mutation probes"), which already owned the per-use rule and is where the
+    // retro's own test-vacuity lesson landed -- so implement.md keeps a pointer
+    // and the incident travels with the rule. Neither cap nor the floor moved,
+    // and the binding margin is unchanged -- the three fields below are the
+    // assertion for that, and no margin is quoted anywhere in this comment.
+    corpusBytes: 181_293,
     largest: { file: 'verify.md', bytes: 29_928 },
-    runnerUp: { file: 'implement.md', bytes: 29_921 },
+    runnerUp: { file: 'implement.md', bytes: 29_915 },
   },
 };
 
@@ -690,9 +702,12 @@ const MIN_REFERENCE_FILES = 6;
 // Inputs at this
 // date: corpus 181,299, largest verify.md 29,928, runner-up implement.md
 // 29,921, so the two thresholds are 151,371 (largest-side) and 151,378
-// (runner-up side, binding); 151,750 clears the binding one by 372 B. The two
-// leaders are now 72 B and 79 B from MAX_REFERENCE_FILE_BYTES -- the binding
-// constraint for the next retro is that cap, not this floor.
+// (runner-up side, binding); 151,750 clears the binding one by 372 B. The
+// binding constraint for the next retro is MAX_REFERENCE_FILE_BYTES rather than
+// this floor. No leader headroom is quoted here: the caps' own failure messages
+// print it live, and the figure an earlier draft stated went stale in the very
+// next retro (the go-to-k/cdkd#2911 one, which moved a leader without moving
+// either bound).
 const MIN_REFERENCE_CORPUS_BYTES = 151_750;
 
 function skillNames(): string[] {


### PR DESCRIPTION
Retrospective (stage 10) of the `/work-issues` run that merged
go-to-k/cdkd#2911, go-to-k/cdkd#2924 and go-to-k/cdkd#2938 — four issues
(go-to-k/cdkd#2827, go-to-k/cdkd#2759, go-to-k/cdkd#2847, go-to-k/cdkd#2885),
all security fixes in the GHSA-p5qg-v9gv-hc7w class.

## Net backlog effect

`closed 5 / filed 8 (new 8 / folded 3 rows into go-to-k/cdkd#2881)`

Four of the five are the issues the lanes claimed; the fifth,
go-to-k/cdkd#2910, was filed by this run and closed by it too — a peer merge
released the rule file it was blocked on mid-lane, so the lane rebased and
carried the correction instead of deferring it.

M > N because the reviews of a four-lane sweep over ONE subsystem (secret
redaction, the import readback, the masked-`Ref` readers) kept turning up
adjacent defects in the files already open. That is the healthy one of the
three reasons — the area really does hold that many independent defects, so it
is a `/hunt-bugs` target rather than a filing-discipline problem. Twenty issues
closed in the same window; the other fifteen belong to at least four concurrent
sessions, attributed one by one from their closing PRs rather than by date.

## Promotion check

6 of the 7 still-open `Session-fit: next` filings name a fix site the run had
open — which is a property of the run's SHAPE (one subsystem, four lanes), not
of the deferrals, so the REASONS decide. Each still holds on its merits: a
`cdkd diff` behaviour decision, a separate `export` integ, a broad-set
`drift-revert` round, a `cdkd import` carry-over contract. None promoted.

One reason had gone stale in its ANCHOR while the decision it justified stood —
go-to-k/cdkd#2909 said the cycle was one "the go-to-k/cdkd#2827 /
go-to-k/cdkd#2759 lane is not paying", and two LATER lanes in the same run
opened the file it names. Corrected on the issue.

## Lessons landed

**1. `.claude/rules/testing.md` → "Mutation probes".** A case reaching the
subject through an outer layer inherits that layer's NORMALISATION, so it
cannot exhibit what it asserts while still reading correct. Four review rounds
on go-to-k/cdkd#2911 shipped two: `resolveValue` rebuilt the structure,
un-sharing the reference a memo case needed, and `Fn::Split` returned a
`string[]` an object branch never enters. It landed in the RULES rather than in
a `/work-issues` stage file because it is about writing a test — any work in
this repo — and it generalises the per-use probe rule already sitting there.

**2. `references/implement.md` §5-g.** A lane whose TRANSCRIPT is gone (3x in
one run) restarts only from a prompt the parent kept SELF-CONTAINED and still
holds. The quiet-lane rule beside it covers a lane that never reports; it does
not cover one that cannot be resumed at all.

## Paid for, not appended

The `/work-issues` corpus comes out **6 B smaller** and the binding floor
margin is unchanged: `implement.md` 5-e gives up the caller-probe paragraph
that the rules file now owns, keeping a pointer, and the go-to-k/cdkd#2719
incident travels with the rule. No cap and no floor moved — §10-c forbids a
retro buying room that way.

Residual: `tests/**`'s rule payload absorbed 502 B net against the 542 B of
headroom it had, leaving 40 B. Filed as go-to-k/cdkd#2940 with the split that
actually fixes it, and with the three sibling instances (go-to-k/cdkd#2288 /
go-to-k/cdkd#2844 / go-to-k/cdkd#2923) listed, since one umbrella may serve
better than four issues.

## Rejected as already covered

Each verified against the file named, not recalled:

- **Structured entries over a re-parsed human-readable string**, including the
  sharp half (one pattern, two consumers whose SAFE DIRECTIONS are opposite) —
  `.claude/rules/layout-deployment.md`, with both mechanisms (the producer
  rename, the hyphenated logical id falling out of `[A-Za-z0-9]+`).
- **Opt-in over a global default** — `.claude/rules/analyzer.md` carries the
  "unconditional for three review rounds, each finding a fresh caller"
  evidence; `layout-deployment.md` carries the bag's presence-as-opt-in at the
  other seam.
- **Derive a population mechanically instead of enumerating it by hand** —
  `implement.md` 5-f' ("three spellings in three rounds is the signal to
  change instrument: parse for real ... fail closed") and
  `.claude/rules/layout-scripts.md` ("the population is not derived from the
  defect").
- **A lane never sets `pr-review`** — `references/verify.md` §8-i already
  states it AND gives the parent the check that caught the violation this run.
  §10-b says escalate rather than restate, and a hook structurally cannot see
  it (a subagent's Bash bypasses PreToolUse), so a third sentence buys nothing.
  Re-confirmed while writing this PR: in this shared IN-PLACE tree
  `markgate verify pr-review` returns rc=0 while `.markgate-pr-review-sha`
  names a previous lane's HEAD — the tell §8-i names, working.
- **`integ-broad` reading FRESH for code its run never saw** —
  `references/launch-mode.md` consequence 10, which is what caught it all three
  times it came up.

## Review

One independent reviewer round against the branch diff (tier heuristic gives
`inline` at 3 files; taken UP one because agent-instruction files are
deliberately not down-biased). **No blockers.** Three findings were demonstrated
errors and are fixed here: the relocation had dropped the caller-probe's
delete-each-argument prescription; "both carrying the three-rounds evidence" was
false of `layout-deployment.md`; and the floor comment's leader-headroom figure
was invalidated by this very diff, so it is DELETED rather than recounted
(go-to-k/cdkd#2519's disposition). The rest were polish and are left.

## Verification

Tooling-only diff, no `src/**` change, so §8-c's prose arm applies: every gate,
path, file and section the new text names was resolved against this repo, and
the commands it sends the next agent to run were run. `vp run check`,
`vp run typecheck:test`, `vp run build`, and the full unit suite
(982 files / 21,536 tests) all pass; `gen:all-matrices` + `audit:coverage:check`
+ `format` left nothing dirty. No changelog entry — agent instructions and
tests write none (go-to-k/cdkd#2779). No integ gate scope touched.
