### PR TITLE
test(docs): drop the redundant whole-tree scan that made one case flaky

### DIFF
--- a/tests/unit/scripts/docs-error-strings.test.ts
+++ b/tests/unit/scripts/docs-error-strings.test.ts
@@ -456,8 +456,19 @@ describe('docs error-string checker: the real tree', () => {
     expect(names.has('LockError')).toBe(true);
     expect(names.has('ProvisioningError')).toBe(true);
     // Subclasses declared outside error-handler.ts must be picked up too.
-    const all = analyze(ROOT);
-    expect(all.counts.errorNames).toBeGreaterThan(names.size);
+    //
+    // `report`, not a second `analyze(ROOT)`. The describe already scans the
+    // whole tree once, at collection time, and re-scanning it INSIDE a case
+    // put a whole-repo walk under vitest's 5 s in-process default — which
+    // passes on an idle machine and fails on a loaded one, i.e. it fails in
+    // the direction that reads as flakiness rather than as an under-declared
+    // bound (go-to-k/cdkd#2953: one failure under a full-suite run, green on
+    // an immediate re-run of the same tree, green in isolation).
+    //
+    // Declaring a timeout would have fixed the symptom; the scan itself was
+    // the redundancy. Do not reintroduce it — the shared `report` is the same
+    // call with the same argument.
+    expect(report.counts.errorNames).toBeGreaterThan(names.size);
   });
 
   it('requires a reason of real length on every allow-list entry', () => {


### PR DESCRIPTION
## Summary

One case in `docs-error-strings.test.ts` failed under a full-suite run, passed on an immediate re-run of the **same tree**, and passed in isolation — measured 2026-09-11 while verifying an unrelated branch (`1 failed | 21620 passed`, then `21621 passed` with nothing changed).

It called `analyze(ROOT)` — a whole-repo scan — inside the test body, under vitest's 5 s in-process default. That is the shape `.claude/rules/testing.md` already names: it passes on an idle machine and fails on a loaded one, so it reads as flakiness rather than as an under-declared bound.

## Not the fix the issue proposed

go-to-k/cdkd#2953 proposed declaring `180_000`, matching the eight siblings in this file that do. Reading the file instead showed the scan was **redundant**: the enclosing `describe` already runs `analyze(ROOT)` once at collection time and binds it to `report`, which is in scope for this case.

```diff
-    const all = analyze(ROOT);
-    expect(all.counts.errorNames).toBeGreaterThan(names.size);
+    expect(report.counts.errorNames).toBeGreaterThan(names.size);
```

So the work goes away rather than the bound going up: no arbitrary constant to justify, and the file runs in **10.9 s instead of 19.3 s**. A comment records why, so the scan is not reintroduced.

## Test plan

- `vp test run` — 991 files / 21839 tests green.
- The assertion still discriminates, and the test passing is itself the evidence: `report.counts.errorNames > names.size` compares the whole-tree scan against `deriveErrorNames([error-handler.ts])`. If `report` were not the broader set the comparison would fail, which is exactly what the case exists to check.

Closes go-to-k/cdkd#2953
