### PR TITLE
ci: add a ci-ok aggregate status check and refuse a stale release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,3 +479,143 @@ jobs:
       - run: vp install --frozen-lockfile
       - run: vp run build
       - run: vp env exec --node ${{ matrix.node-version }} node dist/cli.js --version
+
+  # A stale standing release PR is MERGEABLE and silently reverts main.
+  # release-please does not rebuild a release PR whose computed release is
+  # unchanged — it logs `PR #N remained the same` and leaves the branch on the
+  # base it was cut from. A `chore:` / `ci:` / `docs:` commit produces no
+  # changelog entry, so it lands on main WITHOUT the release branch following;
+  # if it touched a file release-please owns, merging the PR takes the branch's
+  # older copy. GitHub reports MERGEABLE throughout — measured on
+  # go-to-k/cdkd#2503, which would have undone 285 CHANGELOG header
+  # conversions and was closed and recreated as #2508.
+  #
+  # The remedy has always been "close the PR, delete its branch, re-run
+  # release.yml"; what was missing is anything that makes the condition VISIBLE
+  # before the merge. A human reading the diff was that check. Auto-merge
+  # removes the human, so the check has to become a required status.
+  #
+  # `package.json` is deliberately NOT inspected: `chore(deps)` PRs touch it
+  # constantly, and release-please's own diff there is the `version` line
+  # alone — a three-way merge of that cannot revert a dependency line, so
+  # including it would block every release PR that is merely behind.
+  #
+  # A fork contributor can name a branch `release-please--x` and enter this job.
+  # That is harmless and deliberately not guarded against: the job reads only
+  # git ancestry and can do nothing but fail their own PR. Guarding on the PR
+  # author instead would add a SECOND way for the job to go silently inert,
+  # which is the failure mode `ci-ok-gate.test.ts` exists to prevent.
+  release-pr-not-stale:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # The PR HEAD, not the default `refs/pull/N/merge`. That ref has the base
+      # branch already merged into it, so every ancestry question below would
+      # answer "yes" no matter how stale the branch actually is — a vacuous
+      # pass, and the only way this job can be wrong in the unsafe direction.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: release-please-owned files on main must be ancestors of this branch
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+          stale=0
+          for f in CHANGELOG.md .release-please-manifest.json; do
+            tip=$(git rev-list -1 FETCH_HEAD -- "${f}")
+            # An empty answer means the file has no history on main at all —
+            # renamed, deleted, or never committed. The guard cannot answer the
+            # question it was added to answer, and "cannot answer" is a failure
+            # rather than a pass.
+            if [ -z "${tip}" ]; then
+              echo "::error::${f} has no commit history on main. This guard cannot evaluate staleness, so it fails closed. If the file was renamed, update this job."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${tip}" HEAD; then
+              echo "::error::${f} was last changed on main by ${tip}, which is NOT an ancestor of this release branch — the branch is stale and merging it would revert that change. Close this PR, delete its branch, and re-run release.yml via workflow_dispatch to recreate it from current main."
+              stale=1
+            fi
+          done
+          [ "${stale}" -eq 0 ]
+
+  # The single check name the `main` branch ruleset requires. It exists instead
+  # of the ruleset naming the real jobs for two reasons:
+  #
+  #   1. `runtime-compat` is a matrix. A required check has to match the
+  #      EXPANDED name (`runtime-compat (20)`), but a matrix job that never
+  #      starts — because `check-build-test` failed — reports under the
+  #      UNEXPANDED name (`runtime-compat`). Requiring either spelling leaves
+  #      the other permanently "Expected", which blocks the PR forever.
+  #   2. Adding or renaming a job above then needs a line in `needs:` here
+  #      rather than an edit to repository settings nothing in this tree can
+  #      review.
+  #
+  # `if: always()` is load-bearing. Without it this job is SKIPPED whenever an
+  # upstream job fails, and a skipped required check counts as PASSING — the
+  # gate would report green exactly when CI is red.
+  #
+  # What this check does and does not attest to, stated so the ruleset change is
+  # made with eyes open: on a `pull_request` trigger the workflow DEFINITION
+  # comes from the PR's own ref, so a fork author can rewrite this job to `exit
+  # 0` and the required check reports green. That is a property of every
+  # `pull_request`-based required check, not something aggregating into one name
+  # introduced — requiring `check-build-test` directly was defeatable the same
+  # way. The controls are unchanged: the edit is visible in the diff, a
+  # first-time contributor's run needs maintainer approval, and a fork token is
+  # read-only. Human review of a workflow diff remains the control.
+  #
+  # Two checks are deliberately NOT reachable from here and NOT required, both
+  # because a `paths:`-filtered workflow does not START on every PR and a
+  # required check that never reports sits at "Expected" forever:
+  #   - `hooks.yml` / `hook-suites` — runs only on a `.claude/hooks/**` PR,
+  #     which is never a release or a dependabot PR, i.e. never one auto-merge
+  #     is armed on. Agent-side merges still require it via `ci-green-gate`.
+  #   - `docs-deploy.yml` / `build` — this one IS reachable by dependabot
+  #     (`package.json` / `pnpm-lock.yaml` are in its filter), so its
+  #     `pull_request` filter was REMOVED in the same change that added this
+  #     job: it now runs on every PR and is required by name. See that file.
+  ci-ok:
+    if: always()
+    needs: [check-build-test, once-leak-detect, runtime-compat, release-pr-not-stale]
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      # Through `env:` rather than inline in `run:`. The value space here is a
+      # closed enum so inline is safe today, but the repo's pattern is that
+      # expression data reaches a shell as a variable, never as source text.
+      RESULTS: ${{ join(needs.*.result, ' ') }}
+      # Must equal the length of `needs:` above. Both halves are read out of
+      # this file by tests/unit/scripts/ci-ok-gate.test.ts, which also asserts
+      # `needs:` covers every other job — so this cannot drift silently.
+      EXPECTED_UPSTREAM: '4'
+    steps:
+      - name: every upstream job succeeded or was skipped
+        run: |
+          set -euo pipefail
+          # `skipped` is accepted on purpose: release-pr-not-stale skips on
+          # every non-release PR, and a matrix job skipped because its `needs`
+          # failed is already reported by that failing job's own result.
+          echo "upstream results: ${RESULTS}"
+          seen=0
+          for r in ${RESULTS}; do
+            seen=$((seen + 1))
+            case "${r}" in
+              success | skipped) ;;
+              *)
+                echo "::error::an upstream CI job reported '${r}' — this gate is red. See the run summary for which job."
+                exit 1
+                ;;
+            esac
+          done
+          # Without this, "every result was good" and "there were no results"
+          # are the same exit 0: an empty render makes the loop above run zero
+          # times. This job is the SOLE required status check, so a vacuous
+          # green here is a merge gate that examined nothing.
+          if [ "${seen}" -ne "${EXPECTED_UPSTREAM}" ]; then
+            echo "::error::examined ${seen} upstream result(s), expected ${EXPECTED_UPSTREAM}. The needs list did not reach this step, so this gate attests to nothing and fails closed."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,8 +542,11 @@ jobs:
           done
           [ "${stale}" -eq 0 ]
 
-  # The single check name the `main` branch ruleset requires. It exists instead
-  # of the ruleset naming the real jobs for two reasons:
+  # The only name THIS workflow contributes to the `main` branch ruleset's
+  # required checks — the ruleset also names `pr-content`, `check`,
+  # `prefix-scope`, `English-only (pull request)` and docs-deploy's `build`,
+  # which live in other workflows and cannot be reached from `needs:` here. It
+  # exists instead of the ruleset naming this file's real jobs for two reasons:
   #
   #   1. `runtime-compat` is a matrix. A required check has to match the
   #      EXPANDED name (`runtime-compat (20)`), but a matrix job that never
@@ -568,16 +571,21 @@ jobs:
   # first-time contributor's run needs maintainer approval, and a fork token is
   # read-only. Human review of a workflow diff remains the control.
   #
-  # Two checks are deliberately NOT reachable from here and NOT required, both
-  # because a `paths:`-filtered workflow does not START on every PR and a
-  # required check that never reports sits at "Expected" forever:
-  #   - `hooks.yml` / `hook-suites` — runs only on a `.claude/hooks/**` PR,
-  #     which is never a release or a dependabot PR, i.e. never one auto-merge
-  #     is armed on. Agent-side merges still require it via `ci-green-gate`.
-  #   - `docs-deploy.yml` / `build` — this one IS reachable by dependabot
-  #     (`package.json` / `pnpm-lock.yaml` are in its filter), so its
-  #     `pull_request` filter was REMOVED in the same change that added this
-  #     job: it now runs on every PR and is required by name. See that file.
+  # A `paths:`-filtered workflow does not START on every PR, and a required
+  # check that never reports sits at "Expected" forever — so such a check
+  # cannot be required, and is also unreachable from `needs:` here because
+  # `needs:` cannot cross workflows. Two were affected:
+  #   - `docs-deploy.yml` / `build` IS reachable by dependabot (`package.json`
+  #     and `pnpm-lock.yaml` were in its filter), so its `pull_request` filter
+  #     was REMOVED in the same change that added this job: it now runs on
+  #     every PR and is required by name. See that file.
+  #   - `hooks.yml` / `hook-suites` keeps its filter and stays unrequired. The
+  #     assumption that makes that acceptable is UNENFORCED and stated here so
+  #     it can be checked: auto-merge is only ever armed by hand, on a release
+  #     or a dependabot PR, and neither touches `.claude/hooks/**`. Arming it
+  #     on a hooks PR would merge over a red `hook-suites`. Agent-side merges
+  #     are unaffected — `ci-green-gate` requires every check, not just the
+  #     required ones.
   ci-ok:
     if: always()
     needs: [check-build-test, once-leak-detect, runtime-compat, release-pr-not-stale]

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -15,17 +15,22 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+  # No `paths:` filter on PRs, deliberately, and NOT an oversight to be tidied
+  # back into sync with the push list above. `build` is a REQUIRED status check
+  # in the `main` branch ruleset, and a required check can only be required if
+  # it reports on every PR: a `paths:`-filtered workflow does not start at all
+  # when nothing matches, leaving the check at "Expected" forever and blocking
+  # the PR permanently. A skipped JOB reports and counts as passing; a workflow
+  # that never ran does not report.
+  #
+  # What that requirement buys is exactly what the old comment here promised and
+  # could not deliver once auto-merge existed: "a dependency bump that breaks
+  # the docs build must fail on the PR, not after merge." `package.json` and
+  # `pnpm-lock.yaml` are in the push filter for that reason, so every dependabot
+  # PR built the docs — but with auto-merge armed and this check not required,
+  # the merge would proceed over a red build anyway. The cost is one docs build
+  # on PRs that touch neither docs nor dependencies.
   pull_request:
