### PR TITLE
docs(deploy): cli-deploy-safety.md describes the fixed record-side silent drop as fixed

### DIFF
--- a/docs/cli-deploy-safety.md
+++ b/docs/cli-deploy-safety.md
@@ -223,10 +223,13 @@ Three exceptions:
   unchanged; with the flag the property is silently dropped at write time.
   Without the flag the resource takes the Cloud Control route and the property
   reaches AWS verbatim.
-- **NOT** free to undo. A deploy under this flag records the property in cdkd
-  state even though it was never written, and simply dropping the flag later
-  does not deliver it — see
-  [the caveat under `--recreate-via-cc-api`](#recreate-via-cc-api-deploy).
+- **NOT** free to undo for a **create-only** property. Such a property is
+  recorded in cdkd state even though it was never written — deliberately, since
+  narrowing it out would turn it into a replacement of an untouched resource —
+  so simply dropping the flag later does not deliver it. See
+  [the caveat under `--recreate-via-cc-api`](#recreate-via-cc-api-deploy). For
+  every other dropped property, dropping the flag IS enough: the record never
+  claimed it, so the next deploy re-routes and Cloud Control sends it.
 - **NOT** persisted in cdkd state. Every deploy must pass the flag if the
   override is still wanted. The resource's `provisionedBy` state field reflects
   the routing actually used at the last deploy, not the flag.
@@ -285,26 +288,41 @@ before the redeploy survived. A later phase deliberately recreates the alarm
 and checks that tag DIES, so its survival above means something. This section
 said the opposite until that run measured it.
 
-**One sequence defeats this, and it is a bug, not a reason to reach for the
-flag.** If an earlier deploy accepted the drop with
-[`--prefer-sdk-route`](#prefer-sdk-route-deploy), that
-deploy still RECORDED the property in cdkd state without writing it to AWS. The
-later flag-less deploy does re-route the resource to Cloud Control, but the
-update is computed as a patch against that record, the property is identical on
-both sides, and nothing is sent — the deploy reports success and AWS never gets
-the field. That is a defect with its own tracking issue, and the same fixture
-carries the failing sequence as a pinned arm — so anyone who fixes it and runs
-`sdk-to-cc-autoroute` gets a red run telling them to update this page too.
-Until then, a resource in that state needs the property removed
-from the template and re-added across two deploys, or the recreate this flag
-performs.
+**An earlier opt-out deploy no longer defeats this, with one exception.** cdkd
+records only what the SDK provider actually sent, so after a
+[`--prefer-sdk-route`](#prefer-sdk-route-deploy) deploy a removable drop is
+simply absent from the record: the later flag-less deploy sees a genuine
+addition, re-routes the resource, and Cloud Control sends the field. The same
+`sdk-to-cc-autoroute` fixture measures that pair — its `--prefer-sdk-route`
+phase asserts the record does NOT carry `EvaluationWindow`, and the flag-less
+phase after it reads the property back off the live alarm.
+
+**The exception is a create-only drop**, and there the old failure survives.
+cdkd deliberately leaves such a property IN the record, because removing it
+would make the key read as an addition against the template — and an added
+create-only property is a REPLACEMENT, so a plain upgrade deploy over an
+unchanged template would destroy and recreate a resource nobody touched. The
+cost of that choice is stated rather than hidden: the record keeps claiming a
+value AWS does not hold, the flag-less deploy diffs it as identical on both
+sides, nothing is sent, and the deploy reports success. That residual is a
+known defect with its own tracking issue, and it is still open because closing
+it means deciding what cdkd should DO when the flag is dropped — every
+candidate changes what a plain deploy does to a live resource.
 
 Reach for the flag when the auto-routed **update** cannot deliver the property,
 which is a narrower case:
 
 - **The property is create-only.** No update on either layer can set it, so the
   resource has to be created again with the property present. The CFn resource
-  schema's `createOnlyProperties` is what to check.
+  schema's `createOnlyProperties` is what to check. Whether you need this flag
+  depends on what the record holds. If it does NOT already claim the value —
+  the ordinary case, where you just added the property — the change reads as an
+  addition and cdkd classifies it as a
+  [property-driven replacement](#property-driven-replacement-and-stateful-replace-blocked)
+  off the same schema, so it recreates the resource for you with no flag, and a
+  stateful type is refused until `--force-stateful-recreation`. The flag is for
+  the case where the record DOES claim it — the `--prefer-sdk-route` sequence
+  above — because there the diff finds no difference to act on.
 - **The SDK-created resource's physical id is not a valid Cloud Control
   identifier.** Cloud Control addresses a resource by the `Identifier` its
   schema's `primaryIdentifier` defines, while an SDK provider stores whatever
@@ -315,11 +333,15 @@ which is a narrower case:
   update fails and the recreate is the way through.
 
 Both bullets are reasoned from the routing model, not measured — unlike the
-`sdk-to-cc-autoroute` paragraph that opens this section. If you hit one, the
-deploy fails loudly rather than silently dropping anything, so the flag is a
-remedy you reach for after a failure, not a precaution you take before one.
-That is what separates them from the caveat above, which fails silently; the
-two-deploy workaround named there is also reasoned rather than measured.
+`sdk-to-cc-autoroute` paragraph that opens this section. They do not fail the
+same way, so they are not reached for the same way. The second one fails
+loudly: the auto-routed update errors, and the flag is a remedy you reach for
+after a failure rather than a precaution you take before one. The first one
+fails loudly only when the record does not already claim the property — the
+replacement is planned and, for a stateful type, refused out loud. In the
+recorded create-only case above there is no failure at all: the deploy reports
+success, applies nothing, and prints nothing that points at this flag, so that
+one is a precaution you do have to take before the fact.
 
 ### When not to use it
 

--- a/docs/cli-deploy-safety.md
+++ b/docs/cli-deploy-safety.md
@@ -152,7 +152,11 @@ consequences worth knowing:
   resource through Cloud Control and the value reaches AWS in place. (Older cdkd
   versions recorded the property anyway, and the re-routed update — computed as
   a patch against a record that already claimed the value — sent nothing.) The
-  exception is a create-only property; see below.
+  main exception is a create-only property; see below. The narrower one is
+  where the re-route happens but cannot land — the physical-id bullet under
+  [`--recreate-via-cc-api`](#recreate-via-cc-api-deploy). A type the Cloud
+  Control route cannot serve — no Cloud Control handlers, or a provider that
+  declines the fallback — is refused at pre-flight instead.
 - **`cdkd diff` and `cdkd deploy` disagree about the property, on purpose.**
   `diff` registers no `--prefer-sdk-route`, so it previews the
   flag-less deploy and shows the property as a pending change with the
@@ -228,8 +232,13 @@ Three exceptions:
   narrowing it out would turn it into a replacement of an untouched resource —
   so simply dropping the flag later does not deliver it. See
   [the caveat under `--recreate-via-cc-api`](#recreate-via-cc-api-deploy). For
-  every other dropped property, dropping the flag IS enough: the record never
-  claimed it, so the next deploy re-routes and Cloud Control sends it.
+  every other dropped property, dropping the flag usually delivers it: the
+  record never claimed it, so the next deploy re-routes and Cloud Control sends
+  it. Usually, not always: the auto-routed update still has to be able to
+  ADDRESS the resource (the physical-id bullet in that same section), and the
+  Cloud Control route has to be able to serve the type at all — no Cloud
+  Control handlers, or a provider that declines the fallback, and dropping the
+  flag is refused at pre-flight rather than silently ineffective.
 - **NOT** persisted in cdkd state. Every deploy must pass the flag if the
   override is still wanted. The resource's `provisionedBy` state field reflects
   the routing actually used at the last deploy, not the flag.
@@ -305,9 +314,9 @@ unchanged template would destroy and recreate a resource nobody touched. The
 cost of that choice is stated rather than hidden: the record keeps claiming a
 value AWS does not hold, the flag-less deploy diffs it as identical on both
 sides, nothing is sent, and the deploy reports success. That residual is a
-known defect with its own tracking issue, and it is still open because closing
-it means deciding what cdkd should DO when the flag is dropped — every
-candidate changes what a plain deploy does to a live resource.
+known defect with its own tracking issue. It is still open because the
+alternatives to today's behaviour — refuse the deploy, or classify it as a
+replacement — both change what a plain deploy does to a live resource.
 
 Reach for the flag when the auto-routed **update** cannot deliver the property,
 which is a narrower case:
@@ -317,11 +326,20 @@ which is a narrower case:
   schema's `createOnlyProperties` is what to check. Whether you need this flag
   depends on what the record holds. If it does NOT already claim the value —
   the ordinary case, where you just added the property — the change reads as an
-  addition and cdkd classifies it as a
-  [property-driven replacement](#property-driven-replacement-and-stateful-replace-blocked)
-  off the same schema, so it recreates the resource for you with no flag, and a
-  stateful type is refused until `--force-stateful-recreation`. The flag is for
-  the case where the record DOES claim it — the `--prefer-sdk-route` sequence
+  addition, and unless one of cdkd's own rules says that property can change in
+  place it becomes a
+  [property-driven replacement](#property-driven-replacement-and-stateful-replace-blocked),
+  so cdkd recreates the resource for you with no flag. (Where cdkd has no rule
+  of its own, that verdict comes from the type's CFn schema, read through
+  `cloudformation:DescribeType`; without that permission cdkd warns and falls
+  back to treating the change as in-place. What happens then is type-dependent:
+  the provider may refuse it and point you at `--replace`, AWS may reject the
+  update, or — where nothing guards the property — it is quietly dropped and the
+  deploy reports success.) A stateful type is
+  refused until `--force-stateful-recreation`, **unless** it declares
+  `UpdateReplacePolicy: Retain` — that is exempt from the consent flag, because
+  the old resource is orphaned rather than deleted. The flag is for the case
+  where the record DOES claim the value — the `--prefer-sdk-route` sequence
   above — because there the diff finds no difference to act on.
 - **The SDK-created resource's physical id is not a valid Cloud Control
   identifier.** Cloud Control addresses a resource by the `Identifier` its
@@ -338,10 +356,13 @@ same way, so they are not reached for the same way. The second one fails
 loudly: the auto-routed update errors, and the flag is a remedy you reach for
 after a failure rather than a precaution you take before one. The first one
 fails loudly only when the record does not already claim the property — the
-replacement is planned and, for a stateful type, refused out loud. In the
-recorded create-only case above there is no failure at all: the deploy reports
-success, applies nothing, and prints nothing that points at this flag, so that
-one is a precaution you do have to take before the fact.
+replacement is planned, and for a stateful type without
+`UpdateReplacePolicy: Retain` it is refused out loud. In the recorded
+create-only case above there is no failure at all, and the output is worse than
+silent: pre-flight still prints the routing line promising Cloud Control will
+forward the full property map, the diff then finds no change, nothing retracts
+the promise, and nothing points at this flag. So that one is a precaution you
+do have to take before the fact.
 
 ### When not to use it
 

--- a/docs/cli-deploy-safety.md
+++ b/docs/cli-deploy-safety.md
@@ -234,11 +234,12 @@ Three exceptions:
   [the caveat under `--recreate-via-cc-api`](#recreate-via-cc-api-deploy). For
   every other dropped property, dropping the flag usually delivers it: the
   record never claimed it, so the next deploy re-routes and Cloud Control sends
-  it. Usually, not always: the auto-routed update still has to be able to
-  ADDRESS the resource (the physical-id bullet in that same section), and the
-  Cloud Control route has to be able to serve the type at all — no Cloud
-  Control handlers, or a provider that declines the fallback, and dropping the
-  flag is refused at pre-flight rather than silently ineffective.
+  it. Usually, not always. The auto-routed update still has to be able to
+  ADDRESS the resource, and where it cannot it fails at update time — the
+  physical-id bullet in that same section. The Cloud Control route also has to
+  be able to serve the type at all: with no Cloud Control handlers, or a
+  provider that declines the fallback, dropping the flag is refused at
+  pre-flight rather than being silently ineffective.
 - **NOT** persisted in cdkd state. Every deploy must pass the flag if the
   override is still wanted. The resource's `provisionedBy` state field reflects
   the routing actually used at the last deploy, not the flag.
@@ -330,13 +331,12 @@ which is a narrower case:
   place it becomes a
   [property-driven replacement](#property-driven-replacement-and-stateful-replace-blocked),
   so cdkd recreates the resource for you with no flag. (Where cdkd has no rule
-  of its own, that verdict comes from the type's CFn schema, read through
-  `cloudformation:DescribeType`; without that permission cdkd warns and falls
-  back to treating the change as in-place. What happens then is type-dependent:
-  the provider may refuse it and point you at `--replace`, AWS may reject the
-  update, or — where nothing guards the property — it is quietly dropped and the
-  deploy reports success.) A stateful type is
-  refused until `--force-stateful-recreation`, **unless** it declares
+  of its own, that verdict is read from the type's CFn schema through
+  `cloudformation:DescribeType`; without that permission cdkd warns and
+  classifies the change as in-place instead, so that property-driven
+  replacement does not happen — and where nothing rejects the in-place update,
+  the deploy can report success with the property unapplied.) A stateful type
+  is refused until `--force-stateful-recreation`, **unless** it declares
   `UpdateReplacePolicy: Retain` — that is exempt from the consent flag, because
   the old resource is orphaned rather than deleted. The flag is for the case
   where the record DOES claim the value — the `--prefer-sdk-route` sequence


### PR DESCRIPTION
## Summary

Closes #3019.

`docs/cli-deploy-safety.md`'s `--recreate-via-cc-api` → "When to use it" section
still described go-to-k/cdkd#2750 as an open defect. It claimed that a `--prefer-sdk-route`
deploy RECORDS the dropped property, that the later flag-less deploy therefore
sends nothing, and that the remedy "until then" is removing and re-adding the
property across two deploys or recreating the resource. None of that describes a
**removable** drop any more, and the page contradicted `docs/provisioning-layers.md`
step 3, which already said the auto-route delivers the property.

Every sentence below was re-derived from source and from the fixture, not from
the page's own prose — that is what the issue asked for, and the paragraph had
survived a rename edit precisely because the flag name was changed inside the
stale claim without re-reading the claim.

## What is actually true, and where it is written

- `withoutSilentDropProperties` narrows the record to what the SDK route sent
  (`DeployEngine.propertiesToRecord`), and `DiffCalculator` narrows the same
  record side on read — so a pre-go-to-k/cdkd#2750 record heals too.
- `excludeCreateOnly` deliberately leaves a **create-only** drop in the record,
  because removing it makes the key an addition, and
  `createOnlyChangeRequiresReplacement` classifies an added create-only path as
  a REPLACEMENT of a resource nobody touched.
- So the recorded create-only case is the one that still diffs as identical on
  both sides, sends nothing, and reports success. That is go-to-k/cdkd#2790, still open.
- When the record does NOT already claim a create-only property, the change
  reads as an addition and becomes a property-driven replacement, which cdkd
  performs with no flag. Two qualifiers the review rounds added: the schema
  fallback runs only where `ReplacementRulesRegistry` has no opinion
  (`diff-calculator.ts:910`), and the `STATEFUL_REPLACE_BLOCKED` refusal is
  gated on `updateReplacePolicy !== 'Retain'` (`deploy-engine.ts:5507`), so a
  `Retain` stateful resource is not refused at all.

## Changes

All in `docs/cli-deploy-safety.md`.

- **"One sequence defeats this"** (the issue's first ask) is rewritten as two
  paragraphs: the opt-out deploy leaves a removable drop OUT of the record and
  the flag-less deploy delivers it — citing the two `sdk-to-cc-autoroute` phases
  that measure exactly that pair — and then the create-only drop as the one
  surviving exception, with the reason cdkd keeps it. The old promise that "the
  same fixture carries the failing sequence as a pinned arm" is dropped: the
  fixture now pins the FIXED sequence, so that tripwire no longer exists.
- **The create-only bullet** splits by what the record holds, so a reader is not
  sent to a recreate they do not need. It links the page's own
  "Property-driven replacement and `STATEFUL_REPLACE_BLOCKED`" section.
- **The closing paragraph** (the issue's second and third asks) no longer says
  both bullets "fail loudly", and the two-deploy workaround sentence is gone.
  The two bullets now fail differently, and the paragraph says which is which.
- **`### What the flag is NOT`** carried the same stale claim unconditionally,
  three headings earlier, contradicting its own section's correct bullets at
  lines 145-155. The issue did not name this one; it is what the maintainer's
  "check whether the same stale framing survives elsewhere on the page" asked
  for. Now scoped to create-only.

No changelog entry: behavior-describing docs, no shipped-binary delta. The
residual's tracking issue is referred to without a link — user-facing pages carry
no issue/PR references, enforced by `tests/unit/scripts/docs-site-links.test.ts`
(the first draft linked it and the suite caught it).

## Verification

- `vp run check`, `vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices`,
  `vp run audit:coverage:check` all clean.
- `vp test run`: 991 files, 21839 passed, 1 skipped.
- `vp run docs:build` — used to settle the intra-page anchor empirically rather
  than by assumption: the docs-site slugger turns `_` into `-`, so the link is
  `#property-driven-replacement-and-stateful-replace-blocked`, not the GitHub
  spelling. Confirmed against the generated `id=` in `dist/site/`.
- No integ run: docs-only, no code path touched, and no integ gate is in scope.

## Review

Seven rounds, each scoped to the previous round's fix delta. The page asserts
runtime behaviour including data-loss-relevant behaviour, and the issue exists
because a sentence here was edited without re-reading what it claimed, so every
finding below was re-verified against source before being acted on.

- **Round 1** (spec + code, in parallel): no blockers. All four asks confirmed
  done. Four accuracy findings: a stateful type is NOT refused when it declares
  `UpdateReplacePolicy: Retain` (`deploy-engine.ts:5507`); the create-only
  replacement claim skipped the `isClassified` gate (`diff-calculator.ts:910`);
  "dropping the flag IS enough" was refuted by the page's own physical-id
  bullet; and the recorded-create-only case does not merely print nothing --
  pre-flight prints a routing line promising Cloud Control will forward the
  property (`provider-registry.ts:855`) that nothing retracts.
- **Round 2**: four minors. "Closing the issue means deciding what cdkd should
  do" was falsified by the issue's own third candidate -- documenting today's
  behaviour, i.e. this PR. "The replacement proceeds" was wrong under `Retain`,
  which can hard-fail on a held physical name.
- **Rounds 3-5**: the `cloudformation:DescribeType` caveat, added for a round-2
  nit, produced a blocker in two consecutive rounds -- first asserting "AWS
  rejects the update" (the real hazard is silence), then listing three outcomes
  as exhaustive while omitting the Cloud Control auto-fallback. It is now a
  conditional rather than an enumeration.
- **Round 6** refused the version that deleted the caveat outright, with
  evidence that the silent-success residual is documented nowhere else under
  `docs/` and that deleting it would contradict this page's own opening line.
- **Round 7**: clean.

Every finding is fixed in this PR. One out-of-scope finding is filed rather than
fixed: `src/deployment/deploy-engine.ts:2824` still comments "No throw" over the
step 3.5 call that `provider-registry.ts:843` can throw from --
go-to-k/cdkd#3028.

No live test: docs-only, no code path changed, and no integ gate is in scope.
