### PR TITLE
ci: disarm auto-merge on a release PR main has moved past

### DIFF
--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -70,23 +70,32 @@ jobs:
           # armed PR behaves identically to the arm-time run.
           #
           # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
-          # NAME is attacker-chosen, `gh pr list` includes fork PRs, and it
-          # orders newest-first -- so anyone could open a fork PR from a branch
-          # called `release-please--branches--main` and become the `[0]` this
-          # picks. The run would then read `armed` off the DECOY, get `no`, and
-          # exit 0 saying "not armed" while the real, armed, stale release PR
-          # went unchecked and merged. Pushing a branch to THIS repo needs write
-          # access, so restricting to same-repo PRs removes that reach entirely.
+          # NAME is attacker-chosen and open PRs include fork PRs -- so anyone
+          # could open one from a branch called `release-please--branches--main`
+          # and be picked here. The run would then read `armed` off the DECOY,
+          # get `no`, and exit 0 saying "not armed" while the real, armed, stale
+          # release PR went unchecked and merged. Pushing a branch to THIS repo
+          # needs write access, so the same-repo test removes that reach.
+          #
+          # A deleted fork leaves `head.repo` null, which `// ""` turns into a
+          # non-match rather than a jq error -- correct, since it was a fork.
           #
           # Deliberately NOT also matched on author: release-please's PRs are
           # authored by `app/github-actions` today, but switching it to a PAT or
           # a GitHub App changes that silently, and the guard would go inert with
           # nothing saying so -- the same failure mode the `if:` conditions in
           # ci.yml were repeatedly wrong about.
