### PR TITLE
ci: correct the rationale, always fetch the head, and cover both error paths

### DIFF
--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -69,13 +69,20 @@ jobs:
           # both triggers on one code path, and means a `push` run that finds an
           # armed PR behaves identically to the arm-time run.
           #
-          # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
-          # NAME is attacker-chosen and open PRs include fork PRs -- so anyone
-          # could open one from a branch called `release-please--branches--main`
-          # and be picked here. The run would then read `armed` off the DECOY,
-          # get `no`, and exit 0 saying "not armed" while the real, armed, stale
-          # release PR went unchecked and merged. Pushing a branch to THIS repo
-          # needs write access, so the same-repo test removes that reach.
+          # SAME-REPO ONLY. A fork's head branch NAME is attacker-chosen and open
+          # PRs include fork PRs, so without this anyone could open one from a
+          # branch called `release-please--branches--main`. Pushing a branch to
+          # THIS repo needs write access, which is the boundary the test draws.
+          #
+          # What that buys, stated against the code as it stands rather than an
+          # earlier draft of it. The `count != 1` refusal below means a decoy
+          # ALONGSIDE the real release PR would exit 1, not pass silently -- so
+          # the two remaining reaches are:
+          #   * DoS. One fork PR wedges every run into that refusal, turning a
+          #     guard that should be quiet into a permanent red anyone can set.
+          #   * Acting on a fork PR. With no real release PR open, a lone decoy
+          #     is `count == 1`, and this job holds `pull-requests: write` -- it
+          #     would read, and could comment on and disarm, a fork's PR.
           #
           # A deleted fork leaves `head.repo` null, which `// ""` turns into a
           # non-match rather than a jq error -- correct, since it was a fork.
@@ -126,20 +133,23 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          # `fetch-depth: 0` on the checkout already populated
-          # `refs/remotes/origin/*`, so the branch is normally local already.
-          # The fetch is the fallback for a ref created after the checkout, and
-          # it runs ANONYMOUSLY because `persist-credentials: false` strips the
-          # token -- fine for this public repo, and the reason a failure here is
-          # reported rather than swallowed by `--quiet`. The likeliest cause is
-          # the head branch having been deleted between the two calls.
-          if ! head=$(git rev-parse --verify --quiet "refs/remotes/origin/${head_ref}"); then
-            if ! git fetch --no-tags --quiet origin "${head_ref}"; then
-              echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
-              exit 1
-            fi
-            head=$(git rev-parse FETCH_HEAD)
+          # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
+          # already populated. release-please FORCE-PUSHES the release branch
+          # when it rebuilds, so a rebuild landing between the checkout and this
+          # line would leave the cached ref pointing at the OLD head -- and the
+          # run would compare main's tips against it and disarm a PR that had
+          # just been made current. The window is seconds and the direction is
+          # conservative, but a fetch costs nothing and removes it.
+          #
+          # This runs ANONYMOUSLY: `persist-credentials: false` strips the
+          # token. Fine for a public repo, and the reason the failure is
+          # reported rather than swallowed by `--quiet` -- the likeliest cause
+          # is the head branch having been deleted between the two calls.
+          if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+            echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+            exit 1
           fi
+          head=$(git rev-parse FETCH_HEAD)
 
           # CLAUDE.md names THREE release-please-owned files; `package.json` is
           # deliberately not one of them here. Ordinary `chore(deps)` PRs touch

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -24,13 +24,19 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * 0 on every run, which is indistinguishable from "nothing was stale". A suite
  * that pattern-matched the YAML would certify that state.
  *
- * The four cases below are the whole decision table:
+ * The decision table:
  *
  *   current + armed        -> leave alone
  *   stale   + armed        -> disable auto-merge, comment once
  *   stale   + NOT armed    -> no disable, no comment (nothing to disarm; the
  *                             auto_merge_enabled trigger catches it later)
  *   owned file has no history on main -> FAIL CLOSED, never a silent pass
