### PR TITLE
docs(readme): center the hero block and drop the docs-site screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-# cdkd (CDK Direct)
+<div align="center">
+  <h1>cdkd (CDK Direct)</h1>
+  <a href="https://www.npmjs.com/package/@go-to-k/cdkd">
+    <img src="https://img.shields.io/npm/v/@go-to-k/cdkd.svg" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@go-to-k/cdkd">
+    <img src="https://img.shields.io/npm/dw/@go-to-k/cdkd.svg" alt="Downloads" />
+  </a>
+  <a href="./LICENSE">
+    <img src="https://img.shields.io/npm/l/@go-to-k/cdkd.svg" alt="License: Apache-2.0" />
+  </a>
+  <h3>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</h3>
+  <p>
+    📚 Documentation: <a href="https://cdkd.dev"><b>cdkd.dev</b></a>
+  </p>
+</div>
 
-[![npm version](https://img.shields.io/npm/v/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
-[![Downloads](https://img.shields.io/npm/dw/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
-[![License: Apache-2.0](https://img.shields.io/npm/l/@go-to-k/cdkd.svg)](./LICENSE)
-
-Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.
-
-**📚 Documentation: [cdkd.dev](https://cdkd.dev)**
-
-<a href="https://cdkd.dev"><picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/go-to-k/cdkd/main/assets/docs-site-dark.png">
-<img alt="cdkd documentation site — cdkd.dev" src="https://raw.githubusercontent.com/go-to-k/cdkd/main/assets/docs-site-light.png" width="820">
-</picture></a>
+---
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is; just replace `cdk deploy` with `cdkd deploy`.
 - **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits; **faster than Terraform and CloudFormation Express mode** too (see [Benchmark](#benchmark)).


### PR DESCRIPTION
## Summary

- Restructure the README head as a centered hero block — title, badges, tagline, and the `📚 Documentation: cdkd.dev` link — followed by a horizontal rule, matching the layout used by [awslabs/nx-plugin-for-aws](https://github.com/awslabs/nx-plugin-for-aws).
- Badges become inline HTML anchors: GitHub does not render Markdown inside an HTML block, so the Markdown badge shortcuts would have shown as literal text inside the `<div align="center">`.
- Drop the docs-site screenshot (`<picture>` block). `assets/docs-site-light.png` / `assets/docs-site-dark.png` are left in the repo, now unreferenced — removing the files is deliberately out of scope for this PR.
- Content below the rule is untouched; no anchors changed, and nothing links to the removed image.

## Test plan

- [x] Unit tests pass (989 files, 21741 tests)
- [x] `vp run check` / `vp run typecheck:test` / `vp run build` pass
- [x] Rendering verified against GitHub's own renderer (`gh api -X POST /markdown -f mode=gfm`): the `align="center"` div, `<h1>`, badge anchors, `<h3>` tagline, docs link and `<hr>` all survive GitHub's HTML sanitizer
- [ ] Integration test: not applicable — documentation-only change, no shipped-binary behavior delta (hence no `changelog.d` entry)
- [x] Documentation updated (this PR is the documentation change)