-          prs=$(gh pr list --repo "${REPO}" --state open \
-                  --json number,headRefName,isCrossRepository \
-                  --jq '.[] | select(.isCrossRepository | not)
-                            | select(.headRefName | startswith("release-please--"))
+          # `gh api --paginate`, NOT `gh pr list`. `gh pr list` defaults to
+          # `--limit 30` and applies `--jq` CLIENT-SIDE to that one page, so
+          # ~30 fork PRs -- attacker-chosen, no privilege -- evict the release
+          # PR from the page, the filter returns nothing, and the run exits 0
+          # saying "no standing release PR" while the real armed stale PR
+          # merges. Same suppression as the decoy below, reached by truncation
+          # instead of ordering, and it also fires benignly on a dependabot
+          # burst. Pagination enumerates EVERY open PR, so neither can happen.
+          prs=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
+                  --jq '.[] | select((.head.repo.full_name // "") == .base.repo.full_name)
+                            | select(.head.ref | startswith("release-please--"))
                             | .number')
           if [ -z "${prs}" ]; then
             echo "No standing release PR. Nothing to check."

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -1,0 +1,125 @@
+name: release-pr-staleness
+
+# Disarm auto-merge on a standing release PR that `main` has moved past.
+#
+# THE HAZARD. release-please does not rebuild a release PR whose computed
+# release is unchanged -- it logs `PR #N remained the same` and leaves the
+# branch on the base it was cut from. A `chore:` / `ci:` / `docs:` commit
+# produces no changelog entry, so it lands on `main` WITHOUT the release branch
+# following, and merging the PR then takes the branch's older copy of any file
+# release-please owns. GitHub reports MERGEABLE throughout.
+#
+# WHY ci.yml's `release-pr-not-stale` JOB CANNOT COVER THIS. That job is the
+# right check in the wrong place: a `pull_request` workflow does NOT re-run when
+# the BASE branch moves (its default activity types are `opened`,
+# `synchronize`, `reopened` -- all head-side). So the release PR keeps the green
+# it earned at its last head push, and the hazard is precisely the case where
+# release-please never pushes again. The job still earns its keep for the
+# ordinary case, where a feat/fix lands and release-please rebuilds; this
+# workflow covers the path it structurally cannot see.
+#
+# WHY TWO TRIGGERS, AND WHY NEITHER ALONE IS ENOUGH.
+#   push to main         -- main moves while auto-merge is ALREADY armed.
+#   auto_merge_enabled   -- auto-merge is armed on a PR main moved past EARLIER.
+# The second is the common one and is easy to miss: a release PR sits for days,
+# a `chore:` commit lands, and the maintainer later arms auto-merge on a PR that
+# is green from an old run. It merges immediately. A push-only check never runs
+# at that moment.
+#
+# `pull_request_target`, not `pull_request`: this needs `pull-requests: write`
+# to disarm, and a `pull_request` token is read-only for forks. It runs only
+# base-controlled code -- `gh` and `git` against refs -- and never checks out or
+# executes anything from the head.
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [auto_merge_enabled]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-pr-staleness
+  cancel-in-progress: false
+
+jobs:
+  disarm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Full history: `git rev-list -1 <ref> -- <path>` needs the commits that
+      # touched each owned file, which a shallow clone does not carry.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: disarm auto-merge on a release PR main has moved past
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The standing release PR, whatever event brought us here. Reading it
+          # back by head-branch prefix rather than from the event payload keeps
+          # both triggers on one code path, and means a `push` run that finds an
+          # armed PR behaves identically to the arm-time run.
+          pr=$(gh pr list --repo "${REPO}" --state open --json number,headRefName \
+                 --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
+          if [ -z "${pr}" ]; then
+            echo "No standing release PR. Nothing to check."
+            exit 0
+          fi
+
+          armed=$(gh pr view "${pr}" --repo "${REPO}" --json autoMergeRequest \
+                    --jq 'if .autoMergeRequest == null then "no" else "yes" end')
+          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          git fetch --no-tags --quiet origin "${head_ref}"
+          head=$(git rev-parse FETCH_HEAD)
+
+          stale=""
+          for f in CHANGELOG.md .release-please-manifest.json; do
+            tip=$(git rev-list -1 HEAD -- "${f}")
+            # An empty answer means the file has no history on main at all --
+            # renamed, deleted, or never committed. The check cannot answer the
+            # question it exists to answer, and "cannot answer" is a failure
+            # rather than a pass.
+            if [ -z "${tip}" ]; then
+              echo "::error::${f} has no commit history on main. This check cannot evaluate staleness, so it fails closed. If the file was renamed, update this workflow."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${tip}" "${head}"; then
+              stale="${stale}${stale:+, }${f} (main: ${tip})"
+            fi
+          done
+
+          if [ -z "${stale}" ]; then
+            echo "Release PR #${pr} is current with main (auto-merge armed: ${armed})."
+            exit 0
+          fi
+
+          echo "::warning::Release PR #${pr} is stale: ${stale}"
+
+          # Disarming is the only ACTION available, so a PR that is not armed
+          # gets a comment and nothing else -- and gets it once, because a
+          # repeat comment on every push to main would bury the signal. The
+          # arm-time trigger is what catches it later.
+          if [ "${armed}" = "yes" ]; then
+            gh pr merge "${pr}" --repo "${REPO}" --disable-auto
+            gh pr comment "${pr}" --repo "${REPO}" --body "$(cat <<EOF
+          Auto-merge has been **disabled** on this pull request: \`main\` has moved past it.
+
+          Stale against: ${stale}
+
+          release-please does not rebuild a release PR whose computed release is unchanged, so a \`chore:\` / \`ci:\` / \`docs:\` commit lands on \`main\` without this branch following. Merging as-is would take this branch's older copy of the file(s) above and revert that commit, and GitHub reports the PR as mergeable throughout.
+
+          To release: close this PR, delete its branch, and re-run the Release workflow (\`workflow_dispatch\`). release-please recomputes the identical release from current \`main\`.
+          EOF
+          )"
+          else
+            echo "Auto-merge is not armed on #${pr}; nothing to disable. The auto_merge_enabled trigger will re-check when it is."
+          fi

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -68,19 +68,76 @@ jobs:
           # back by head-branch prefix rather than from the event payload keeps
           # both triggers on one code path, and means a `push` run that finds an
           # armed PR behaves identically to the arm-time run.
-          pr=$(gh pr list --repo "${REPO}" --state open --json number,headRefName \
-                 --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
-          if [ -z "${pr}" ]; then
+          #
+          # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
+          # NAME is attacker-chosen, `gh pr list` includes fork PRs, and it
+          # orders newest-first -- so anyone could open a fork PR from a branch
+          # called `release-please--branches--main` and become the `[0]` this
+          # picks. The run would then read `armed` off the DECOY, get `no`, and
+          # exit 0 saying "not armed" while the real, armed, stale release PR
+          # went unchecked and merged. Pushing a branch to THIS repo needs write
+          # access, so restricting to same-repo PRs removes that reach entirely.
+          #
+          # Deliberately NOT also matched on author: release-please's PRs are
+          # authored by `app/github-actions` today, but switching it to a PAT or
+          # a GitHub App changes that silently, and the guard would go inert with
+          # nothing saying so -- the same failure mode the `if:` conditions in
+          # ci.yml were repeatedly wrong about.
+          prs=$(gh pr list --repo "${REPO}" --state open \
+                  --json number,headRefName,isCrossRepository \
+                  --jq '.[] | select(.isCrossRepository | not)
+                            | select(.headRefName | startswith("release-please--"))
+                            | .number')
+          if [ -z "${prs}" ]; then
             echo "No standing release PR. Nothing to check."
             exit 0
           fi
+          # More than one is an anomaly, not a case to guess at: picking one
+          # would leave the other unchecked and still exit 0.
+          count=$(printf '%s\n' "${prs}" | wc -l | tr -d ' ')
+          if [ "${count}" != "1" ]; then
+            echo "::error::found ${count} open same-repo release PRs ($(printf '%s' "${prs}" | tr '\n' ' ')). Refusing to guess which one auto-merge is armed on — close the extras."
+            exit 1
+          fi
+          pr="${prs}"
 
           armed=$(gh pr view "${pr}" --repo "${REPO}" --json autoMergeRequest \
                     --jq 'if .autoMergeRequest == null then "no" else "yes" end')
-          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          git fetch --no-tags --quiet origin "${head_ref}"
-          head=$(git rev-parse FETCH_HEAD)
+          # Anything other than the two known answers FAILS CLOSED. A bare
+          # `[ "${armed}" = "yes" ]` sends every other value down the no-op
+          # branch and exits 0, which is indistinguishable from a genuinely
+          # unarmed PR -- so a `gh` that exits 0 with empty stdout, or one whose
+          # schema drops `autoMergeRequest`, would silently retire this check.
+          case "${armed}" in
+            yes | no) ;;
+            *)
+              echo "::error::could not read auto-merge state for #${pr} (got '${armed}'). Refusing to treat an unreadable answer as 'not armed'."
+              exit 1
+              ;;
+          esac
 
+          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          # `fetch-depth: 0` on the checkout already populated
+          # `refs/remotes/origin/*`, so the branch is normally local already.
+          # The fetch is the fallback for a ref created after the checkout, and
+          # it runs ANONYMOUSLY because `persist-credentials: false` strips the
+          # token -- fine for this public repo, and the reason a failure here is
+          # reported rather than swallowed by `--quiet`. The likeliest cause is
+          # the head branch having been deleted between the two calls.
+          if ! head=$(git rev-parse --verify --quiet "refs/remotes/origin/${head_ref}"); then
+            if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+              echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+              exit 1
+            fi
+            head=$(git rev-parse FETCH_HEAD)
+          fi
+
+          # CLAUDE.md names THREE release-please-owned files; `package.json` is
+          # deliberately not one of them here. Ordinary `chore(deps)` PRs touch
+          # it constantly, so main's tip for it moves far more often than a
+          # release PR is rebuilt -- every release PR would read as stale. And
+          # release-please's own diff there is the `version` line alone, which a
+          # three-way merge cannot use to revert a dependency line.
           stale=""
           for f in CHANGELOG.md .release-please-manifest.json; do
             tip=$(git rev-list -1 HEAD -- "${f}")
@@ -104,12 +161,23 @@ jobs:
 
           echo "::warning::Release PR #${pr} is stale: ${stale}"
 
-          # Disarming is the only ACTION available, so a PR that is not armed
-          # gets a comment and nothing else -- and gets it once, because a
-          # repeat comment on every push to main would bury the signal. The
-          # arm-time trigger is what catches it later.
+          # Disarming is the only ACTION available, so an UNARMED stale PR gets
+          # nothing but a run-log line: there is no auto-merge to remove, and a
+          # comment repeated on every push to main would bury the signal. The
+          # `auto_merge_enabled` trigger is what catches it the moment arming
+          # makes it actionable.
           if [ "${armed}" = "yes" ]; then
-            gh pr merge "${pr}" --repo "${REPO}" --disable-auto
+            # Guarded because this races the very thing it polices: auto-merge
+            # can fire, or a human can disarm, between the read above and here.
+            # Unguarded, `set -e` would abort with gh's raw error BEFORE the
+            # comment below explains what happened.
+            if ! gh pr merge "${pr}" --repo "${REPO}" --disable-auto; then
+              echo "::error::could not disable auto-merge on #${pr} — it may already have merged, or been disarmed since this run started."
+              exit 1
+            fi
+            # The heredoc body sits at COLUMN 0 on purpose: YAML dedents the
+            # block scalar before bash sees it, so re-indenting these lines to
+            # match the `if` turns the terminator into a syntax error.
             gh pr comment "${pr}" --repo "${REPO}" --body "$(cat <<EOF
           Auto-merge has been **disabled** on this pull request: \`main\` has moved past it.
 

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -304,6 +304,11 @@ gates:
       # workflows above -- a checker INPUT outside this scope is a marker that
       # reads fresh while the thing it certifies has changed.
       - ".github/workflows/docs-deploy.yml"
+      # release-pr-staleness.test.ts EXECUTES this workflow's shell against real
+      # git repositories, so the suite's verdict is about this file's contents.
+      # Same reason as the workflows above: a checker INPUT outside this scope
+      # is a marker that reads fresh while the thing it certifies has changed.
+      - ".github/workflows/release-pr-staleness.yml"
       # release-please-v0.test.ts reads all three: the config's
       # bump-minor-pre-major, the manifest's 0.x version, and the release
       # workflow's publish-job guard (the two layers that keep an accidental

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -105,7 +105,11 @@ function commit(repo: string, file: string, body: string, subject: string): stri
 interface Run {
   status: number;
   output: string;
-  /** Every `gh` invocation the shell made, one per line, args space-joined. */
+  /**
+   * Every `gh` invocation's argv, space-joined. NOT one line per call — the
+   * multi-line `--body` puts a call's own newlines in here too, so these are
+   * safe to search with `.some(c => c.includes(...))` and unsafe to COUNT.
+   */
   ghCalls: string[];
 }
 
@@ -135,7 +139,19 @@ describe('release-pr-staleness', () => {
     lastFile?: string;
     seedManifest?: boolean;
     noReleasePr?: boolean;
-  }): { cwd: string; ghLog: string; tip: string } {
+    /**
+     * Open PRs the stub reports, BEFORE the workflow's jq filter. Supplying
+     * this is what lets a case exercise the filter itself — a fork decoy whose
+     * head branch carries the release prefix, or two same-repo matches.
+     */
+    openPrs?: { number: number; headRefName: string; isCrossRepository: boolean }[];
+    /**
+     * Raw stdout for the `autoMergeRequest` read, overriding `armed`. Lets a
+     * case drive the answer the shell must FAIL CLOSED on — an empty string is
+     * what a `gh` that exits 0 without the field would produce.
+     */
+    armedAnswer?: string;
+  }): { cwd: string; ghLog: string; tip: string; binDir: string } {
     const id = `f${seq++}`;
     const origin = join(scratch, `${id}-origin`);
     mkdirSync(origin);
@@ -175,17 +191,30 @@ describe('release-pr-staleness', () => {
     const binDir = join(scratch, `${id}-bin`);
     mkdirSync(binDir);
     const ghLog = join(scratch, `${id}-gh.log`);
-    // The stub emulates `--jq`, because the production shell reads the FILTERED
-    // value: `gh pr list --jq '[...][0].number // empty'` yields a bare number
-    // or nothing, never the array. Returning raw JSON here made `$pr` the whole
-    // document and every downstream call nonsense — a stub more permissive than
-    // real `gh` is how a suite certifies a check that cannot work.
-    const prNumber = opts.noReleasePr ? '' : '42';
+    // `pr list` runs the WORKFLOW'S OWN `--jq` expression through real `jq`
+    // against a canned PR list, rather than returning a canned answer. The
+    // filter is the thing under test — restricting to same-repo PRs is what
+    // stops a fork decoy named `release-please--…` becoming the `[0]` this
+    // picks — and a stub that answered `42` regardless would certify a filter
+    // that had been deleted. (An earlier cut returned the raw JSON array,
+    // ignoring `--jq` altogether; that is the same class one step further out.)
+    const openPrs =
+      opts.openPrs ??
+      (opts.noReleasePr
+        ? [{ number: 9, headRefName: 'feat/unrelated', isCrossRepository: false }]
+        : [{ number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false }]);
     const ghStub = `#!/usr/bin/env bash
 echo "$*" >> ${JSON.stringify(ghLog)}
+# Pull the --jq expression out of argv the way real gh consumes it.
+filter=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--jq" ]; then filter="$a"; fi
+  prev="$a"
+done
 case "$*" in
-  *"pr list"*)        printf '%s' ${JSON.stringify(prNumber)} ;;
-  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armed ? 'yes' : 'no')} ;;
+  *"pr list"*)        printf '%s' ${JSON.stringify(JSON.stringify(openPrs))} | jq -r "$filter" ;;
+  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
   *)                  : ;;
 esac
@@ -194,13 +223,11 @@ esac
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
 
-    return { cwd, ghLog, tip };
+    return { cwd, ghLog, tip, binDir };
   }
 
   function run(fx: ReturnType<typeof fixture>): Run {
-    const binDir = dirname(join(fx.ghLog, '..')); // unused placeholder, see below
-    void binDir;
-    const stubDir = fx.ghLog.replace(/-gh\.log$/, '-bin');
+    const stubDir = fx.binDir;
     let status = 0;
     let output = '';
     try {
@@ -232,6 +259,22 @@ esac
 
   const disarmed = (r: Run) => r.ghCalls.some((c) => c.includes('--disable-auto'));
   const commented = (r: Run) => r.ghCalls.some((c) => c.includes('pr comment'));
+
+  /**
+   * PR numbers the shell actually addressed — the argv token right after a
+   * `pr view` / `pr merge` / `pr comment` verb.
+   *
+   * NOT a substring search over `ghCalls`. The comment's `--body` embeds commit
+   * SHAs, so `c.includes('99')` is satisfied by any run whose fixture happened
+   * to produce a SHA containing those digits — which passes in isolation and
+   * fails under the full suite, since the SHAs differ with the commit
+   * timestamps. Measured exactly that way.
+   */
+  const targetedPrs = (r: Run): string[] =>
+    r.ghCalls.flatMap((c) => {
+      const m = /^pr (?:view|merge|comment) (\d+)\b/.exec(c);
+      return m ? [m[1] as string] : [];
+    });
 
   it('leaves a current release PR alone', () => {
     const r = run(fixture({ stale: false, armed: true }));
@@ -278,6 +321,60 @@ esac
     expect(disarmed(r)).toBe(false);
   });
 
+  it('ignores a FORK PR whose head branch carries the release prefix', () => {
+    // `gh pr list` includes fork PRs and orders newest-first, and a fork's head
+    // branch NAME is attacker-chosen. Without the same-repo filter, a decoy
+    // named `release-please--branches--main` becomes the `[0]` the shell picks:
+    // `armed` is then read off the DECOY (not armed), the run exits 0 saying
+    // "not armed", and the real armed, stale release PR is never checked and
+    // merges. Pushing a branch to THIS repo needs write access, which is what
+    // the filter buys.
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [
+        // Newest first, as gh returns them.
+        { number: 99, headRefName: RELEASE_BRANCH, isCrossRepository: true },
+        { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+      ],
+    });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    // The real PR is the one acted on — not the decoy.
+    expect(disarmed(r)).toBe(true);
+    expect(targetedPrs(r)).toContain('42');
+    expect(targetedPrs(r)).not.toContain('99');
+  });
+
+  it('refuses rather than guessing when two same-repo release PRs are open', () => {
+    // Picking one would leave the other unchecked and still exit 0 — the
+    // silent-pass shape this whole workflow exists to remove.
+    const r = run(
+      fixture({
+        stale: true,
+        armed: true,
+        openPrs: [
+          { number: 43, headRefName: `${RELEASE_BRANCH}--components--x`, isCrossRepository: false },
+          { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+        ],
+      })
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('found 2 open same-repo release PRs');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when the auto-merge state cannot be read', () => {
+    // A `gh` that exits 0 with empty stdout — a schema change dropping
+    // `autoMergeRequest`, or a build without the field — used to fall through
+    // to the no-op branch and exit 0, which is indistinguishable from a
+    // genuinely unarmed PR. That retires the whole check silently.
+    const r = run(fixture({ stale: true, armed: true, armedAnswer: '' }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not read auto-merge state');
+    expect(disarmed(r)).toBe(false);
+  });
+
   it('fails closed when an owned file has no history on main', () => {
     // "Cannot answer" must not read as "found nothing wrong": a rename would
     // otherwise silence this check forever, and it is the last line of defence.
@@ -312,7 +409,12 @@ esac
       // and this workflow must never execute head-controlled content.
       expect(yml()).toContain('fetch-depth: 0');
       expect(yml()).toContain('persist-credentials: false');
-      expect(yml()).not.toContain('github.event.pull_request.head.sha');
+      // The realistic regression on a `pull_request_target` workflow is not the
+      // one exact expression — it is ANY head reference reaching the checkout
+      // or a shell, `github.head_ref` and `…head.ref` included. The PR number
+      // and head ref are read back through `gh` precisely so none of them
+      // appears here.
+      expect(yml()).not.toMatch(/github\.(event\.pull_request\.head|head_ref)/);
     });
 
     it('checks exactly the files release-please owns', () => {

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -144,7 +144,7 @@ describe('release-pr-staleness', () => {
      * this is what lets a case exercise the filter itself — a fork decoy whose
      * head branch carries the release prefix, or two same-repo matches.
      */
-    openPrs?: { number: number; headRefName: string; isCrossRepository: boolean }[];
+    openPrs?: { number: number; headRef: string; fork: boolean }[];
     /**
      * Raw stdout for the `autoMergeRequest` read, overriding `armed`. Lets a
      * case drive the answer the shell must FAIL CLOSED on — an empty string is
@@ -191,7 +191,7 @@ describe('release-pr-staleness', () => {
     const binDir = join(scratch, `${id}-bin`);
     mkdirSync(binDir);
     const ghLog = join(scratch, `${id}-gh.log`);
-    // `pr list` runs the WORKFLOW'S OWN `--jq` expression through real `jq`
+    // The PR lookup runs the WORKFLOW'S OWN `--jq` expression through real `jq`
     // against a canned PR list, rather than returning a canned answer. The
     // filter is the thing under test — restricting to same-repo PRs is what
     // stops a fork decoy named `release-please--…` becoming the `[0]` this
@@ -201,8 +201,23 @@ describe('release-pr-staleness', () => {
     const openPrs =
       opts.openPrs ??
       (opts.noReleasePr
-        ? [{ number: 9, headRefName: 'feat/unrelated', isCrossRepository: false }]
-        : [{ number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false }]);
+        ? [{ number: 9, headRef: 'feat/unrelated', fork: false }]
+        : [{ number: 42, headRef: RELEASE_BRANCH, fork: false }]);
+    // REST shape, because the shell now reads `gh api .../pulls` rather than
+    // `gh pr list` — the latter caps at `--limit 30` and filters that one page
+    // client-side, so ~30 fork PRs evict the release PR and the run exits 0.
+    const restPrs = openPrs.map((o) => ({
+      number: o.number,
+      head: { ref: o.headRef, repo: o.fork ? { full_name: 'attacker/cdkd' } : { full_name: 'go-to-k/cdkd' } },
+      base: { repo: { full_name: 'go-to-k/cdkd' } },
+    }));
+    // The stub ALSO answers the old `gh pr list` shape, truncated to 30 the
+    // way real gh does. That is what makes the eviction probe faithful:
+    // reverting the workflow to `gh pr list` reds the 40-fork case because the
+    // release PR falls off the page, not because the stub stopped matching.
+    const ghListPrs = openPrs
+      .slice(0, 30)
+      .map((o) => ({ number: o.number, headRefName: o.headRef, isCrossRepository: o.fork }));
     const ghStub = `#!/usr/bin/env bash
 echo "$*" >> ${JSON.stringify(ghLog)}
 # Pull the --jq expression out of argv the way real gh consumes it.
@@ -213,7 +228,8 @@ for a in "$@"; do
   prev="$a"
 done
 case "$*" in
-  *"pr list"*)        printf '%s' ${JSON.stringify(JSON.stringify(openPrs))} | jq -r "$filter" ;;
+  *"api repos/"*pulls*) printf '%s' ${JSON.stringify(JSON.stringify(restPrs))} | jq -r "$filter" ;;
+  *"pr list"*)          printf '%s' ${JSON.stringify(JSON.stringify(ghListPrs))} | jq -r "$filter" ;;
   *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
   *)                  : ;;
