### PR TITLE
docs(readme): move the brand logo above the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <div align="center">
+  <p>
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-dark.svg">
+      <img alt="cdkd logo" src="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-light.svg" width="96" height="96">
+    </picture>
+  </p>
   <h1>cdkd (CDK Direct)</h1>
   <a href="https://www.npmjs.com/package/@go-to-k/cdkd">
     <img src="https://img.shields.io/npm/v/@go-to-k/cdkd.svg" alt="npm version" />
@@ -9,12 +15,6 @@
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@go-to-k/cdkd.svg" alt="License: Apache-2.0" />
   </a>
-  <p>
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-dark.svg">
-      <img alt="cdkd logo" src="https://raw.githubusercontent.com/go-to-k/cdkd/main/docs-site/public/brand/logo-light.svg" width="96" height="96">
-    </picture>
-  </p>
   <h3>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</h3>
   <p>
     📚 Documentation: <a href="https://cdkd.dev"><b>cdkd.dev</b></a>


### PR DESCRIPTION
## Summary

- Move the brand logo to the top of the centered hero block, directly above the `<h1>`, so the mark and the project name read as one unit and the badge row sits below them as metadata.
- Follow-up to go-to-k/cdkd#3021, which placed the logo between the badges and the tagline — a position where it belonged to neither.
- Markup is otherwise unchanged: same `<picture>` element, same `logo-light.svg` / `logo-dark.svg` sources, same 96x96 size. Final order is logo → title → badges → tagline → documentation link → rule.

## Test plan

- [x] Unit tests pass (991 files, 21839 tests)
- [x] `vp run check` / `vp run typecheck:test` / `vp run build` pass; `gen:all-matrices` + `format` produced no drift
- [x] Rendering verified against GitHub's own renderer (`gh api -X POST /markdown -f mode=gfm`): the logo expands to `<themed-picture>` as the first child of the centered div, with the `<h1>` following it
- [ ] Integration test: not applicable — documentation-only change, no shipped-binary behavior delta (hence no `changelog.d` entry)
