### PR TITLE
docs(readme): add the brand logo below the badges in the hero block

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@go-to-k/cdkd.svg" alt="License: Apache-2.0" />
   </a>
+  <p>
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-dark.svg">
+      <img alt="cdkd logo" src="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-light.svg" width="96" height="96">
+    </picture>
+  </p>
   <h3>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</h3>
   <p>
     📚 Documentation: <a href="https://cdkd.dev"><b>cdkd.dev</b></a>


### PR DESCRIPTION
## Summary

- Add the brand logo to the centered hero block, between the badge row and the tagline.
- Reuses the mark cdkd.dev already serves (`docs-site/public/brand/logo-light.svg` / `logo-dark.svg`) — no new asset files — wrapped in a `<picture>` so the dark variant is used under `prefers-color-scheme: dark`, sized 96x96.
- Referenced by `raw.githubusercontent.com` URL rather than a repo-relative path, matching the other images in this README, so the logo also renders on the npmjs.com package page.

## Test plan

- [x] Unit tests pass (991 files, 21818 tests)
- [x] `vp run check` / `vp run typecheck:test` / `vp run build` pass; `gen:all-matrices` + `format` produced no drift
- [x] Rendering verified against GitHub's own renderer (`gh api -X POST /markdown -f mode=gfm`): the block expands to `<themed-picture>` with both sources intact
- [x] Asset availability verified: `curl -I` on the raw URL returns `200` with `content-type: image/svg+xml`
- [ ] Integration test: not applicable — documentation-only change, no shipped-binary behavior delta (hence no `changelog.d` entry)