@@ -334,8 +350,8 @@ esac
       armed: true,
       openPrs: [
         // Newest first, as gh returns them.
-        { number: 99, headRefName: RELEASE_BRANCH, isCrossRepository: true },
-        { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+        { number: 99, headRef: RELEASE_BRANCH, fork: true },
+        { number: 42, headRef: RELEASE_BRANCH, fork: false },
       ],
     });
     const r = run(fx);
@@ -346,6 +362,31 @@ esac
     expect(targetedPrs(r)).not.toContain('99');
   });
 
+  it('still finds the release PR behind 40 unrelated fork PRs', () => {
+    // `gh pr list` defaults to `--limit 30` and applies `--jq` CLIENT-SIDE to
+    // that one page. So ~30 fork PRs — attacker-chosen, no privilege — evict
+    // the release PR from the page, the filter returns nothing, and the run
+    // exits 0 reporting "no standing release PR" while the real armed stale PR
+    // merges. Same suppression as the decoy above, reached by TRUNCATION
+    // instead of ordering, and it fires benignly on a dependabot burst too.
+    // The shell uses `gh api --paginate` for exactly this reason.
+    const noise = Array.from({ length: 40 }, (_, i) => ({
+      number: 1000 + i,
+      headRef: `feat/noise-${i}`,
+      fork: true,
+    }));
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [...noise, { number: 42, headRef: RELEASE_BRANCH, fork: false }],
+    });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    expect(r.output).not.toContain('No standing release PR');
+    expect(disarmed(r)).toBe(true);
+    expect(targetedPrs(r)).toContain('42');
+  });
+
   it('refuses rather than guessing when two same-repo release PRs are open', () => {
     // Picking one would leave the other unchecked and still exit 0 — the
     // silent-pass shape this whole workflow exists to remove.
@@ -354,8 +395,8 @@ esac
         stale: true,
         armed: true,
         openPrs: [
-          { number: 43, headRefName: `${RELEASE_BRANCH}--components--x`, isCrossRepository: false },
-          { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+          { number: 43, headRef: `${RELEASE_BRANCH}--components--x`, fork: false },
+          { number: 42, headRef: RELEASE_BRANCH, fork: false },
         ],
       })
     );

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -1,0 +1,326 @@
+import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * `.github/workflows/release-pr-staleness.yml` — the check that disarms
+ * auto-merge on a standing release PR that `main` has moved past.
+ *
+ * Why it exists rather than the `release-pr-not-stale` job in ci.yml doing the
+ * whole job: a `pull_request` workflow does NOT re-run when the BASE branch
+ * moves, so that job keeps whatever verdict it reached at the release PR's last
+ * head push — and the hazard is precisely the case where release-please never
+ * pushes again (a `chore:` commit produces no changelog entry, so the computed
+ * release is unchanged and the PR is left on its original base).
+ *
+ * Why this suite EXECUTES the workflow's shell against real git repositories
+ * and a stubbed `gh`: the whole check is six git/gh invocations, each of which
+ * rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
+ * invert the `armed` test — and it stops disarming anything while still exiting
+ * 0 on every run, which is indistinguishable from "nothing was stale". A suite
+ * that pattern-matched the YAML would certify that state.
+ *
+ * The four cases below are the whole decision table:
+ *
+ *   current + armed        -> leave alone
+ *   stale   + armed        -> disable auto-merge, comment once
+ *   stale   + NOT armed    -> no disable, no comment (nothing to disarm; the
+ *                             auto_merge_enabled trigger catches it later)
+ *   owned file has no history on main -> FAIL CLOSED, never a silent pass
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const WORKFLOW = join(repoRoot, '.github', 'workflows', 'release-pr-staleness.yml');
+
+const CHANGELOG = 'CHANGELOG.md';
+const MANIFEST = '.release-please-manifest.json';
+const RELEASE_BRANCH = 'release-please--branches--main';
+
+const DISARM_STEP = 'disarm auto-merge on a release PR main has moved past';
+
+interface StalenessWorkflow {
+  on?: Record<string, { types?: unknown; branches?: unknown } | null>;
+  jobs?: Record<
+    string,
+    {
+      permissions?: unknown;
+      steps?: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+    }
+  >;
+}
+
+function workflow(): StalenessWorkflow {
+  return parseYaml(readFileSync(WORKFLOW, 'utf8')) as StalenessWorkflow;
+}
+
+/**
+ * The `run:` body of the workflow's disarm step, taken from the file rather
+ * than re-typed — a copy here would keep passing after the workflow's copy was
+ * broken. Selected BY STEP NAME, so inserting a step ahead of it cannot
+ * silently retarget the extractor.
+ *
+ * (The sibling repos read this as TEXT because they ship no YAML library, the
+ * reason `release-please-v0.test.ts` records there. cdkd has `yaml`, and its
+ * two other workflow fences already parse, so this one does too.)
+ */
+function disarmShell(): string {
+  const step = workflow().jobs?.['disarm']?.steps?.find((s) => s.name === DISARM_STEP);
+  expect(
+    step?.run,
+    `the \`${DISARM_STEP}\` step is gone from .github/workflows/release-pr-staleness.yml. ` +
+      'If it was renamed, update this extractor; if it was REMOVED, restore it — a stale ' +
+      'release PR could then auto-merge with nothing objecting.'
+  ).toBeTruthy();
+  return step?.run as string;
+}
+
+const GIT_ENV = {
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 't',
+  GIT_AUTHOR_EMAIL: 't@example.invalid',
+  GIT_COMMITTER_NAME: 't',
+  GIT_COMMITTER_EMAIL: 't@example.invalid',
+};
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function commit(repo: string, file: string, body: string, subject: string): string {
+  writeFileSync(join(repo, file), body);
+  git(repo, 'add', file);
+  git(repo, 'commit', '-q', '-m', subject);
+  return git(repo, 'rev-parse', 'HEAD');
+}
+
+interface Run {
+  status: number;
+  output: string;
+  /** Every `gh` invocation the shell made, one per line, args space-joined. */
+  ghCalls: string[];
+}
+
+describe('release-pr-staleness', () => {
+  let scratch: string;
+  let seq = 0;
+
+  afterAll(() => {
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cdkd-staleness-'));
+  });
+
+  /**
+   * A repo whose `main` ends in a commit touching only `lastFile` and whose
+   * release branch was cut BEFORE it (`stale: true`) or at the tip
+   * (`stale: false`). Returns the working clone the shell runs in.
+   *
+   * `seedManifest: false` builds a history where the manifest never existed, so
+   * the empty-tip branch is reached with the CHANGELOG arm able to pass.
+   */
+  function fixture(opts: {
+    stale: boolean;
+    armed: boolean;
+    lastFile?: string;
+    seedManifest?: boolean;
+    noReleasePr?: boolean;
+  }): { cwd: string; ghLog: string; tip: string } {
+    const id = `f${seq++}`;
+    const origin = join(scratch, `${id}-origin`);
+    mkdirSync(origin);
+    git(origin, 'init', '-q', '-b', 'main');
+    writeFileSync(join(origin, CHANGELOG), '# Changelog\n\n## 0.1.0\n');
+    if (opts.seedManifest !== false) {
+      writeFileSync(join(origin, MANIFEST), '{ ".": "0.1.0" }\n');
+    }
+    git(origin, 'add', '.');
+    git(origin, 'commit', '-q', '-m', 'chore(release): 0.1.0');
+    const base = commit(origin, 'src.txt', 'work\n', 'feat: something');
+
+    // The release branch, cut from `base` when stale and from the tip when not.
+    // Its own commit touches a file release-please does NOT own, so the branch
+    // is never an ancestor of main in either case — only the owned-file tips
+    // decide, which is the property under test.
+    const lastFile = opts.lastFile ?? CHANGELOG;
+    const tip =
+      lastFile === CHANGELOG
+        ? commit(origin, CHANGELOG, '# Changelog\n\n## 0.1.0 (normalized)\n', 'chore(docs): normalize')
+        : commit(origin, MANIFEST, '{ ".": "0.1.0-edited" }\n', 'chore: hand-edit the manifest');
+
+    git(origin, 'checkout', '-q', '-b', RELEASE_BRANCH, opts.stale ? base : tip);
+    commit(origin, 'RELEASE_NOTE.txt', 'release-please\n', 'chore(release): 0.1.1');
+    git(origin, 'checkout', '-q', 'main');
+
+    const bare = join(scratch, `${id}-remote.git`);
+    execFileSync('git', ['clone', '-q', '--bare', origin, bare], {
+      env: { ...process.env, ...GIT_ENV },
+    });
+    const cwd = join(scratch, `${id}-work`);
+    execFileSync('git', ['clone', '-q', bare, cwd], { env: { ...process.env, ...GIT_ENV } });
+
+    // `gh` stub: canned reads, recorded writes. Writing the log from the stub
+    // (rather than inferring from stdout) is what lets a case assert that
+    // `pr merge --disable-auto` was NOT called.
+    const binDir = join(scratch, `${id}-bin`);
+    mkdirSync(binDir);
+    const ghLog = join(scratch, `${id}-gh.log`);
+    // The stub emulates `--jq`, because the production shell reads the FILTERED
+    // value: `gh pr list --jq '[...][0].number // empty'` yields a bare number
+    // or nothing, never the array. Returning raw JSON here made `$pr` the whole
+    // document and every downstream call nonsense — a stub more permissive than
+    // real `gh` is how a suite certifies a check that cannot work.
+    const prNumber = opts.noReleasePr ? '' : '42';
+    const ghStub = `#!/usr/bin/env bash
+echo "$*" >> ${JSON.stringify(ghLog)}
+case "$*" in
+  *"pr list"*)        printf '%s' ${JSON.stringify(prNumber)} ;;
+  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armed ? 'yes' : 'no')} ;;
+  *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *)                  : ;;
+esac
+`;
+    const ghPath = join(binDir, 'gh');
+    writeFileSync(ghPath, ghStub);
+    chmodSync(ghPath, 0o755);
+
+    return { cwd, ghLog, tip };
+  }
+
+  function run(fx: ReturnType<typeof fixture>): Run {
+    const binDir = dirname(join(fx.ghLog, '..')); // unused placeholder, see below
+    void binDir;
+    const stubDir = fx.ghLog.replace(/-gh\.log$/, '-bin');
+    let status = 0;
+    let output = '';
+    try {
+      output = execFileSync('bash', ['-c', disarmShell()], {
+        cwd: fx.cwd,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...GIT_ENV,
+          PATH: `${stubDir}:${process.env['PATH'] ?? ''}`,
+          GH_TOKEN: 'x',
+          REPO: 'go-to-k/cdkd',
+        },
+        stdio: 'pipe',
+      });
+    } catch (error) {
+      const e = error as { status?: number; stdout?: string; stderr?: string };
+      status = e.status ?? 1;
+      output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+    let ghCalls: string[] = [];
+    try {
+      ghCalls = readFileSync(fx.ghLog, 'utf8').split('\n').filter(Boolean);
+    } catch {
+      ghCalls = [];
+    }
+    return { status, output, ghCalls };
+  }
+
+  const disarmed = (r: Run) => r.ghCalls.some((c) => c.includes('--disable-auto'));
+  const commented = (r: Run) => r.ghCalls.some((c) => c.includes('pr comment'));
+
+  it('leaves a current release PR alone', () => {
+    const r = run(fixture({ stale: false, armed: true }));
+    expect(r.status).toBe(0);
+    expect(r.output).toContain('is current with main');
+    expect(disarmed(r)).toBe(false);
+    expect(commented(r)).toBe(false);
+  });
+
+  it('disarms and comments when main moved CHANGELOG.md past an armed PR', () => {
+    const fx = fixture({ stale: true, armed: true });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    expect(disarmed(r)).toBe(true);
+    expect(commented(r)).toBe(true);
+    expect(r.output).toContain(CHANGELOG);
+    expect(r.output).toContain(fx.tip);
+  });
+
+  it('disarms when main moved the MANIFEST past an armed PR', () => {
+    // Without this, gating the ancestry test on `[ "${f}" = "CHANGELOG.md" ]`
+    // survives the suite and the manifest arm never discriminates.
+    const fx = fixture({ stale: true, armed: true, lastFile: MANIFEST });
+    const r = run(fx);
+    expect(disarmed(r)).toBe(true);
+    expect(r.output).toContain(MANIFEST);
+    expect(r.output).not.toContain(`${CHANGELOG} (main:`);
+  });
+
+  it('does not comment on a stale PR that is not armed', () => {
+    // There is nothing to disarm, and a comment on every push to main would
+    // bury the signal. The auto_merge_enabled trigger catches it later.
+    const r = run(fixture({ stale: true, armed: false }));
+    expect(r.status).toBe(0);
+    expect(disarmed(r)).toBe(false);
+    expect(commented(r)).toBe(false);
+    expect(r.output).toContain('not armed');
+  });
+
+  it('does nothing when no release PR is open', () => {
+    const r = run(fixture({ stale: true, armed: true, noReleasePr: true }));
+    expect(r.status).toBe(0);
+    expect(r.output).toContain('No standing release PR');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when an owned file has no history on main', () => {
+    // "Cannot answer" must not read as "found nothing wrong": a rename would
+    // otherwise silence this check forever, and it is the last line of defence.
+    const r = run(fixture({ stale: false, armed: true, seedManifest: false }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('cannot evaluate staleness');
+    expect(r.output).toContain(MANIFEST);
+    expect(disarmed(r)).toBe(false);
+  });
+
+  describe('the workflow wiring', () => {
+    const yml = () => readFileSync(WORKFLOW, 'utf8');
+
+    it('fires both when main moves and when auto-merge is armed', () => {
+      // Neither trigger alone is enough. `push` misses a PR armed AFTER main
+      // moved — the common case, since a release PR can sit for days — and
+      // `auto_merge_enabled` misses main moving under an already-armed PR.
+      expect(yml()).toContain('types: [auto_merge_enabled]');
+      expect(yml()).toMatch(/push:\s*\n\s*branches: \[main\]/);
+    });
+
+    it('can actually disarm', () => {
+      // `gh pr merge --disable-auto` needs pull-requests: write, and a
+      // `pull_request` token is read-only for forks — which is why the trigger
+      // is `pull_request_target`.
+      expect(yml()).toContain('pull_request_target:');
+      expect(yml()).toContain('pull-requests: write');
+    });
+
+    it('checks out full history and no head code', () => {
+      // `rev-list -1 <ref> -- <path>` needs the commits that touched each file;
+      // and this workflow must never execute head-controlled content.
+      expect(yml()).toContain('fetch-depth: 0');
+      expect(yml()).toContain('persist-credentials: false');
+      expect(yml()).not.toContain('github.event.pull_request.head.sha');
+    });
+
+    it('checks exactly the files release-please owns', () => {
+      const m = /^for f in (.+); do$/m.exec(disarmShell());
+      expect(m, "the check's `for f in ...; do` loop is gone").not.toBeNull();
+      expect((m as RegExpExecArray)[1]!.trim().split(/\s+/).sort()).toEqual(
+        [CHANGELOG, MANIFEST].sort()
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes the residual go-to-k/cdkd#2999 named in its own body and commit message.
The sibling repos already carry this workflow; cdkd was split out so that PR
could merge on the review it had.

## The gap

`release-pr-not-stale` (added in go-to-k/cdkd#2999) is the right check in the
wrong place. **A `pull_request` workflow does not re-run when the BASE branch
moves** — its default activity types are all head-side — so the release PR keeps
whatever verdict it reached at its last head push. And the hazard is *precisely*
the case where release-please never pushes again:

1. release PR is open and green
2. a `chore:` commit touching `CHANGELOG.md` lands on `main`
3. it produces no changelog entry, so the computed release is unchanged,
   release-please logs `PR #N remained the same`, and pushes nothing
4. no push means no new run, so the check stays green from step 1
5. auto-merge fires and reverts step 2

Step 4 is where the in-PR job was meant to help and cannot. It still earns its
keep for the ordinary case, where a `feat:` / `fix:` lands and release-please
rebuilds.

That is go-to-k/cdkd#2503's shape, and it is not hypothetical in this repo.

## Two triggers, because neither alone is enough

| trigger | catches |
| --- | --- |
| `push` to `main` | main moves while auto-merge is **already** armed |
| `pull_request_target: [auto_merge_enabled]` | auto-merge is armed on a PR main moved past **earlier** |

The second is the common one and the easy one to miss: a release PR sits for
days, a `chore:` commit lands, and the maintainer later arms auto-merge on a PR
that is green from an old run. It merges immediately, and a push-only check
never runs at that moment.

`pull_request_target` rather than `pull_request` because disarming needs
`pull-requests: write` and a `pull_request` token is read-only for forks. It runs
only base-controlled code — `gh` and `git` against refs — and never checks out or
executes head content.

Disarming is the only *action* available, so a PR that is not armed gets nothing
rather than a comment repeated on every push to `main`.

## Tests

`tests/unit/scripts/release-pr-staleness.test.ts` **executes** the workflow's
shell against real git repositories and a stubbed `gh`, covering the whole
decision table:

| state | expected |
| --- | --- |
| current + armed | leave alone |
| stale (`CHANGELOG.md`) + armed | disable auto-merge, comment |
| stale (manifest) + armed | disable auto-merge |
| stale + **not** armed | no disable, no comment |
| no release PR open | no-op |
| owned file with no history on `main` | **fail closed** |

Each owned file gets its own fixture whose last commit touches only that file,
so `CHANGELOG.md` and the manifest each discriminate alone.

Probes:

| mutation | red |
| --- | --- |
| gate the ancestry test on the filename | the manifest case only |
| invert the `armed` test | the three disarm cases |

## Two deliberate differences from the sibling copies

- The shell is extracted through **`yaml`** rather than by slicing text. The
  siblings ship no YAML library and say so in their own comments; cdkd has one,
  and its two other workflow fences already parse.
- **`.markgate.yml` gains the workflow in the `check` gate.** The suite's verdict
  is about this file's *contents*, and a checker input outside that scope is a
  marker that reads fresh while the thing it certifies has changed —
  `check-scope-checker-inputs.test.ts` demands it the moment the suite reads the
  file.

No changelog entry: CI-only, no shipped-binary behavior delta.