-    # Keep in sync with the push paths (minus nothing): a dependency bump that
-    # breaks the docs build must fail on the PR, not after merge.
-    paths:
-      - "docs/**"
-      - "docs-site/**"
-      - "vite.docs.config.ts"
-      - ".github/workflows/docs-deploy.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -37,8 +37,13 @@ permissions:
   contents: read
 
 concurrency:
+  # PRs cancel, main does not. `build` became a REQUIRED check that runs on
+  # every PR, so with `cancel-in-progress: false` a second push queued its full
+  # SSG build behind the superseded one and every PR's required check
+  # serialized. A superseded PR build has no value; a superseded main build
+  # feeds a deploy, so that one still runs to completion.
   group: docs-deploy-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -296,6 +296,14 @@ gates:
       - ".github/workflows/issue-conventions.yml"
       - ".github/workflows/pr-content-checks.yml"
       - ".github/workflows/pr-title-check.yml"
+      # ci-ok-gate.test.ts reads this one to assert its `pull_request` trigger
+      # carries NO `paths:` filter. That is not a style preference: docs-deploy's
+      # `build` is a REQUIRED status check, and a `paths:`-filtered workflow does
+      # not start at all when nothing matches, so the check would sit at
+      # "Expected" forever and block every PR. Listed for the same reason as the
+      # workflows above -- a checker INPUT outside this scope is a marker that
+      # reads fresh while the thing it certifies has changed.
+      - ".github/workflows/docs-deploy.yml"
       # release-please-v0.test.ts reads all three: the config's
       # bump-minor-pre-major, the manifest's 0.x version, and the release
       # workflow's publish-job guard (the two layers that keep an accidental

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -44,7 +44,10 @@ const DOCS_DEPLOY_YML = join(REPO_ROOT, '.github', 'workflows', 'docs-deploy.yml
 const GATE_STEP = 'every upstream job succeeded or was skipped';
 
 interface CiWorkflow {
-  on?: Record<string, { paths?: unknown; 'paths-ignore'?: unknown } | null>;
+  on?: Record<
+    string,
+    { paths?: unknown; 'paths-ignore'?: unknown; branches?: unknown } | null
+  >;
   jobs: Record<
     string,
     {
@@ -148,28 +151,52 @@ describe('ci-ok — the single required status check', () => {
     // job) and a step-level `if:` that is false (the step is skipped). Both
     // read as innocuous, and both reach the "green having examined nothing"
     // failure this file exists for.
+    // `?? false` because an explicit `continue-on-error: false` is semantically
+    // identical to its absence, and a fence that reds on it refuses a correct
+    // spelling.
     const job = workflow().jobs['ci-ok'];
     const step = job?.steps?.find((s) => s.name === GATE_STEP);
-    expect(step?.['continue-on-error']).toBeUndefined();
+    expect(step?.['continue-on-error'] ?? false).toBe(false);
     expect(step?.if).toBeUndefined();
-    expect(job?.['continue-on-error']).toBeUndefined();
+    expect(job?.['continue-on-error'] ?? false).toBe(false);
   });
 
-  it('keeps every gated job unconditional', () => {
-    // `skipped` is accepted for every upstream, so an `if:` on
-    // `check-build-test` or `once-leak-detect` yields four skipped results,
-    // `seen == EXPECTED_UPSTREAM`, and a green gate over a CI that ran nothing.
-    // Only the two jobs that are SUPPOSED to be conditional may carry one.
+  it('keeps every gated job unconditional and failing', () => {
+    // Three levers make an upstream job stop contributing a real verdict while
+    // `ci-ok` still counts it, and each lands a different `needs.*.result`:
+    //
+    //   job `if:`                 -> `skipped`, which ci-ok ACCEPTS
+    //   job `continue-on-error`   -> a FAILED job reports `success`
+    //   step `if:`                -> `success` with the step never executed
+    //
+    // All three give `seen == EXPECTED_UPSTREAM` and a green gate over a CI
+    // that decided nothing, and the first two also read green in the Checks UI,
+    // so `ci-green-gate` passes too. Only the two jobs that are SUPPOSED to be
+    // conditional may carry an `if:`.
     const jobs = workflow().jobs;
-    const conditional = Object.entries(jobs)
-      .filter(([name, j]) => j.if !== undefined && name !== 'ci-ok' && name !== 'release-pr-not-stale')
-      .map(([name]) => name);
+    const ALLOWED_CONDITIONAL = new Set(['ci-ok', 'release-pr-not-stale']);
+    const offenders: string[] = [];
+    for (const [name, j] of Object.entries(jobs)) {
+      if (j.if !== undefined && !ALLOWED_CONDITIONAL.has(name)) {
+        offenders.push(`${name} (job if:)`);
+      }
+      if ((j['continue-on-error'] ?? false) !== false) {
+        offenders.push(`${name} (job continue-on-error)`);
+      }
+      for (const s of j.steps ?? []) {
+        const label = s.name ?? s.run?.split('\n')[0] ?? '<step>';
+        if (s.if !== undefined && !ALLOWED_CONDITIONAL.has(name)) {
+          offenders.push(`${name} > ${label} (step if:)`);
+        }
+      }
+    }
     expect(
-      conditional,
-      `these ci.yml jobs gained an \`if:\`: ${conditional.join(', ')}. ci-ok accepts a ` +
-        'SKIPPED upstream, so a conditional job can make the gate green over a CI that ran ' +
-        'nothing. If the condition is intended, teach ci-ok to tell "skipped because not ' +
-        'applicable" from "skipped because nothing ran".'
+      offenders,
+      `these ci.yml jobs can report a verdict ci-ok counts without earning it: ` +
+        `${offenders.join(', ')}. ci-ok accepts a SKIPPED upstream and cannot tell a ` +
+        `continue-on-error success from a real one, so any of these makes the gate green ` +
+        `over a CI that ran nothing. If the condition is intended, teach ci-ok to tell ` +
+        `"skipped because not applicable" from "skipped because nothing ran".`
     ).toEqual([]);
   });
 
@@ -189,6 +216,10 @@ describe('ci-ok — the single required status check', () => {
     expect(pr, 'ci.yml no longer triggers on `pull_request`').not.toBeUndefined();
     expect(pr?.paths).toBeUndefined();
     expect(pr?.['paths-ignore']).toBeUndefined();
+    // `branches:` narrows the same way a `paths:` filter does — a PR whose base
+    // is not listed never starts the workflow, so the required check sits at
+    // "Expected" forever. `main` is the only base this repo takes PRs against.
+    expect(pr?.branches).toEqual(['main']);
   });
 
   it('takes the results through env, not as inlined expression text', () => {
@@ -258,5 +289,19 @@ describe('the other required checks this workflow cannot reach', () => {
         'and every such PR is blocked forever. Remove the filter, or drop `build` from the ' +
         "ruleset's required checks."
     ).toBe(true);
+  });
+
+  it('cancels superseded docs builds on PRs but never on main', () => {
+    // Load-bearing in BOTH directions, which is why the expression is pinned
+    // rather than just its truthiness: `build` is required and runs on every
+    // PR, so a never-cancelling group queues each push's full SSG build behind
+    // the superseded one and serializes every PR's required check. On `main`
+    // the same build feeds a deploy, so cancelling there would drop a publish.
+    const docs = parseYaml(readFileSync(DOCS_DEPLOY_YML, 'utf8')) as {
+      concurrency?: { 'cancel-in-progress'?: unknown };
+    };
+    expect(docs.concurrency?.['cancel-in-progress']).toBe(
+      "${{ github.event_name == 'pull_request' }}"
+    );
   });
 });

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -44,13 +44,16 @@ const DOCS_DEPLOY_YML = join(REPO_ROOT, '.github', 'workflows', 'docs-deploy.yml
 const GATE_STEP = 'every upstream job succeeded or was skipped';
 
 interface CiWorkflow {
+  on?: Record<string, { paths?: unknown; 'paths-ignore'?: unknown } | null>;
   jobs: Record<
     string,
     {
       if?: string;
       needs?: string[];
       env?: Record<string, string>;
-      steps?: { name?: string; run?: string }[];
+      permissions?: unknown;
+      'continue-on-error'?: unknown;
+      steps?: { name?: string; run?: string; if?: string; 'continue-on-error'?: unknown }[];
     }
   >;
 }
@@ -135,6 +138,57 @@ describe('ci-ok — the single required status check', () => {
   it('declares the upstream count its shell checks against', () => {
     const job = workflow().jobs['ci-ok'];
     expect(job?.env?.['EXPECTED_UPSTREAM']).toBe(String(job?.needs?.length ?? -1));
+  });
+
+  it('lets the shell exit status decide the job', () => {
+    // The suites below EXECUTE the extracted shell, so they attest that its
+    // TEXT is correct — never that the runner acts on its exit status. Two
+    // one-line additions sever that link and make the job report success with
+    // nothing decided: `continue-on-error: true` (the failure stops failing the
+    // job) and a step-level `if:` that is false (the step is skipped). Both
+    // read as innocuous, and both reach the "green having examined nothing"
+    // failure this file exists for.
+    const job = workflow().jobs['ci-ok'];
+    const step = job?.steps?.find((s) => s.name === GATE_STEP);
+    expect(step?.['continue-on-error']).toBeUndefined();
+    expect(step?.if).toBeUndefined();
+    expect(job?.['continue-on-error']).toBeUndefined();
+  });
+
+  it('keeps every gated job unconditional', () => {
+    // `skipped` is accepted for every upstream, so an `if:` on
+    // `check-build-test` or `once-leak-detect` yields four skipped results,
+    // `seen == EXPECTED_UPSTREAM`, and a green gate over a CI that ran nothing.
+    // Only the two jobs that are SUPPOSED to be conditional may carry one.
+    const jobs = workflow().jobs;
+    const conditional = Object.entries(jobs)
+      .filter(([name, j]) => j.if !== undefined && name !== 'ci-ok' && name !== 'release-pr-not-stale')
+      .map(([name]) => name);
+    expect(
+      conditional,
+      `these ci.yml jobs gained an \`if:\`: ${conditional.join(', ')}. ci-ok accepts a ` +
+        'SKIPPED upstream, so a conditional job can make the gate green over a CI that ran ' +
+        'nothing. If the condition is intended, teach ci-ok to tell "skipped because not ' +
+        'applicable" from "skipped because nothing ran".'
+    ).toEqual([]);
+  });
+
+  it('pins the least privilege each new job was given', () => {
+    // ci.yml has no top-level `permissions:`, so deleting either of these
+    // silently restores the repo-default token to a job that runs shell.
+    expect(workflow().jobs['ci-ok']?.permissions).toEqual({});
+    expect(workflow().jobs['release-pr-not-stale']?.permissions).toEqual({ contents: 'read' });
+  });
+
+  it('runs on every PR, so ci-ok can be a required check at all', () => {
+    // Same trap the docs-deploy case below covers, for the workflow that OWNS
+    // the required check: a `paths:`-filtered workflow does not start when
+    // nothing matches, so `ci-ok` never reports and every PR blocks forever at
+    // "Expected".
+    const pr = workflow().on?.['pull_request'];
+    expect(pr, 'ci.yml no longer triggers on `pull_request`').not.toBeUndefined();
+    expect(pr?.paths).toBeUndefined();
+    expect(pr?.['paths-ignore']).toBeUndefined();
   });
 
   it('takes the results through env, not as inlined expression text', () => {

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -39,6 +39,9 @@ import { describe, expect, it } from 'vite-plus/test';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const CI_YML = join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+const DOCS_DEPLOY_YML = join(REPO_ROOT, '.github', 'workflows', 'docs-deploy.yml');
+
+const GATE_STEP = 'every upstream job succeeded or was skipped';
 
 interface CiWorkflow {
   jobs: Record<
@@ -56,14 +59,18 @@ function workflow(): CiWorkflow {
   return parseYaml(readFileSync(CI_YML, 'utf8')) as CiWorkflow;
 }
 
-/** The `run:` body of `ci-ok`'s only step, as the runner would execute it. */
+/**
+ * The `run:` body of `ci-ok`'s gate step, as the runner would execute it.
+ * Selected BY NAME, not by index — inserting a step ahead of it would otherwise
+ * silently retarget this extractor at the new step.
+ */
 function gateShell(): string {
-  const step = workflow().jobs['ci-ok']?.steps?.[0];
+  const step = workflow().jobs['ci-ok']?.steps?.find((s) => s.name === GATE_STEP);
   expect(
     step?.run,
-    'ci-ok has no first step with a `run:` body in .github/workflows/ci.yml. If the ' +
-      'step was renamed or reordered, update this extractor; if it was REMOVED, restore ' +
-      'it — without it the sole required status check asserts nothing.'
+    `ci-ok has no \`${GATE_STEP}\` step with a \`run:\` body in .github/workflows/ci.yml. ` +
+      'If the step was renamed, update this extractor; if it was REMOVED, restore it — ' +
+      'without it the sole required status check asserts nothing.'
   ).toBeTruthy();
   return step?.run as string;
 }
@@ -168,5 +175,34 @@ describe('ci-ok — the single required status check', () => {
     it('fails when fewer results arrive than the needs list declares', () => {
       expect(gateStatus('success success', '4')).not.toBe(0);
     });
+  });
+});
+
+describe('the other required checks this workflow cannot reach', () => {
+  it('docs-deploy runs on every PR so its `build` can be a required check', () => {
+    // `build` is required by name, and a required check can only be required if
+    // it REPORTS on every PR: a `paths:`-filtered workflow does not start at all
+    // when nothing matches, leaving the check at "Expected" forever and blocking
+    // every PR permanently. The filter was removed for that reason, and the
+    // obvious tidy-up — "re-sync the pull_request paths with the push list" —
+    // is exactly what must not happen. Nothing else in the tree notices it.
+    const docs = parseYaml(readFileSync(DOCS_DEPLOY_YML, 'utf8')) as {
+      on?: Record<string, unknown>;
+      jobs?: Record<string, unknown>;
+    };
+    expect(docs.jobs?.['build'], 'docs-deploy.yml no longer has a `build` job to require').toBeTruthy();
+    expect(
+      docs.on,
+      'docs-deploy.yml no longer triggers on `pull_request`, so its required `build` check ' +
+        'never reports and every PR blocks at "Expected".'
+    ).toHaveProperty('pull_request');
+    const pr = docs.on?.['pull_request'] as { paths?: unknown } | null | undefined;
+    expect(
+      pr == null || pr.paths === undefined,
+      'docs-deploy.yml regained a `paths:` filter on `pull_request`. The workflow then does ' +
+        'not start on a PR that matches nothing, the required `build` check never reports, ' +
+        'and every such PR is blocked forever. Remove the filter, or drop `build` from the ' +
+        "ruleset's required checks."
+    ).toBe(true);
   });
 });

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Invariants of `.github/workflows/ci.yml`'s `ci-ok` job — the SINGLE status
+ * check the `main` branch ruleset requires.
+ *
+ * Everything about this job is load-bearing in one direction: a green `ci-ok`
+ * is what lets a merge through, and with auto-merge armed on the release PR and
+ * on dependabot PRs there is no human reading the checks at the moment the
+ * merge happens. So the failure that matters is not "the gate went red when it
+ * should have been green" — that is loud and self-correcting — but "the gate
+ * went GREEN having examined nothing", which is indistinguishable from a clean
+ * run at every surface a human or a hook looks at.
+ *
+ * Three such vacuities are reachable and each has a case below.
+ *
+ *   1. A job is added to the file and not to `ci-ok`'s `needs:`. It is then
+ *      outside the gate entirely and can be red under a green `ci-ok`.
+ *   2. `if: always()` is dropped. `ci-ok` is then SKIPPED whenever an upstream
+ *      job fails — and a skipped required check counts as PASSING, so the gate
+ *      reports green exactly when CI is red.
+ *   3. `RESULTS` renders empty. `for r in ${RESULTS}` runs zero times and the
+ *      step exits 0. Measured before the floor was added: `results=""` gives
+ *      `iterations=0 exit=0`. The `EXPECTED_UPSTREAM` count is the floor, and
+ *      the count is only a floor while it EQUALS the `needs:` length, which is
+ *      why that equality is asserted here rather than trusted to a comment.
+ *
+ * The shell is read out of the workflow and EXECUTED rather than pattern-
+ * matched: a suite that greps for `EXPECTED_UPSTREAM` passes over a step whose
+ * comparison was inverted. The YAML is parsed rather than sliced out of the
+ * text, so a renamed step fails here as `undefined` instead of silently
+ * matching nothing.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const CI_YML = join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+
+interface CiWorkflow {
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      needs?: string[];
+      env?: Record<string, string>;
+      steps?: { name?: string; run?: string }[];
+    }
+  >;
+}
+
+function workflow(): CiWorkflow {
+  return parseYaml(readFileSync(CI_YML, 'utf8')) as CiWorkflow;
+}
+
+/** The `run:` body of `ci-ok`'s only step, as the runner would execute it. */
+function gateShell(): string {
+  const step = workflow().jobs['ci-ok']?.steps?.[0];
+  expect(
+    step?.run,
+    'ci-ok has no first step with a `run:` body in .github/workflows/ci.yml. If the ' +
+      'step was renamed or reordered, update this extractor; if it was REMOVED, restore ' +
+      'it — without it the sole required status check asserts nothing.'
+  ).toBeTruthy();
+  return step?.run as string;
+}
+
+/**
+ * Run the extracted step under bash with the two env vars the runner supplies,
+ * returning its exit status.
+ */
+function gateStatus(results: string, expectedUpstream: string): number {
+  try {
+    execFileSync('bash', ['-c', gateShell()], {
+      env: {
+        ...process.env,
+        RESULTS: results,
+        EXPECTED_UPSTREAM: expectedUpstream,
+      },
+      stdio: 'pipe',
+    });
+    return 0;
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1;
+  }
+}
+
+describe('ci-ok — the single required status check', () => {
+  it('gates every other job in the workflow', () => {
+    const jobs = workflow().jobs;
+    const names = Object.keys(jobs);
+
+    // Non-vacuity floor. With one job in the file the set equality below is
+    // trivially satisfiable, and this suite would attest to nothing.
+    expect(
+      names.length,
+      'ci.yml has fewer jobs than when this fence was written — re-read it before ' +
+        'lowering this floor.'
+    ).toBeGreaterThanOrEqual(5);
+
+    const gated = new Set(jobs['ci-ok']?.needs ?? []);
+    const ungated = names.filter((n) => n !== 'ci-ok' && !gated.has(n));
+    expect(
+      ungated,
+      `these ci.yml jobs are not in ci-ok's \`needs:\`, so they are outside the merge ` +
+        `gate and can be red while the required check is green: ${ungated.join(', ')}. ` +
+        `Add them to \`needs:\` and bump EXPECTED_UPSTREAM.`
+    ).toEqual([]);
+
+    // The other direction: a `needs:` entry naming a job that no longer exists
+    // makes the workflow invalid, which fails loudly — but it also silently
+    // inflates EXPECTED_UPSTREAM's intended value, so pin it here too.
+    const phantom = [...gated].filter((n) => !names.includes(n));
+    expect(phantom, `ci-ok \`needs:\` names jobs that do not exist: ${phantom.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  it('runs even when an upstream job failed', () => {
+    // Without `always()` the job is SKIPPED on an upstream failure, and a
+    // skipped required check counts as PASSING.
+    expect(workflow().jobs['ci-ok']?.if).toBe('always()');
+  });
+
+  it('declares the upstream count its shell checks against', () => {
+    const job = workflow().jobs['ci-ok'];
+    expect(job?.env?.['EXPECTED_UPSTREAM']).toBe(String(job?.needs?.length ?? -1));
+  });
+
+  it('takes the results through env, not as inlined expression text', () => {
+    // The value space is a closed enum today, so inlining is safe by accident
+    // rather than by construction. The repo's pattern is that expression data
+    // reaches a shell as a variable.
+    expect(gateShell()).not.toContain('${{');
+    expect(workflow().jobs['ci-ok']?.env?.['RESULTS']).toContain('join(needs.*.result');
+  });
+
+  describe('the extracted step', () => {
+    it('passes when every upstream job succeeded', () => {
+      expect(gateStatus('success success success success', '4')).toBe(0);
+    });
+
+    it('passes when an upstream job was skipped', () => {
+      // release-pr-not-stale skips on every non-release PR, and a matrix job
+      // skipped because its `needs:` failed is reported by that job's own
+      // failure instead.
+      expect(gateStatus('success skipped success skipped', '4')).toBe(0);
+    });
+
+    it('fails on a failed upstream job', () => {
+      expect(gateStatus('success failure success success', '4')).not.toBe(0);
+    });
+
+    it('fails on a cancelled upstream job', () => {
+      // A cancelled run must not satisfy auto-merge.
+      expect(gateStatus('success cancelled success success', '4')).not.toBe(0);
+    });
+
+    it('fails when the results render empty', () => {
+      // THE case this floor exists for: the loop runs zero times, so without
+      // the count check "all good" and "examined nothing" are the same exit 0.
+      expect(gateStatus('', '4')).not.toBe(0);
+    });
+
+    it('fails when fewer results arrive than the needs list declares', () => {
+      expect(gateStatus('success success', '4')).not.toBe(0);
+    });
+  });
+});

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -46,7 +46,7 @@ const GATE_STEP = 'every upstream job succeeded or was skipped';
 interface CiWorkflow {
   on?: Record<
     string,
-    { paths?: unknown; 'paths-ignore'?: unknown; branches?: unknown } | null
+    { paths?: unknown; 'paths-ignore'?: unknown; branches?: unknown; types?: unknown } | null
   >;
   jobs: Record<
     string,
@@ -79,6 +79,36 @@ function gateShell(): string {
       'without it the sole required status check asserts nothing.'
   ).toBeTruthy();
   return step?.run as string;
+}
+
+function bareCondition(condition: string): string {
+  return condition
+    .trim()
+    .replace(/^\$\{\{\s*/, '')
+    .replace(/\s*\}\}$/, '')
+    .trim();
+}
+
+/**
+ * Whether a step `if:` is exempt from the unconditional-step rule.
+ *
+ * `always()` is exempt outright — the step runs on every path, so it can never
+ * be the reason a job reported success having done nothing.
+ *
+ * `failure()` / `cancelled()` are exempt ONLY when the job carries at least one
+ * UNCONDITIONAL step, and that qualifier is the whole point. A diagnostic dump
+ * gated on `failure()` beside real work is correct code, and banning it refuses
+ * a shape the sibling repos actually carry. But the SAME condition on a job's
+ * only work — `- name: unit tests / if: failure() / run: vp test` — skips on
+ * every green path while the job reports `success`, which is precisely the
+ * vacuity ci-ok cannot see. An earlier cut exempted the two conditions
+ * unconditionally and readmitted exactly that mutation.
+ */
+function isExemptStepCondition(condition: string, jobSteps: { if?: string }[]): boolean {
+  const bare = bareCondition(condition);
+  if (bare === 'always()') return true;
+  if (bare !== 'failure()' && bare !== 'cancelled()') return false;
+  return jobSteps.some((s) => s.if === undefined);
 }
 
 /**
@@ -185,8 +215,19 @@ describe('ci-ok — the single required status check', () => {
       }
       for (const s of j.steps ?? []) {
         const label = s.name ?? s.run?.split('\n')[0] ?? '<step>';
-        if (s.if !== undefined && !ALLOWED_CONDITIONAL.has(name)) {
+        if (
+          s.if !== undefined &&
+          !ALLOWED_CONDITIONAL.has(name) &&
+          !isExemptStepCondition(s.if, j.steps ?? [])
+        ) {
           offenders.push(`${name} > ${label} (step if:)`);
+        }
+        // NOT gated on ALLOWED_CONDITIONAL: a step-level `continue-on-error`
+        // is the same lever as the job-level one, one level down — the step
+        // fails, the job reports `success`, ci-ok counts it, and it reads green
+        // in the Checks UI so `ci-green-gate` passes too.
+        if ((s['continue-on-error'] ?? false) !== false) {
+          offenders.push(`${name} > ${label} (step continue-on-error)`);
         }
       }
     }
@@ -216,9 +257,15 @@ describe('ci-ok — the single required status check', () => {
     expect(pr, 'ci.yml no longer triggers on `pull_request`').not.toBeUndefined();
     expect(pr?.paths).toBeUndefined();
     expect(pr?.['paths-ignore']).toBeUndefined();
+    // `types:` is the same trap with a different key: narrowing it to
+    // `[opened]` means a later push creates a head sha with NO check run, and
+    // the required check sits at "Expected" on that sha forever. The default
+    // set (opened / synchronize / reopened) is what a required check needs.
+    expect(pr?.types).toBeUndefined();
     // `branches:` narrows the same way a `paths:` filter does — a PR whose base
     // is not listed never starts the workflow, so the required check sits at
-    // "Expected" forever. `main` is the only base this repo takes PRs against.
+    // "Expected" forever. `main` is the only base this repo takes PRs against,
+    // and pinning the value reds on REMOVAL too, which is the safer direction.
     expect(pr?.branches).toEqual(['main']);
   });
 

--- a/tests/unit/scripts/ci-ok-gate.test.ts
+++ b/tests/unit/scripts/ci-ok-gate.test.ts
@@ -81,35 +81,33 @@ function gateShell(): string {
   return step?.run as string;
 }
 
-function bareCondition(condition: string): string {
-  return condition
-    .trim()
-    .replace(/^\$\{\{\s*/, '')
-    .replace(/\s*\}\}$/, '')
-    .trim();
-}
-
-/**
- * Whether a step `if:` is exempt from the unconditional-step rule.
+/*
+ * There is deliberately NO exemption for a step `if:`, and the two revisions
+ * that tried to write one are why.
  *
- * `always()` is exempt outright — the step runs on every path, so it can never
- * be the reason a job reported success having done nothing.
+ * The shape an exemption would serve is a diagnostic dump gated on `failure()`
+ * beside real work. `.github/workflows/ci.yml` contains ZERO step-level `if:`
+ * (measured), so every exemption written so far funded a shape this file does
+ * not have — while each one opened a real hole:
  *
- * `failure()` / `cancelled()` are exempt ONLY when the job carries at least one
- * UNCONDITIONAL step, and that qualifier is the whole point. A diagnostic dump
- * gated on `failure()` beside real work is correct code, and banning it refuses
- * a shape the sibling repos actually carry. But the SAME condition on a job's
- * only work — `- name: unit tests / if: failure() / run: vp test` — skips on
- * every green path while the job reports `success`, which is precisely the
- * vacuity ci-ok cannot see. An earlier cut exempted the two conditions
- * unconditionally and readmitted exactly that mutation.
+ *   1. `failure()` / `cancelled()` exempt outright. A job whose only work is
+ *      gated on `failure()` skips on every green path, reports `success`, and
+ *      ci-ok counts it.
+ *   2. Exempt when "some step is unconditional". Every job here opens with an
+ *      unconditional `uses: actions/checkout@…`, so the predicate is TRUE for
+ *      all five jobs by construction and (1) came straight back. Measured:
+ *      gating all 30 `run:` steps of `check-build-test` while leaving the two
+ *      `uses:` steps alone yielded zero offenders.
+ *
+ * Revision 2's probe only reddened because it gated the CHECKOUT too — the one
+ * arm the hole does not cover. A probe that varied the wrong thing.
+ *
+ * So: any step `if:` in a gated job is an offender, full stop. If a diagnostic
+ * dump ever lands here, the PR adding it adds an exemption keyed on a FLOOR of
+ * unconditional `run:` steps per job — a dump only ADDS a gated step, so a
+ * floor admits it while gating real work still reds — and proves it with a
+ * probe that leaves the checkout alone.
  */
-function isExemptStepCondition(condition: string, jobSteps: { if?: string }[]): boolean {
-  const bare = bareCondition(condition);
-  if (bare === 'always()') return true;
-  if (bare !== 'failure()' && bare !== 'cancelled()') return false;
-  return jobSteps.some((s) => s.if === undefined);
-}
 
 /**
  * Run the extracted step under bash with the two env vars the runner supplies,
@@ -215,11 +213,7 @@ describe('ci-ok — the single required status check', () => {
       }
       for (const s of j.steps ?? []) {
         const label = s.name ?? s.run?.split('\n')[0] ?? '<step>';
-        if (
-          s.if !== undefined &&
-          !ALLOWED_CONDITIONAL.has(name) &&
-          !isExemptStepCondition(s.if, j.steps ?? [])
-        ) {
+        if (s.if !== undefined && !ALLOWED_CONDITIONAL.has(name)) {
           offenders.push(`${name} > ${label} (step if:)`);
         }
         // NOT gated on ALLOWED_CONDITIONAL: a step-level `continue-on-error`

--- a/tests/unit/scripts/release-pr-not-stale-guard.test.ts
+++ b/tests/unit/scripts/release-pr-not-stale-guard.test.ts
@@ -20,42 +20,65 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * A human reading the diff was the only thing catching that, and arming
  * auto-merge on the release PR removes the human.
  *
- * Why it needs a suite at all: the job is a CHECKER, and
- * `.claude/rules/testing.md` forbids a checker whose "found nothing" and "went
- * dead" produce the same green. Its whole body is three git invocations, each
- * of which rots silently — drop the `!` from the `merge-base` test, drop the
- * `--` from `rev-list`, misspell `FETCH_HEAD`, and the job passes on every
- * input including the stale one it exists to refuse. Both arms were probed by
- * hand once before the job was committed; nothing re-ran them, which is what
- * this file fixes.
+ * Why it needs a suite: the job is a CHECKER, and `.claude/rules/testing.md`
+ * forbids one whose "found nothing" and "went dead" produce the same green.
  *
- * The shell is EXTRACTED from the workflow and executed, never re-typed: a
- * copy in this file would keep passing after the workflow's copy was broken.
+ * Three properties are fenced, and the first two were review findings on this
+ * PR rather than hypotheticals:
+ *
+ *   1. The CHECKOUT, not just the shell. Deleting `ref: head.sha` from step 0
+ *      makes the runner use the default `refs/pull/N/merge`, which has the base
+ *      already merged in — so every `merge-base --is-ancestor` answers yes and
+ *      the job passes on a stale branch. An earlier revision of this file read
+ *      `steps[1]` only and stayed green through exactly that mutation.
+ *   2. EACH ARM of the loop separately. An earlier fixture only ever moved
+ *      `CHANGELOG.md` on main, so `.release-please-manifest.json` never
+ *      discriminated and gating the ancestry test on the filename survived
+ *      undetected. The remotes below are built so that each file, in turn, is
+ *      the only one that can fail.
+ *   3. The shell itself, EXTRACTED and EXECUTED, never re-typed — a copy here
+ *      would keep passing after the workflow's copy was broken — and selected
+ *      BY STEP NAME, so inserting a step ahead of it cannot silently retarget
+ *      the extractor.
  */
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const CI_YML = join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+const RELEASE_YML = join(REPO_ROOT, '.github', 'workflows', 'release.yml');
 
-/** Files the job asserts main's tip for. Kept in step with the job below. */
-const OWNED_FILES = ['CHANGELOG.md', '.release-please-manifest.json'] as const;
+const JOB = 'release-pr-not-stale';
+const STEP = 'release-please-owned files on main must be ancestors of this branch';
+const CHANGELOG = 'CHANGELOG.md';
+const MANIFEST = '.release-please-manifest.json';
 
 interface CiWorkflow {
-  jobs: Record<string, { if?: string; steps?: { name?: string; run?: string }[] }>;
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      steps?: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+    }
+  >;
 }
 
 function workflow(): CiWorkflow {
   return parseYaml(readFileSync(CI_YML, 'utf8')) as CiWorkflow;
 }
 
-/** The `run:` body of the job's ancestry step (step 0 is the checkout). */
+function jobSteps(): NonNullable<CiWorkflow['jobs'][string]['steps']> {
+  const steps = workflow().jobs[JOB]?.steps;
+  expect(steps, `job \`${JOB}\` is gone from .github/workflows/ci.yml`).toBeTruthy();
+  return steps as NonNullable<CiWorkflow['jobs'][string]['steps']>;
+}
+
+/** The ancestry step's `run:` body, selected by NAME rather than by index. */
 function guardShell(): string {
-  const step = workflow().jobs['release-pr-not-stale']?.steps?.[1];
+  const step = jobSteps().find((s) => s.name === STEP);
   expect(
     step?.run,
-    'release-pr-not-stale has no second step with a `run:` body in ' +
-      '.github/workflows/ci.yml. If the step was renamed or reordered, update this ' +
-      'extractor; if it was REMOVED, restore it — a release PR could then be merged ' +
-      'stale with nothing objecting.'
+    `the step \`${STEP}\` is gone from job \`${JOB}\` in .github/workflows/ci.yml. If it ` +
+      `was renamed, update this extractor; if it was REMOVED, restore it — a release PR ` +
+      `could then be merged stale with nothing objecting.`
   ).toBeTruthy();
   return step?.run as string;
 }
@@ -87,7 +110,7 @@ function commit(repo: string, file: string, body: string, subject: string): stri
 
 /**
  * Run the extracted guard with `cwd` as the checked-out release branch and
- * `origin` pointing at the fixture's bare remote. Returns exit status + output.
+ * `origin` pointing at the fixture's bare remote.
  */
 function guardRun(cwd: string): { status: number; output: string } {
   try {
@@ -106,123 +129,167 @@ function guardRun(cwd: string): { status: number; output: string } {
 
 describe('release-pr-not-stale', () => {
   let scratch: string;
-  let remote: string;
-  /** Commit on main that last touched CHANGELOG.md. */
-  let changelogTip: string;
-  /** The commit immediately before it — what a stale branch was cut from. */
-  let beforeChangelog: string;
+  let cloneSeq = 0;
 
-  beforeAll(() => {
-    scratch = mkdtempSync(join(tmpdir(), 'cdkd-release-stale-'));
-    const origin = join(scratch, 'origin');
+  interface Fixture {
+    /** Bare remote the guard's `git fetch origin main` will read. */
+    remote: string;
+    /** Commit that last touched the file this fixture is about. */
+    tip: string;
+    /** The commit before it — what a branch left behind would be cut from. */
+    base: string;
+  }
+
+  /**
+   * A main history ending in a commit that touches ONLY `lastFile`. A release
+   * branch cut at `base` is then stale by `lastFile` and by nothing else, which
+   * is what makes each arm of the production loop separately observable.
+   *
+   * `seedManifest: false` builds a history where the manifest NEVER existed, so
+   * `git rev-list -1 ... -- <manifest>` comes back empty and the fail-closed
+   * branch of the loop is reached with the CHANGELOG arm passing.
+   */
+  function makeRemote(name: string, lastFile: string, seedManifest = true): Fixture {
+    const origin = join(scratch, `${name}-origin`);
     mkdirSync(origin);
     git(origin, 'init', '-q', '-b', 'main');
-
-    // A main history shaped like this repo's: a release commit touching both
-    // owned files, then ordinary work, then a later edit to CHANGELOG.md that
-    // a standing release PR would NOT absorb.
-    writeFileSync(join(origin, 'CHANGELOG.md'), '# Changelog\n\n## 0.1.0\n');
-    writeFileSync(join(origin, '.release-please-manifest.json'), '{ ".": "0.1.0" }\n');
+    writeFileSync(join(origin, CHANGELOG), '# Changelog\n\n## 0.1.0\n');
+    if (seedManifest) writeFileSync(join(origin, MANIFEST), '{ ".": "0.1.0" }\n');
     git(origin, 'add', '.');
     git(origin, 'commit', '-q', '-m', 'chore(release): 0.1.0');
-    commit(origin, 'src.txt', 'work\n', 'feat: something');
-    beforeChangelog = git(origin, 'rev-parse', 'HEAD');
-    changelogTip = commit(
-      origin,
-      'CHANGELOG.md',
-      '# Changelog\n\n## 0.1.0 (normalized)\n',
-      'chore(docs): normalize changelog headers'
-    );
+    const base = commit(origin, 'src.txt', 'work\n', 'feat: something');
+    const tip =
+      lastFile === CHANGELOG
+        ? commit(origin, CHANGELOG, '# Changelog\n\n## 0.1.0 (normalized)\n', 'chore(docs): normalize')
+        : commit(origin, MANIFEST, '{ ".": "0.1.0-edited" }\n', 'chore: hand-edit the manifest');
 
-    remote = join(scratch, 'remote.git');
+    const remote = join(scratch, `${name}-remote.git`);
     execFileSync('git', ['clone', '-q', '--bare', origin, remote], {
       env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
     });
+    return { remote, tip, base };
+  }
+
+  /** A release branch cut from `at`, with release-please's own commit on top. */
+  function releaseBranchAt(fixture: Fixture, at: string): string {
+    const wt = join(scratch, `wt-${cloneSeq++}`);
+    execFileSync('git', ['clone', '-q', fixture.remote, wt], {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+    git(wt, 'checkout', '-q', '-b', 'release-please--branches--main', at);
+    commit(wt, 'RELEASE_NOTE.txt', 'release-please commit\n', 'chore(release): 0.1.1');
+    return wt;
+  }
+
+  let changelogFixture: Fixture;
+  let manifestFixture: Fixture;
+  let noManifestFixture: Fixture;
+
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cdkd-release-stale-'));
+    changelogFixture = makeRemote('changelog', CHANGELOG);
+    manifestFixture = makeRemote('manifest', MANIFEST);
+    // Main never had the manifest at all — the "cannot answer" path, with the
+    // CHANGELOG arm deliberately able to pass so it cannot mask the verdict.
+    noManifestFixture = makeRemote('nomanifest', CHANGELOG, false);
   });
 
   afterAll(() => {
     rmSync(scratch, { recursive: true, force: true });
   });
 
-  /** A release branch cut from `base`, with release-please's own commit on top. */
-  function releaseBranchAt(base: string, name: string): string {
-    const wt = join(scratch, name);
-    execFileSync('git', ['clone', '-q', remote, wt], {
-      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+  describe('the checkout the guard depends on', () => {
+    it('takes the PR HEAD, not the default merge ref', () => {
+      // `refs/pull/N/merge` has the base already merged in, so every ancestry
+      // question answers "yes" no matter how stale the branch is. Losing this
+      // `ref:` is the one mutation that makes the whole job vacuous while its
+      // shell is still perfectly correct.
+      const checkout = jobSteps().find((s) => (s.uses ?? '').startsWith('actions/checkout@'));
+      expect(checkout, `job \`${JOB}\` no longer checks anything out`).toBeTruthy();
+      expect(checkout?.with?.['ref']).toBe('${{ github.event.pull_request.head.sha }}');
     });
-    git(wt, 'checkout', '-q', '-b', 'release-please--branches--main', base);
-    commit(wt, '.release-please-manifest.json', '{ ".": "0.1.1" }\n', 'chore(release): 0.1.1');
-    return wt;
-  }
 
-  it('passes on a release branch cut from current main', () => {
-    const { status, output } = guardRun(releaseBranchAt('origin/main', 'fresh'));
-    expect(output).not.toContain('::error::');
-    expect(status).toBe(0);
+    it('fetches the full history the ancestry test needs', () => {
+      const checkout = jobSteps().find((s) => (s.uses ?? '').startsWith('actions/checkout@'));
+      expect(checkout?.with?.['fetch-depth']).toBe(0);
+    });
   });
 
-  it('fails on a release branch cut before main moved CHANGELOG.md', () => {
-    // The go-to-k/cdkd#2503 shape: `chore(docs):` produced no changelog entry,
-    // so release-please left the branch behind, and merging it reverts the
-    // normalization.
-    const { status, output } = guardRun(releaseBranchAt(beforeChangelog, 'stale'));
-    expect(status).not.toBe(0);
-    expect(output).toContain('CHANGELOG.md');
-    expect(output).toContain(changelogTip);
-    expect(output).toContain('re-run release.yml');
+  describe('each owned file separately', () => {
+    it('passes on a release branch cut from current main', () => {
+      const { status, output } = guardRun(releaseBranchAt(changelogFixture, 'origin/main'));
+      expect(status).toBe(0);
+      expect(output).not.toContain('::error::');
+    });
+
+    it('fails when main moved CHANGELOG.md after the branch was cut', () => {
+      // The go-to-k/cdkd#2503 shape: `chore(docs):` produced no changelog entry,
+      // so release-please left the branch behind and merging it reverts the
+      // normalization.
+      const { status, output } = guardRun(
+        releaseBranchAt(changelogFixture, changelogFixture.base)
+      );
+      expect(status).not.toBe(0);
+      expect(output).toContain(CHANGELOG);
+      expect(output).toContain(changelogFixture.tip);
+      expect(output).toContain('re-run release.yml');
+      // Only this arm may fire here — otherwise the case cannot tell a
+      // per-file check from one that refuses everything.
+      expect(output).not.toContain(`${MANIFEST} was last changed`);
+    });
+
+    it('fails when main moved the manifest after the branch was cut', () => {
+      // Without this case the manifest arm never discriminates, and gating the
+      // ancestry test on `[ "${f}" = "CHANGELOG.md" ]` survives the suite.
+      const { status, output } = guardRun(releaseBranchAt(manifestFixture, manifestFixture.base));
+      expect(status).not.toBe(0);
+      expect(output).toContain(MANIFEST);
+      expect(output).toContain(manifestFixture.tip);
+      expect(output).not.toContain(`${CHANGELOG} was last changed`);
+    });
+
+    it('fails closed when an owned file has no history on main', () => {
+      // "The guard cannot answer" must not read as "the guard found nothing
+      // wrong". The CHANGELOG arm passes in this fixture, so the non-zero exit
+      // can only come from the empty-tip branch.
+      const { status, output } = guardRun(releaseBranchAt(noManifestFixture, 'origin/main'));
+      expect(status).not.toBe(0);
+      expect(output).toContain('cannot evaluate staleness');
+      expect(output).toContain(MANIFEST);
+      expect(output).not.toContain(`${CHANGELOG} has no commit history`);
+    });
   });
 
-  it('fails closed when an owned file has no history on main', () => {
-    // "The guard cannot answer" must not read as "the guard found nothing
-    // wrong" — a rename of either file would otherwise silence it forever.
-    const wt = releaseBranchAt('origin/main', 'renamed');
-    // Rewrite the remote's main so .release-please-manifest.json never existed.
-    const bare = join(scratch, 'empty-remote.git');
-    mkdirSync(bare);
-    git(bare, 'init', '-q', '--bare', '-b', 'main');
-    const seed = join(scratch, 'seed');
-    mkdirSync(seed);
-    git(seed, 'init', '-q', '-b', 'main');
-    commit(seed, 'CHANGELOG.md', '# Changelog\n', 'chore(release): 0.1.0');
-    git(seed, 'remote', 'add', 'origin', bare);
-    git(seed, 'push', '-q', 'origin', 'main');
-    git(wt, 'remote', 'set-url', 'origin', bare);
+  describe('the job stays wired to the thing it guards', () => {
+    it('checks exactly the files release-please owns', () => {
+      // Read the loop's actual subject list rather than asserting a substring
+      // is absent — `not.toContain('package.json')` passes over an empty
+      // string and over a shell that checks nothing at all.
+      const m = /^for f in (.+); do$/m.exec(guardShell());
+      expect(m, "the guard's `for f in ...; do` loop is gone").not.toBeNull();
+      expect((m as RegExpExecArray)[1]!.trim().split(/\s+/).sort()).toEqual(
+        [CHANGELOG, MANIFEST].sort()
+      );
+    });
 
-    const { status, output } = guardRun(wt);
-    expect(status).not.toBe(0);
-    expect(output).toContain('.release-please-manifest.json');
-    expect(output).toContain('cannot evaluate staleness');
-  });
-
-  it('checks every file release-please owns', () => {
-    // A shrunk list is the cheapest way for this job to go quiet: dropping
-    // CHANGELOG.md leaves the manifest check green on the exact #2503 shape.
-    const shell = guardShell();
-    for (const f of OWNED_FILES) {
-      expect(shell).toContain(f);
-    }
-    // package.json is deliberately EXCLUDED — `chore(deps)` PRs touch it
-    // constantly and release-please's own diff there is the `version` line
-    // alone, which a three-way merge cannot use to revert a dependency line.
-    expect(shell).not.toContain('package.json');
-  });
-
-  it('is guarded by the branch prefix release-please actually produces', () => {
-    // `release-please--` is the action's built-in prefix. It changes only if
-    // the config sets `branch-prefix`, and if it ever does, this job silently
-    // skips on every PR and ci-ok stays green — the vacuous pass the
-    // once-leak-detect canary exists to forbid for its own detector.
-    expect(workflow().jobs['release-pr-not-stale']?.if).toBe(
-      "startsWith(github.head_ref, 'release-please--')"
-    );
-    const config = JSON.parse(
-      readFileSync(join(REPO_ROOT, 'release-please-config.json'), 'utf8')
-    ) as Record<string, unknown> & { packages?: Record<string, Record<string, unknown>> };
-    expect(
-      'branch-prefix' in config || 'branch-prefix' in (config.packages?.['.'] ?? {}),
-      'release-please-config.json now sets `branch-prefix`, so the release branch no ' +
-        'longer starts with `release-please--` and the release-pr-not-stale job skips on ' +
-        'every PR. Update its `if:` to the new prefix.'
-    ).toBe(false);
+    it('is guarded by the branch prefix release-please actually produces', () => {
+      expect(workflow().jobs[JOB]?.if).toBe("startsWith(github.head_ref, 'release-please--')");
+      // What can actually move that prefix is a release-please MAJOR, not any
+      // config key — `branch-prefix` does not exist in release-please's config
+      // schema, so an earlier revision of this case asserted the absence of a
+      // key that can never appear. The action is SHA-pinned, so the pin's major
+      // is the real change vector: bumping it must force a re-check of the
+      // `if:` above, and dependabot's weekly patch bumps must not.
+      const pin = /googleapis\/release-please-action@[0-9a-f]{40} # v(\d+)/.exec(
+        readFileSync(RELEASE_YML, 'utf8')
+      );
+      expect(pin, 'release.yml no longer SHA-pins googleapis/release-please-action').not.toBeNull();
+      expect(
+        (pin as RegExpExecArray)[1],
+        'release-please was bumped to a new MAJOR. Its release branch prefix is a property ' +
+          `of that major — re-verify that a release PR's head still starts with ` +
+          "'release-please--' before updating this expectation."
+      ).toBe('5');
+    });
   });
 });

--- a/tests/unit/scripts/release-pr-not-stale-guard.test.ts
+++ b/tests/unit/scripts/release-pr-not-stale-guard.test.ts
@@ -136,16 +136,16 @@ function guardRun(cwd: string): { status: number; output: string } {
 }
 
 describe('release-pr-not-stale', () => {
-  // `| undefined` on purpose: the `if (scratch)` guard in afterAll exists
-  // because `mkdtempSync` can fail, and the non-nullable type said otherwise.
-  // Everything that USES it goes through `scratchDir()`, which turns a
-  // not-yet-created scratch into a named failure rather than a `join(undefined)`
-  // TypeError several frames away from the cause.
+  // `| undefined` on purpose: the `if (scratch)` guard in afterAll is the one
+  // that matters — `mkdtempSync` THROWS rather than returning undefined, and a
+  // thrown `beforeAll` means no test body runs, so `scratchDir()` below cannot
+  // actually fire. It exists to satisfy the type without an `as string` cast
+  // scattered through the fixture builders, not as a fence.
   let scratch: string | undefined;
 
   function scratchDir(): string {
-    expect(scratch, 'the scratch directory was never created (mkdtempSync failed)').toBeTruthy();
-    return scratch as string;
+    if (!scratch) throw new Error('scratch directory was never created');
+    return scratch;
   }
   let cloneSeq = 0;
 

--- a/tests/unit/scripts/release-pr-not-stale-guard.test.ts
+++ b/tests/unit/scripts/release-pr-not-stale-guard.test.ts
@@ -56,7 +56,15 @@ interface CiWorkflow {
     string,
     {
       if?: string;
-      steps?: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+      'continue-on-error'?: unknown;
+      steps?: {
+        name?: string;
+        uses?: string;
+        run?: string;
+        if?: string;
+        'continue-on-error'?: unknown;
+        with?: Record<string, unknown>;
+      }[];
     }
   >;
 }
@@ -195,7 +203,9 @@ describe('release-pr-not-stale', () => {
   });
 
   afterAll(() => {
-    rmSync(scratch, { recursive: true, force: true });
+    // `mkdtempSync` failing leaves `scratch` undefined, and an unguarded
+    // `rmSync` then throws a TypeError that buries the real cause.
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
   });
 
   describe('the checkout the guard depends on', () => {
@@ -211,7 +221,20 @@ describe('release-pr-not-stale', () => {
 
     it('fetches the full history the ancestry test needs', () => {
       const checkout = jobSteps().find((s) => (s.uses ?? '').startsWith('actions/checkout@'));
-      expect(checkout?.with?.['fetch-depth']).toBe(0);
+      // `Number(...)` because `fetch-depth: "0"` is equally valid YAML and
+      // equally correct — a bare `toBe(0)` reds on a harmless requoting.
+      expect(Number(checkout?.with?.['fetch-depth'])).toBe(0);
+    });
+
+    it('lets the shell exit status decide the job', () => {
+      // This suite EXECUTES the extracted shell, so it attests that the TEXT is
+      // correct — never that the runner acts on its exit status.
+      // `continue-on-error: true` or a false step-level `if:` severs that link
+      // and the job reports success having decided nothing.
+      const step = jobSteps().find((s) => s.name === STEP);
+      expect(step?.['continue-on-error']).toBeUndefined();
+      expect(step?.if).toBeUndefined();
+      expect(workflow().jobs[JOB]?.['continue-on-error']).toBeUndefined();
     });
   });
 

--- a/tests/unit/scripts/release-pr-not-stale-guard.test.ts
+++ b/tests/unit/scripts/release-pr-not-stale-guard.test.ts
@@ -136,7 +136,17 @@ function guardRun(cwd: string): { status: number; output: string } {
 }
 
 describe('release-pr-not-stale', () => {
-  let scratch: string;
+  // `| undefined` on purpose: the `if (scratch)` guard in afterAll exists
+  // because `mkdtempSync` can fail, and the non-nullable type said otherwise.
+  // Everything that USES it goes through `scratchDir()`, which turns a
+  // not-yet-created scratch into a named failure rather than a `join(undefined)`
+  // TypeError several frames away from the cause.
+  let scratch: string | undefined;
+
+  function scratchDir(): string {
+    expect(scratch, 'the scratch directory was never created (mkdtempSync failed)').toBeTruthy();
+    return scratch as string;
+  }
   let cloneSeq = 0;
 
   interface Fixture {
@@ -158,7 +168,7 @@ describe('release-pr-not-stale', () => {
    * branch of the loop is reached with the CHANGELOG arm passing.
    */
   function makeRemote(name: string, lastFile: string, seedManifest = true): Fixture {
-    const origin = join(scratch, `${name}-origin`);
+    const origin = join(scratchDir(), `${name}-origin`);
     mkdirSync(origin);
     git(origin, 'init', '-q', '-b', 'main');
     writeFileSync(join(origin, CHANGELOG), '# Changelog\n\n## 0.1.0\n');
@@ -171,7 +181,7 @@ describe('release-pr-not-stale', () => {
         ? commit(origin, CHANGELOG, '# Changelog\n\n## 0.1.0 (normalized)\n', 'chore(docs): normalize')
         : commit(origin, MANIFEST, '{ ".": "0.1.0-edited" }\n', 'chore: hand-edit the manifest');
 
-    const remote = join(scratch, `${name}-remote.git`);
+    const remote = join(scratchDir(), `${name}-remote.git`);
     execFileSync('git', ['clone', '-q', '--bare', origin, remote], {
       env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
     });
@@ -180,7 +190,7 @@ describe('release-pr-not-stale', () => {
 
   /** A release branch cut from `at`, with release-please's own commit on top. */
   function releaseBranchAt(fixture: Fixture, at: string): string {
-    const wt = join(scratch, `wt-${cloneSeq++}`);
+    const wt = join(scratchDir(), `wt-${cloneSeq++}`);
     execFileSync('git', ['clone', '-q', fixture.remote, wt], {
       env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
     });
@@ -221,9 +231,14 @@ describe('release-pr-not-stale', () => {
 
     it('fetches the full history the ancestry test needs', () => {
       const checkout = jobSteps().find((s) => (s.uses ?? '').startsWith('actions/checkout@'));
-      // `Number(...)` because `fetch-depth: "0"` is equally valid YAML and
-      // equally correct — a bare `toBe(0)` reds on a harmless requoting.
-      expect(Number(checkout?.with?.['fetch-depth'])).toBe(0);
+      // `String(... ?? '')`, NOT `Number(...)`. Comparing numerically was an
+      // attempt to tolerate the equally-valid `fetch-depth: "0"`, and it
+      // RETIRED the bound instead: a bare `fetch-depth:` parses to null and
+      // `fetch-depth: ""` to the empty string, both of which `Number()` maps to
+      // 0 — while actions/checkout reads `Number(getInput(...) || '1')` and
+      // clones at depth ONE. That is precisely the shallow-clone mutation this
+      // case exists to catch, and the numeric form greened on it.
+      expect(String(checkout?.with?.['fetch-depth'] ?? '')).toBe('0');
     });
 
     it('lets the shell exit status decide the job', () => {
@@ -231,10 +246,13 @@ describe('release-pr-not-stale', () => {
       // correct — never that the runner acts on its exit status.
       // `continue-on-error: true` or a false step-level `if:` severs that link
       // and the job reports success having decided nothing.
+      // `?? false` because an explicit `continue-on-error: false` is
+      // semantically identical to its absence, and a fence that reds on it is
+      // refusing a correct spelling.
       const step = jobSteps().find((s) => s.name === STEP);
-      expect(step?.['continue-on-error']).toBeUndefined();
+      expect(step?.['continue-on-error'] ?? false).toBe(false);
       expect(step?.if).toBeUndefined();
-      expect(workflow().jobs[JOB]?.['continue-on-error']).toBeUndefined();
+      expect(workflow().jobs[JOB]?.['continue-on-error'] ?? false).toBe(false);
     });
   });
 

--- a/tests/unit/scripts/release-pr-not-stale-guard.test.ts
+++ b/tests/unit/scripts/release-pr-not-stale-guard.test.ts
@@ -1,0 +1,228 @@
+import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * The `release-pr-not-stale` job in `.github/workflows/ci.yml`, driven against
+ * real git repositories rather than inspected as text.
+ *
+ * What it guards: release-please does NOT rebuild a standing release PR whose
+ * computed release is unchanged — it logs `PR #N remained the same` and leaves
+ * the branch on the base it was cut from. A `chore:` / `ci:` / `docs:` commit
+ * produces no changelog entry, so it lands on main WITHOUT the release branch
+ * following, and merging the PR then takes the branch's older copy of any file
+ * release-please owns. GitHub reports MERGEABLE throughout — measured on
+ * go-to-k/cdkd#2503, which would have undone 285 CHANGELOG header conversions.
+ * A human reading the diff was the only thing catching that, and arming
+ * auto-merge on the release PR removes the human.
+ *
+ * Why it needs a suite at all: the job is a CHECKER, and
+ * `.claude/rules/testing.md` forbids a checker whose "found nothing" and "went
+ * dead" produce the same green. Its whole body is three git invocations, each
+ * of which rots silently — drop the `!` from the `merge-base` test, drop the
+ * `--` from `rev-list`, misspell `FETCH_HEAD`, and the job passes on every
+ * input including the stale one it exists to refuse. Both arms were probed by
+ * hand once before the job was committed; nothing re-ran them, which is what
+ * this file fixes.
+ *
+ * The shell is EXTRACTED from the workflow and executed, never re-typed: a
+ * copy in this file would keep passing after the workflow's copy was broken.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const CI_YML = join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+
+/** Files the job asserts main's tip for. Kept in step with the job below. */
+const OWNED_FILES = ['CHANGELOG.md', '.release-please-manifest.json'] as const;
+
+interface CiWorkflow {
+  jobs: Record<string, { if?: string; steps?: { name?: string; run?: string }[] }>;
+}
+
+function workflow(): CiWorkflow {
+  return parseYaml(readFileSync(CI_YML, 'utf8')) as CiWorkflow;
+}
+
+/** The `run:` body of the job's ancestry step (step 0 is the checkout). */
+function guardShell(): string {
+  const step = workflow().jobs['release-pr-not-stale']?.steps?.[1];
+  expect(
+    step?.run,
+    'release-pr-not-stale has no second step with a `run:` body in ' +
+      '.github/workflows/ci.yml. If the step was renamed or reordered, update this ' +
+      'extractor; if it was REMOVED, restore it — a release PR could then be merged ' +
+      'stale with nothing objecting.'
+  ).toBeTruthy();
+  return step?.run as string;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      // Hermetic: a maintainer's global config (hooks path, signing, a
+      // different default branch) must not decide this suite's verdict.
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+      GIT_AUTHOR_NAME: 't',
+      GIT_AUTHOR_EMAIL: 't@example.invalid',
+      GIT_COMMITTER_NAME: 't',
+      GIT_COMMITTER_EMAIL: 't@example.invalid',
+    },
+  }).trim();
+}
+
+function commit(repo: string, file: string, body: string, subject: string): string {
+  writeFileSync(join(repo, file), body);
+  git(repo, 'add', file);
+  git(repo, 'commit', '-q', '-m', subject);
+  return git(repo, 'rev-parse', 'HEAD');
+}
+
+/**
+ * Run the extracted guard with `cwd` as the checked-out release branch and
+ * `origin` pointing at the fixture's bare remote. Returns exit status + output.
+ */
+function guardRun(cwd: string): { status: number; output: string } {
+  try {
+    const output = execFileSync('bash', ['-c', guardShell()], {
+      cwd,
+      encoding: 'utf8',
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+      stdio: 'pipe',
+    });
+    return { status: 0, output };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, output: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+describe('release-pr-not-stale', () => {
+  let scratch: string;
+  let remote: string;
+  /** Commit on main that last touched CHANGELOG.md. */
+  let changelogTip: string;
+  /** The commit immediately before it — what a stale branch was cut from. */
+  let beforeChangelog: string;
+
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cdkd-release-stale-'));
+    const origin = join(scratch, 'origin');
+    mkdirSync(origin);
+    git(origin, 'init', '-q', '-b', 'main');
+
+    // A main history shaped like this repo's: a release commit touching both
+    // owned files, then ordinary work, then a later edit to CHANGELOG.md that
+    // a standing release PR would NOT absorb.
+    writeFileSync(join(origin, 'CHANGELOG.md'), '# Changelog\n\n## 0.1.0\n');
+    writeFileSync(join(origin, '.release-please-manifest.json'), '{ ".": "0.1.0" }\n');
+    git(origin, 'add', '.');
+    git(origin, 'commit', '-q', '-m', 'chore(release): 0.1.0');
+    commit(origin, 'src.txt', 'work\n', 'feat: something');
+    beforeChangelog = git(origin, 'rev-parse', 'HEAD');
+    changelogTip = commit(
+      origin,
+      'CHANGELOG.md',
+      '# Changelog\n\n## 0.1.0 (normalized)\n',
+      'chore(docs): normalize changelog headers'
+    );
+
+    remote = join(scratch, 'remote.git');
+    execFileSync('git', ['clone', '-q', '--bare', origin, remote], {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+  });
+
+  afterAll(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  /** A release branch cut from `base`, with release-please's own commit on top. */
+  function releaseBranchAt(base: string, name: string): string {
+    const wt = join(scratch, name);
+    execFileSync('git', ['clone', '-q', remote, wt], {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+    git(wt, 'checkout', '-q', '-b', 'release-please--branches--main', base);
+    commit(wt, '.release-please-manifest.json', '{ ".": "0.1.1" }\n', 'chore(release): 0.1.1');
+    return wt;
+  }
+
+  it('passes on a release branch cut from current main', () => {
+    const { status, output } = guardRun(releaseBranchAt('origin/main', 'fresh'));
+    expect(output).not.toContain('::error::');
+    expect(status).toBe(0);
+  });
+
+  it('fails on a release branch cut before main moved CHANGELOG.md', () => {
+    // The go-to-k/cdkd#2503 shape: `chore(docs):` produced no changelog entry,
+    // so release-please left the branch behind, and merging it reverts the
+    // normalization.
+    const { status, output } = guardRun(releaseBranchAt(beforeChangelog, 'stale'));
+    expect(status).not.toBe(0);
+    expect(output).toContain('CHANGELOG.md');
+    expect(output).toContain(changelogTip);
+    expect(output).toContain('re-run release.yml');
+  });
+
+  it('fails closed when an owned file has no history on main', () => {
+    // "The guard cannot answer" must not read as "the guard found nothing
+    // wrong" — a rename of either file would otherwise silence it forever.
+    const wt = releaseBranchAt('origin/main', 'renamed');
+    // Rewrite the remote's main so .release-please-manifest.json never existed.
+    const bare = join(scratch, 'empty-remote.git');
+    mkdirSync(bare);
+    git(bare, 'init', '-q', '--bare', '-b', 'main');
+    const seed = join(scratch, 'seed');
+    mkdirSync(seed);
+    git(seed, 'init', '-q', '-b', 'main');
+    commit(seed, 'CHANGELOG.md', '# Changelog\n', 'chore(release): 0.1.0');
+    git(seed, 'remote', 'add', 'origin', bare);
+    git(seed, 'push', '-q', 'origin', 'main');
+    git(wt, 'remote', 'set-url', 'origin', bare);
+
+    const { status, output } = guardRun(wt);
+    expect(status).not.toBe(0);
+    expect(output).toContain('.release-please-manifest.json');
+    expect(output).toContain('cannot evaluate staleness');
+  });
+
+  it('checks every file release-please owns', () => {
+    // A shrunk list is the cheapest way for this job to go quiet: dropping
+    // CHANGELOG.md leaves the manifest check green on the exact #2503 shape.
+    const shell = guardShell();
+    for (const f of OWNED_FILES) {
+      expect(shell).toContain(f);
+    }
+    // package.json is deliberately EXCLUDED — `chore(deps)` PRs touch it
+    // constantly and release-please's own diff there is the `version` line
+    // alone, which a three-way merge cannot use to revert a dependency line.
+    expect(shell).not.toContain('package.json');
+  });
+
+  it('is guarded by the branch prefix release-please actually produces', () => {
+    // `release-please--` is the action's built-in prefix. It changes only if
+    // the config sets `branch-prefix`, and if it ever does, this job silently
+    // skips on every PR and ci-ok stays green — the vacuous pass the
+    // once-leak-detect canary exists to forbid for its own detector.
+    expect(workflow().jobs['release-pr-not-stale']?.if).toBe(
+      "startsWith(github.head_ref, 'release-please--')"
+    );
+    const config = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'release-please-config.json'), 'utf8')
+    ) as Record<string, unknown> & { packages?: Record<string, Record<string, unknown>> };
+    expect(
+      'branch-prefix' in config || 'branch-prefix' in (config.packages?.['.'] ?? {}),
+      'release-please-config.json now sets `branch-prefix`, so the release branch no ' +
+        'longer starts with `release-please--` and the release-pr-not-stale job skips on ' +
+        'every PR. Update its `if:` to the new prefix.'
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The `main` branch ruleset requires no status check, so **GitHub never offers the
auto-merge button** — it is only offered on a PR that cannot be merged right
now. The release PR and the dependabot PRs are the two classes the maintainer
merges by hand, and both currently need approve → wait for CI → click merge.
With a required check they become approve → arm auto-merge → walk away.

This PR adds the jobs that a required-check ruleset makes load-bearing. The
ruleset change itself lands **after** this merges: requiring a check no branch
reports yet would leave every open PR blocked at "Expected".

## What

### `ci-ok` — the single name the ruleset will require

Requiring the real jobs does not work. `runtime-compat` is a matrix, so a
required check must match the **expanded** name (`runtime-compat (20)`), while a
matrix job that never starts — because `check-build-test` failed — reports under
the **unexpanded** name (`runtime-compat`). Requiring either spelling leaves the
other permanently "Expected", blocking the PR forever.

The aggregate also means adding a job needs a line in `needs:` rather than an
edit to repository settings nothing in this tree can review.

### `release-pr-not-stale` — the hazard auto-merge introduces

release-please does not rebuild a release PR whose computed release is
unchanged; it logs `PR #N remained the same` and leaves the branch on the base
it was cut from. A `chore:` / `ci:` / `docs:` commit produces no changelog
entry, so it lands on `main` **without the release branch following** — and if
it touched a file release-please owns, merging the PR takes the branch's older
copy while GitHub reports MERGEABLE throughout. Measured on
go-to-k/cdkd#2503, which would have undone 285 CHANGELOG header conversions.

A human reading the diff was the only thing catching that. Auto-merge removes
the human, so the check has to become a required status.

`package.json` is deliberately **not** inspected: `chore(deps)` PRs touch it
constantly and release-please's own diff there is the `version` line alone,
which a three-way merge cannot use to revert a dependency line.

### `docs-deploy.yml` — PR `paths:` filter removed

`build` is now a required check, and a required check can only be required if it
reports on every PR — a `paths:`-filtered workflow does not start at all when
nothing matches, leaving the check at "Expected" forever.

That requirement is what the filter's own comment promised and could no longer
deliver: *"a dependency bump that breaks the docs build must fail on the PR, not
after merge."* `package.json` / `pnpm-lock.yaml` were in the filter for exactly
that reason, so every dependabot PR already built the docs — but with auto-merge
armed and the check not required, the merge proceeded over a red build anyway.
Cost: one docs build on PRs touching neither docs nor dependencies — measured at
1m4s on this PR.

Its concurrency group also gains `cancel-in-progress: ${{ github.event_name ==
'pull_request' }}`. Now that `build` is required and runs on every PR, a
never-cancelling group queued each new push's full SSG build behind the
superseded one, serializing every PR's required check. A superseded PR build has
no value; a superseded main build feeds a deploy, so that one still completes.

## Tests

Both new jobs carry the vacuity risk that matters for a merge gate — reporting
**green having examined nothing** — so both are fenced by suites that EXECUTE
the shell extracted from the workflow rather than pattern-matching it.

`tests/unit/scripts/ci-ok-gate.test.ts`
- `needs:` covers every other job in the file (a job outside it can be red under
  a green `ci-ok`)
- `if: always()` is present (without it `ci-ok` is skipped on an upstream
  failure, and a skipped required check counts as **passing**)
- `EXPECTED_UPSTREAM` equals the `needs:` length
- the extracted step over `success` / `skipped` / `failure` / `cancelled`, plus
  the two vacuity cases: an **empty** render and a **short** one

`tests/unit/scripts/release-pr-not-stale-guard.test.ts`
- the **checkout**, not just the shell: `ref: head.sha` and `fetch-depth: 0`.
  Losing the `ref:` makes the runner use `refs/pull/N/merge`, which has the base
  already merged in, so every ancestry question answers yes and the job passes
  on a stale branch while its shell is still perfectly correct
- **each owned file separately** — three synthesized remotes whose last commit
  touches only one file, so `CHANGELOG.md` and the manifest each discriminate
  alone
- fails **closed** when an owned file has no history on main, in a fixture where
  the other arm passes so the verdict is isolated
- the loop's actual subject list equals the two owned files
- the `if:` prefix, plus the release-please action's pinned **major** — a
  `branch-prefix` config key does not exist in release-please's schema, so
  fencing its absence guarded nothing

Both files also assert the RUNNER acts on the shell's exit status:
`continue-on-error` and a step-level `if:` must be absent, every gated job must
be unconditional, `ci.yml`'s own `pull_request:` must carry no `paths:`, and
each new job's `permissions:` is pinned.

Measured before the floor existed: `results=""` gives `iterations=0 exit=0` —
the sole required check green having examined nothing.

Every fence was probed by making the production edit and confirming the expected
cases, **and only those**, go red:

| mutation | red cases |
| --- | --- |
| disable the `EXPECTED_UPSTREAM` comparison | empty render, short render |
| drop `runtime-compat` from `needs:` | needs coverage, count equality |
| invert `! git merge-base --is-ancestor` | the stale-branch case |
| drop `CHANGELOG.md` from the owned list | stale-branch case, list fence |
| remove `ref: head.sha` from the checkout | the PR-HEAD case |
| gate the ancestry test on the filename | the manifest-arm case |
| make the empty-tip branch non-fatal | the fails-closed case |
| re-add docs-deploy's `pull_request` paths filter | the docs-deploy case |
| `continue-on-error: true` on the gate step | the exit-status case |
| an `if:` on `once-leak-detect` | the unconditional-job case |
| a `paths:` filter on `ci.yml`'s `pull_request` | the every-PR case |

## Known residual — NOT closed by this PR

A `pull_request` workflow does **not** re-run when the BASE branch moves. So
`release-pr-not-stale` only evaluates when release-please pushes to the release
PR — and the hazard it guards is precisely the case where release-please does
**not** push, because a `chore:` commit produces no changelog entry and leaves
the computed release unchanged.

So after such a commit touches `CHANGELOG.md` on main, the release PR keeps its
previous green and armed auto-merge would still merge it stale. The job covers
the ordinary case, where a `feat:` / `fix:` lands and release-please rebuilds.

Two ways to close it were weighed. The ruleset's **up-to-date** requirement is
correct and costs no code, but every merge to main then leaves every other open
PR BEHIND — this repo runs four to five parallel lanes, so that is a daily toll
for a hazard that lives on one PR. The maintainer chose the alternative: a
staleness check in `release.yml`, which runs on every push to main and therefore
fires at the exact moment the hazard appears, at zero cost to every other PR. It
lands in a follow-up PR rather than here so this one can go in on the review it
has already had.

## Review

Code + test + security reviewers ran in parallel. No blockers; every finding is
addressed here — the two vacuity gaps above, job-level `permissions:` on both
new jobs (`contents: read` / none), and the results reaching the shell through
`env:` rather than as inlined expression text.

Two findings were decided rather than fixed, and both are recorded in the file:

- **A fork PR runs its own copy of `ci.yml`**, so a fork author can rewrite
  `ci-ok` to `exit 0`. This is a property of every `pull_request`-based required
  check, not something aggregating into one name introduced — requiring
  `check-build-test` directly was defeatable the same way. Controls are
  unchanged: the edit is visible in the diff, a first-time contributor's run
  needs maintainer approval, and a fork token is read-only.
- **`hooks.yml` / `hook-suites` stays unrequired.** It runs only on a
  `.claude/hooks/**` PR, which is never a release or dependabot PR — never one
  auto-merge is armed on. Agent-side merges still require it via
  `ci-green-gate`.

## Follow-up

Once merged, the `main` ruleset gains **Require status checks to pass** naming
`ci-ok`, `pr-content`, `check`, `prefix-scope`, `English-only (pull request)`
and `build`. No changelog entry: CI-only, no shipped-binary behavior delta.