+ *
+ * plus the failure modes that are NOT in the table and were each a live defect
+ * found in review: a fork PR decoying the lookup, 30+ PRs evicting the real one
+ * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
+ * state, a head branch that cannot be read, and `--disable-auto` losing the
+ * race it polices.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -63,9 +69,9 @@ function workflow(): StalenessWorkflow {
  * broken. Selected BY STEP NAME, so inserting a step ahead of it cannot
  * silently retarget the extractor.
  *
- * (The sibling repos read this as TEXT because they ship no YAML library, the
- * reason `release-please-v0.test.ts` records there. cdkd has `yaml`, and its
- * two other workflow fences already parse, so this one does too.)
+ * (The sibling repos slice this out of the TEXT instead, so one review covers
+ * both of their copies. cdkd has `yaml` and its two other workflow fences
+ * already parse, so this one does too.)
  */
 function disarmShell(): string {
   const step = workflow().jobs?.['disarm']?.steps?.find((s) => s.name === DISARM_STEP);
@@ -122,6 +128,17 @@ describe('release-pr-staleness', () => {
   });
 
   beforeAll(() => {
+    // The `gh` stub pipes through real `jq` so the workflow's OWN `--jq`
+    // expression is what runs. Without jq the stub exits 127 and every case
+    // fails as "expected 1 to be 0" — name the cause instead. CI's
+    // ubuntu-latest ships it; a dev machine may not.
+    try {
+      execFileSync('jq', ['--version'], { stdio: 'ignore' });
+    } catch {
+      throw new Error(
+        'this suite needs `jq` on PATH: the gh stub runs the workflow\'s own --jq filter through it'
+      );
+    }
     scratch = mkdtempSync(join(tmpdir(), 'cdkd-staleness-'));
   });
 
@@ -139,6 +156,10 @@ describe('release-pr-staleness', () => {
     lastFile?: string;
     seedManifest?: boolean;
     noReleasePr?: boolean;
+    /** Make `gh pr merge --disable-auto` exit non-zero — it races auto-merge firing. */
+    disarmFails?: boolean;
+    /** Drop the release branch from the clone AND its remote, so the head cannot be read. */
+    headRefMissing?: boolean;
     /**
      * Open PRs the stub reports, BEFORE the workflow's jq filter. Supplying
      * this is what lets a case exercise the filter itself — a fork decoy whose
@@ -185,6 +206,14 @@ describe('release-pr-staleness', () => {
     const cwd = join(scratch, `${id}-work`);
     execFileSync('git', ['clone', '-q', bare, cwd], { env: { ...process.env, ...GIT_ENV } });
 
+    // Delete the release branch from the BARE remote, so the clone's fetch of
+    // it fails the way a deleted head branch really does. Deleting only the
+    // clone's own ref would leave the fetch succeeding.
+    if (opts.headRefMissing) {
+      git(bare, 'branch', '-D', RELEASE_BRANCH);
+      git(cwd, 'update-ref', '-d', `refs/remotes/origin/${RELEASE_BRANCH}`);
+    }
+
     // `gh` stub: canned reads, recorded writes. Writing the log from the stub
     // (rather than inferring from stdout) is what lets a case assert that
     // `pr merge --disable-auto` was NOT called.
@@ -211,6 +240,10 @@ describe('release-pr-staleness', () => {
       head: { ref: o.headRef, repo: o.fork ? { full_name: 'attacker/cdkd' } : { full_name: 'go-to-k/cdkd' } },
       base: { repo: { full_name: 'go-to-k/cdkd' } },
     }));
+    // DELIBERATELY UNREACHABLE at HEAD: nothing in the workflow calls
+    // `gh pr list` any more. It exists so the eviction probe stays faithful —
+    // see the comment on the 40-fork case. Delete it only together with that
+    // case.
     // The stub ALSO answers the old `gh pr list` shape, truncated to 30 the
     // way real gh does. That is what makes the eviction probe faithful:
     // reverting the workflow to `gh pr list` reds the 40-fork case because the
@@ -228,13 +261,20 @@ for a in "$@"; do
   prev="$a"
 done
 case "$*" in
-  *"api repos/"*pulls*) printf '%s' ${JSON.stringify(JSON.stringify(restPrs))} | jq -r "$filter" ;;
-  *"pr list"*)          printf '%s' ${JSON.stringify(JSON.stringify(ghListPrs))} | jq -r "$filter" ;;
+  *"api repos/"*pulls*) jq -r "$filter" "$(dirname "$0")/rest.json" ;;
+  *"pr list"*)          jq -r "$filter" "$(dirname "$0")/ghlist.json" ;;
   *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *"--disable-auto"*) exit ${opts.disarmFails ? 1 : 0} ;;
   *)                  : ;;
 esac
 `;
+    // The payloads go in FILES beside the stub, never interpolated into the
+    // script. Embedding them put JSON inside a bash double-quoted string, so a
+    // `$` or backtick in a head ref would EXPAND — in a suite whose whole point
+    // is modelling attacker-chosen branch names.
+    writeFileSync(join(binDir, 'rest.json'), JSON.stringify(restPrs));
+    writeFileSync(join(binDir, 'ghlist.json'), JSON.stringify(ghListPrs));
     const ghPath = join(binDir, 'gh');
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
@@ -413,6 +453,26 @@ esac
     const r = run(fixture({ stale: true, armed: true, armedAnswer: '' }));
     expect(r.status).not.toBe(0);
     expect(r.output).toContain('could not read auto-merge state');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails loudly when disarming loses the race it polices', () => {
+    // auto-merge can fire, or a human can disarm, between the read and the
+    // call. Unguarded, `set -e` aborted with gh's raw error BEFORE the comment
+    // that explains what happened.
+    const r = run(fixture({ stale: true, armed: true, disarmFails: true }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not disable auto-merge');
+    expect(commented(r)).toBe(false);
+  });
+
+  it('fails closed when the head branch cannot be read', () => {
+    // A deleted head branch, or a private repo refusing the anonymous fetch
+    // (`persist-credentials: false` strips the token). Swallowed by `--quiet`,
+    // this was a bare git error with no context.
+    const r = run(fixture({ stale: true, armed: true, headRefMissing: true }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not read the head branch');
     expect(disarmed(r)).toBe(false);
   });
 


### PR DESCRIPTION
Review findings on `release-pr-staleness.yml` (go-to-k/cdkd#3014, already
merged). The same fixes are in go-to-k/cdk-local#721 and
go-to-k/cdk-real-drift#1902.

## The rationale described code that never shipped

The fork-decoy comment said a decoy "becomes the `[0]` this picks" and the run
"exits 0 saying not armed" while the real PR merges.

There is no `[0]` any more, and the `count != 1` refusal — added in the **same
commit** as the filter — turns decoy-plus-real into `exit 1`, not a silent pass.
Measured:

```
with the filter    → 42
without the filter → 99, 42   → count=2 → exit 1
```

So the comment described the intermediate state between the two halves of one
commit. What the same-repo filter actually buys, stated against the shipped
code:

- **DoS** — one fork PR wedges *every* run into that refusal, turning a guard
  that should be quiet into a permanent red anyone can set.
- **Acting on a fork PR** — with no real release PR open, a lone decoy is
  `count == 1`, and this job holds `pull-requests: write`, so it would read, and
  could comment on and disarm, a fork's PR.

## Always fetch the head

Preferring the `refs/remotes/origin/*` the checkout populated was wrong:
release-please **force-pushes** the release branch when it rebuilds. A rebuild
landing between the checkout and that line leaves the cached ref on the old
head, and the run compares main's tips against it and disarms a PR that was just
made current. Seconds wide and conservative in direction, but a fetch costs
nothing and removes it.

## Both new error paths were untested

Added by the previous commit and covered by nothing — in a suite whose own
header says these invocations rot silently:

| path | case | probe |
| --- | --- | --- |
| `--disable-auto` fails (it races the auto-merge it polices) | `fails loudly when disarming loses the race it polices` | guard removed → reds |
| head ref unreadable (deleted branch; private repo refusing the anonymous fetch `persist-credentials: false` forces) | `fails closed when the head branch cannot be read` | guard removed → reds |

## The stub could expand a head ref

It interpolated JSON into a bash double-quoted string, so a `$` or backtick in a
branch name would **expand** — in the suite whose entire subject is
attacker-chosen branch names. The payloads now go in files beside the stub and
are read with `jq -r "$filter" <file>`.

## Smaller

- A `jq` prerequisite probe: without it the stub exits 127 and every case fails
  as "expected 1 to be 0" rather than naming the cause.
- The header's "four cases" is now honest about the ten, and says which of them
  are failure modes the decision table omits.
- The `gh pr list` stub arm is marked deliberately unreachable at HEAD — it
  exists only to keep the eviction probe faithful, and should be deleted only
  with that case.

No changelog entry: CI-only, no shipped-binary behavior delta.
