### PR TITLE
ci: correct the fork-decoy reach, guard an empty head ref, cover a hostile one

### DIFF
--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -80,9 +80,17 @@ jobs:
           # the two remaining reaches are:
           #   * DoS. One fork PR wedges every run into that refusal, turning a
           #     guard that should be quiet into a permanent red anyone can set.
-          #   * Acting on a fork PR. With no real release PR open, a lone decoy
-          #     is `count == 1`, and this job holds `pull-requests: write` -- it
-          #     would read, and could comment on and disarm, a fork's PR.
+          #   * Reading a fork PR. With no real release PR open, a lone decoy
+          #     is `count == 1`, so the run picks it up -- and then hard-fails,
+          #     because `git fetch origin "${head_ref}"` below resolves the
+          #     FORK's branch name against THIS repo, which does not carry it.
+          #     So the reach is a second DoS wearing a misleading cause ("may
+          #     have been deleted"), not a write. The comment/disarm this job's
+          #     `pull-requests: write` allows needs BOTH an identically named
+          #     branch still present here AND someone with write access having
+          #     armed auto-merge on that fork PR -- a fork author cannot arm it.
+          #     Stated at that length because two earlier drafts of this bullet
+          #     overstated the reach, each time describing a chain nobody ran.
           #
           # A deleted fork leaves `head.repo` null, which `// ""` turns into a
           # non-match rather than a jq error -- correct, since it was a fork.
@@ -97,9 +105,10 @@ jobs:
           # ~30 fork PRs -- attacker-chosen, no privilege -- evict the release
           # PR from the page, the filter returns nothing, and the run exits 0
           # saying "no standing release PR" while the real armed stale PR
-          # merges. Same suppression as the decoy below, reached by truncation
-          # instead of ordering, and it also fires benignly on a dependabot
-          # burst. Pagination enumerates EVERY open PR, so neither can happen.
+          # merges. This one is the SILENT failure of the two: the decoy above
+          # ends in the loud `count != 1` refusal, while truncation leaves
+          # nothing to count, and it also fires benignly on a dependabot burst.
+          # Pagination enumerates EVERY open PR, so neither can happen.
           prs=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
                   --jq '.[] | select((.head.repo.full_name // "") == .base.repo.full_name)
                             | select(.head.ref | startswith("release-please--"))
@@ -133,6 +142,14 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          # Same fail-closed rule as `armed` above. An empty answer would reach
+          # `git fetch origin ""`, whose failure is reported as "could not read
+          # the head branch ''" -- a misdiagnosis pointing at a deleted branch
+          # when the real fault was `gh`.
+          if [ -z "${head_ref}" ]; then
+            echo "::error::gh returned no head branch name for #${pr}. Refusing to guess which branch to compare."
+            exit 1
+          fi
           # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
           # already populated. release-please FORCE-PUSHES the release branch
           # when it rebuilds, so a rebuild landing between the checkout and this
@@ -146,7 +163,7 @@ jobs:
           # reported rather than swallowed by `--quiet` -- the likeliest cause
           # is the head branch having been deleted between the two calls.
           if ! git fetch --no-tags --quiet origin "${head_ref}"; then
-            echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+            echo "::error::could not read the head branch '${head_ref}' of #${pr}. Likeliest causes: the branch was deleted, a transient network failure (this fetch is not retried), or this repo is private and the anonymous fetch was refused."
             exit 1
           fi
           head=$(git rev-parse FETCH_HEAD)

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -86,9 +86,11 @@ jobs:
           #     FORK's branch name against THIS repo, which does not carry it.
           #     So the reach is a second DoS wearing a misleading cause ("may
           #     have been deleted"), not a write. The comment/disarm this job's
-          #     `pull-requests: write` allows needs BOTH an identically named
-          #     branch still present here AND someone with write access having
-          #     armed auto-merge on that fork PR -- a fork author cannot arm it.
+          #     `pull-requests: write` allows needs THREE things at once: an
+          #     identically named branch still present here, someone with write
+          #     access having armed auto-merge on that fork PR (its author
+          #     cannot -- arming needs merge rights), and that branch being
+          #     STALE, since a current one exits 0 below without writing.
           #     Stated at that length because two earlier drafts of this bullet
           #     overstated the reach, each time describing a chain nobody ran.
           #
@@ -142,12 +144,16 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          # Same fail-closed rule as `armed` above. An empty answer would reach
-          # `git fetch origin ""`, whose failure is reported as "could not read
-          # the head branch ''" -- a misdiagnosis pointing at a deleted branch
-          # when the real fault was `gh`.
-          if [ -z "${head_ref}" ]; then
-            echo "::error::gh returned no head branch name for #${pr}. Refusing to guess which branch to compare."
+          # Same ALLOWLIST discipline as `armed` above -- accept only what git
+          # itself calls a valid branch name -- rather than testing one bad
+          # shape. A bare `-z` was the single-shape version and let whitespace
+          # and leading-dash answers through: measured, `check-ref-format`
+          # REJECTS '', '   ' and '--upload-pack=x', and ACCEPTS an ordinary
+          # `release-please--branches--main`. An empty answer reaching
+          # `git fetch origin ""` was also reported as "could not read the head
+          # branch ''", pointing at a deleted branch when the fault was `gh`.
+          if ! git check-ref-format --branch "${head_ref}" >/dev/null 2>&1; then
+            echo "::error::gh gave no usable head branch name for #${pr} (got '${head_ref}'). Refusing to guess which branch to compare."
             exit 1
           fi
           # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
@@ -162,7 +168,10 @@ jobs:
           # token. Fine for a public repo, and the reason the failure is
           # reported rather than swallowed by `--quiet` -- the likeliest cause
           # is the head branch having been deleted between the two calls.
-          if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+          # `refs/heads/...`, not the bare name: the answer then reaches git in
+          # an unambiguous ref position rather than one where a leading dash
+          # could be read as an option.
+          if ! git fetch --no-tags --quiet origin "refs/heads/${head_ref}"; then
             echo "::error::could not read the head branch '${head_ref}' of #${pr}. Likeliest causes: the branch was deleted, a transient network failure (this fetch is not retried), or this repo is private and the anonymous fetch was refused."
             exit 1
           fi

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -26,8 +26,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * release is unchanged and the PR is left on its original base).
  *
  * Why this suite EXECUTES the workflow's shell against real git repositories
- * and a stubbed `gh`: the whole check is six git/gh invocations, each of which
- * rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
+ * and a stubbed `gh`: the whole check is a chain of git/gh invocations, each of
+ * which rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
  * invert the `armed` test — and it stops disarming anything while still exiting
  * 0 on every run, which is indistinguishable from "nothing was stale". A suite
  * that pattern-matched the YAML would certify that state.
@@ -45,9 +45,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
  * state, a head branch that cannot be read, `gh` naming no head branch at all,
  * a head branch name carrying shell metacharacters, and `--disable-auto`
- * losing the race it polices. The table's four rows plus those eight are the
- * shell cases; the `describe` below them checks the YAML wiring instead, so do
- * not read a count off one half.
+ * losing the race it polices.
+ *
+ * Deliberately NOT stated as a count. Three successive revisions of this
+ * docblock gave a number ("six invocations", "the ten", "those eight") and all
+ * three were wrong, because nothing re-checks a number in prose. The `describe`
+ * block at the bottom covers the YAML wiring rather than the shell, so any
+ * count taken off one half was going to be wrong anyway.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -512,8 +516,10 @@ esac
     // Distinct from the case above: there the fetch fails, here `gh` answered
     // nothing. Without the guard the empty value reaches `git fetch origin ""`
     // and is reported as a branch that "may have been deleted" — a
-    // misdiagnosis pointing at the repo when the fault was the CLI. Same
-    // fail-closed rule the `armed` read already had.
+    // misdiagnosis pointing at the repo when the fault was the CLI. The guard
+    // is `git check-ref-format`, an ALLOWLIST like the `armed` read's, rather
+    // than a `-z` testing one bad shape: it also rejects whitespace-only and
+    // leading-dash answers.
     const r = run(
       fixture({
         stale: true,
@@ -523,21 +529,33 @@ esac
       })
     );
     expect(r.status).not.toBe(0);
-    expect(r.output).toContain('no head branch name');
+    expect(r.output).toContain('no usable head branch name');
     expect(disarmed(r)).toBe(false);
   });
 
   it('does not evaluate a head branch name that carries shell metacharacters', () => {
     // The one place a head ref reaches a shell is `git fetch … "${head_ref}"`.
+    //
+    // The payload is `$(>pwned)` and NOT `$(touch pwned)`, which is what this
+    // case first used: `git check-ref-format --branch` REJECTS the latter (it
+    // contains a space), so it modelled a value GitHub can never hand back,
+    // while `$(>pwned)` is ref-format VALID and still writes the file under a
+    // parser. Both measured.
+    //
     // What this case does NOT catch, measured rather than assumed: dropping the
-    // quotes changes nothing, because bash does not re-scan a variable's VALUE
-    // for command substitution — `v=$(printf %s 'x$(touch /tmp/p)'); cmd $v`
-    // creates no file. What it DOES catch is the rewrite that makes the value
-    // re-enter the parser: replacing the line with `eval "git fetch … $head_ref"`
-    // reds this case and ONLY this case. The probe is the side effect — if the
-    // `$(…)` ever runs, the file exists. The run itself is expected to fail,
-    // since no such branch exists to fetch.
-    const hostile = `${RELEASE_BRANCH}$(touch pwned)`;
+    // quotes changes nothing here. Two separate reasons, and only the second is
+    // load-bearing — bash does not re-scan a variable's VALUE for command
+    // substitution, AND unquoted expansion still word-splits and globs, which
+    // this payload would trigger if a ref could carry it. It cannot:
+    // `check-ref-format` rejects space, `*`, `?`, `[`, `:`, `\`, `~` and `^`,
+    // and the workflow now runs that same check before the fetch.
+    //
+    // What it DOES catch is the rewrite that makes the value re-enter the
+    // parser: replacing the line with `eval "git fetch … $head_ref"` reds this
+    // case and ONLY this case. The probe is the side effect — if the `$(…)`
+    // ever runs, the file exists. The run itself is expected to fail, since no
+    // such branch exists to fetch.
+    const hostile = `${RELEASE_BRANCH}$(>pwned)`;
     const fx = fixture({
       stale: true,
       armed: true,
@@ -545,6 +563,9 @@ esac
     });
     const r = run(fx);
     expect(r.status).not.toBe(0);
+    // Pins WHICH failure. Without it, a future change that exits 1 before ever
+    // reaching the fetch satisfies both assertions below vacuously.
+    expect(r.output).toContain('could not read the head branch');
     expect(existsSync(join(fx.cwd, 'pwned'))).toBe(false);
     expect(disarmed(r)).toBe(false);
   });

--- a/tests/unit/scripts/release-pr-staleness.test.ts
+++ b/tests/unit/scripts/release-pr-staleness.test.ts
@@ -1,4 +1,12 @@
-import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import {
+  readFileSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  existsSync,
+} from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -35,8 +43,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * plus the failure modes that are NOT in the table and were each a live defect
  * found in review: a fork PR decoying the lookup, 30+ PRs evicting the real one
  * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
- * state, a head branch that cannot be read, and `--disable-auto` losing the
- * race it polices.
+ * state, a head branch that cannot be read, `gh` naming no head branch at all,
+ * a head branch name carrying shell metacharacters, and `--disable-auto`
+ * losing the race it polices. The table's four rows plus those eight are the
+ * shell cases; the `describe` below them checks the YAML wiring instead, so do
+ * not read a count off one half.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -172,6 +183,12 @@ describe('release-pr-staleness', () => {
      * what a `gh` that exits 0 without the field would produce.
      */
     armedAnswer?: string;
+    /**
+     * Make the `headRefName` read answer with nothing — a `gh` that exits 0
+     * without the field. Distinct from `headRefMissing`, where `gh` answers
+     * fine and the FETCH is what fails.
+     */
+    headRefAnswerEmpty?: boolean;
   }): { cwd: string; ghLog: string; tip: string; binDir: string } {
     const id = `f${seq++}`;
     const origin = join(scratch, `${id}-origin`);
@@ -223,8 +240,9 @@ describe('release-pr-staleness', () => {
     // The PR lookup runs the WORKFLOW'S OWN `--jq` expression through real `jq`
     // against a canned PR list, rather than returning a canned answer. The
     // filter is the thing under test — restricting to same-repo PRs is what
-    // stops a fork decoy named `release-please--…` becoming the `[0]` this
-    // picks — and a stub that answered `42` regardless would certify a filter
+    // keeps a fork decoy named `release-please--…` out of the match set, so
+    // the real PR is the only thing counted — and a stub that answered `42`
+    // regardless would certify a filter
     // that had been deleted. (An earlier cut returned the raw JSON array,
     // ignoring `--jq` altogether; that is the same class one step further out.)
     const openPrs =
@@ -252,29 +270,39 @@ describe('release-pr-staleness', () => {
       .slice(0, 30)
       .map((o) => ({ number: o.number, headRefName: o.headRef, isCrossRepository: o.fork }));
     const ghStub = `#!/usr/bin/env bash
-echo "$*" >> ${JSON.stringify(ghLog)}
-# Pull the --jq expression out of argv the way real gh consumes it.
+echo "$*" >> "$GH_LOG"
+# Pull the --jq expression, and the PR number, out of argv the way real gh
+# consumes them.
 filter=""
+prnum=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "--jq" ]; then filter="$a"; fi
+  case "$prev" in view | merge | comment) prnum="$a" ;; esac
   prev="$a"
 done
 case "$*" in
   *"api repos/"*pulls*) jq -r "$filter" "$(dirname "$0")/rest.json" ;;
   *"pr list"*)          jq -r "$filter" "$(dirname "$0")/ghlist.json" ;;
-  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
-  *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *autoMergeRequest*) cat "$(dirname "$0")/armed.txt" ;;
+  # The head ref of the PR the shell ACTUALLY matched, read back out of the
+  # same canned list — not a constant. A constant meant no case could drive an
+  # attacker-shaped branch name into \`git fetch\`, the one place a head ref
+  # reaches a shell, so the earlier hardening protected the STUB and left the
+  # workflow path uncovered.
+  *headRefName*)      ${opts.headRefAnswerEmpty ? ':' : `jq -r --arg n "$prnum" '.[] | select(.number == ($n | tonumber)) | .head.ref' "$(dirname "$0")/rest.json"`} ;;
   *"--disable-auto"*) exit ${opts.disarmFails ? 1 : 0} ;;
   *)                  : ;;
 esac
 `;
-    // The payloads go in FILES beside the stub, never interpolated into the
-    // script. Embedding them put JSON inside a bash double-quoted string, so a
-    // `$` or backtick in a head ref would EXPAND — in a suite whose whole point
-    // is modelling attacker-chosen branch names.
+    // Every payload goes in a FILE beside the stub, or an env var — never
+    // interpolated into the script. Embedding them put JSON inside a bash
+    // double-quoted string, so a `$` or backtick in a head ref (or in the
+    // canned `armed` answer, or the log path) would EXPAND — in a suite whose
+    // whole point is modelling attacker-chosen branch names.
     writeFileSync(join(binDir, 'rest.json'), JSON.stringify(restPrs));
     writeFileSync(join(binDir, 'ghlist.json'), JSON.stringify(ghListPrs));
+    writeFileSync(join(binDir, 'armed.txt'), opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'));
     const ghPath = join(binDir, 'gh');
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
@@ -294,6 +322,7 @@ esac
           ...process.env,
           ...GIT_ENV,
           PATH: `${stubDir}:${process.env['PATH'] ?? ''}`,
+          GH_LOG: fx.ghLog,
           GH_TOKEN: 'x',
           REPO: 'go-to-k/cdkd',
         },
@@ -378,13 +407,15 @@ esac
   });
 
   it('ignores a FORK PR whose head branch carries the release prefix', () => {
-    // `gh pr list` includes fork PRs and orders newest-first, and a fork's head
-    // branch NAME is attacker-chosen. Without the same-repo filter, a decoy
-    // named `release-please--branches--main` becomes the `[0]` the shell picks:
-    // `armed` is then read off the DECOY (not armed), the run exits 0 saying
-    // "not armed", and the real armed, stale release PR is never checked and
-    // merges. Pushing a branch to THIS repo needs write access, which is what
-    // the filter buys.
+    // Open PRs include fork PRs, and a fork's head branch NAME is
+    // attacker-chosen. Without the same-repo filter, a decoy named
+    // `release-please--branches--main` joins the match set, so `count` is 2 and
+    // the run ends in the "refusing to guess which one" refusal — the real
+    // stale PR is never disarmed, and one PR anyone can open reds this guard on
+    // every run. Pushing a branch to THIS repo needs write access, which is
+    // what the filter buys. (This comment described an `[0]`-picks-the-decoy
+    // silent pass for two revisions. There is no `[0]`, and the `count != 1`
+    // refusal landed in the same commit as the filter; measured below.)
     const fx = fixture({
       stale: true,
       armed: true,
@@ -407,9 +438,10 @@ esac
     // that one page. So ~30 fork PRs — attacker-chosen, no privilege — evict
     // the release PR from the page, the filter returns nothing, and the run
     // exits 0 reporting "no standing release PR" while the real armed stale PR
-    // merges. Same suppression as the decoy above, reached by TRUNCATION
-    // instead of ordering, and it fires benignly on a dependabot burst too.
-    // The shell uses `gh api --paginate` for exactly this reason.
+    // merges. This is the SILENT one of the two fork reaches: the decoy above
+    // ends in a loud `count != 1` refusal, while truncation leaves nothing to
+    // count. It fires benignly on a dependabot burst too. The shell uses
+    // `gh api --paginate` for exactly this reason.
     const noise = Array.from({ length: 40 }, (_, i) => ({
       number: 1000 + i,
       headRef: `feat/noise-${i}`,
@@ -473,6 +505,47 @@ esac
     const r = run(fixture({ stale: true, armed: true, headRefMissing: true }));
     expect(r.status).not.toBe(0);
     expect(r.output).toContain('could not read the head branch');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when gh returns no head branch name', () => {
+    // Distinct from the case above: there the fetch fails, here `gh` answered
+    // nothing. Without the guard the empty value reaches `git fetch origin ""`
+    // and is reported as a branch that "may have been deleted" — a
+    // misdiagnosis pointing at the repo when the fault was the CLI. Same
+    // fail-closed rule the `armed` read already had.
+    const r = run(
+      fixture({
+        stale: true,
+        armed: true,
+        openPrs: [{ number: 7, headRef: RELEASE_BRANCH, fork: false }],
+        headRefAnswerEmpty: true,
+      })
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('no head branch name');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('does not evaluate a head branch name that carries shell metacharacters', () => {
+    // The one place a head ref reaches a shell is `git fetch … "${head_ref}"`.
+    // What this case does NOT catch, measured rather than assumed: dropping the
+    // quotes changes nothing, because bash does not re-scan a variable's VALUE
+    // for command substitution — `v=$(printf %s 'x$(touch /tmp/p)'); cmd $v`
+    // creates no file. What it DOES catch is the rewrite that makes the value
+    // re-enter the parser: replacing the line with `eval "git fetch … $head_ref"`
+    // reds this case and ONLY this case. The probe is the side effect — if the
+    // `$(…)` ever runs, the file exists. The run itself is expected to fail,
+    // since no such branch exists to fetch.
+    const hostile = `${RELEASE_BRANCH}$(touch pwned)`;
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [{ number: 42, headRef: hostile, fork: false }],
+    });
+    const r = run(fx);
+    expect(r.status).not.toBe(0);
+    expect(existsSync(join(fx.cwd, 'pwned'))).toBe(false);
     expect(disarmed(r)).toBe(false);
   });
 


### PR DESCRIPTION
Follow-up to go-to-k/cdkd#3025, which merged with the same defect it was written to fix: a
comment that overstates what the code does. Two reviewers, on the two sibling
repos carrying this file, found it independently. Same fixes are in
go-to-k/cdk-local#721 and go-to-k/cdk-real-drift#1902.

## The reach was one step too long

The bullet said a lone fork decoy "would read, and could comment on and disarm,
a fork's PR". The read is right. The disarm is not reachable:

```
head_ref  = the FORK's branch name
git fetch --no-tags --quiet origin "${head_ref}"   # resolves against THIS repo
                                                   # which does not carry it
  -> exit 1
```

So the honest reach is a **second DoS** wearing a misleading cause ("may have
been deleted"). Comment/disarm needs *both* an identically named branch still
present in this repo *and* a write-access user having armed auto-merge on the
fork PR — which its author cannot do.

## The debunked story survived in the test

go-to-k/cdkd#3025 rewrote the `[0]`-picks-the-decoy model in the workflow only. The test
carried it verbatim in two places, and that is the copy a reader hits first.
Both now describe what the `count != 1` refusal actually does.

The eviction case's "same suppression as the decoy" is wrong in both files too:
the decoy is the **loud** failure (`count != 1` → exit 1) and truncation is the
silent one. It also said the decoy block was "below" when it is above.

## An empty head ref was not fail-closed

`armed` already refused an unreadable answer; `head_ref` did not. A `gh` exiting
0 with empty stdout reached `git fetch origin ""` and was reported as a branch
that "may have been deleted" — pointing at the repo when the fault was the CLI.

## The hardening had protected the stub, not the workflow

`headRefName` answered a **constant**, so no case could drive an attacker-shaped
branch name into `git fetch` — the one place a head ref reaches a shell. The
stub now reads the matched PR's ref back out of the same canned list, and a case
drives `release-please--branches--main$(touch pwned)` through it.

Measured rather than asserted, because the obvious claim is false:

| mutation | result |
| --- | --- |
| drop the quotes (`origin ${head_ref}`) | **no change** — bash does not re-scan a variable's value |
| `eval "git fetch … $head_ref"` | reds the new case, and **only** that case (17 others green) |
| neutralize the empty-`head_ref` guard | reds the new empty-ref case, and only that one |

All three probes run in all three repos.

## Smaller

- The remaining interpolations into the stub's bash source (the canned `armed`
  answer, the log path) move to a file and an env var.
- The fetch error names transient failure as a cause, since it is not retried.
- The header's case count is replaced with the enumeration — the number was
  already off by two.

No changelog entry: CI-only, no shipped-binary behavior delta.

## Round 4 — the head ref is now validated against git's own grammar

Two findings, both "right conclusion, wrong reason" — the same class as the
three rounds before.

- The hostile fixture drove `release-please--branches--main$(touch pwned)`
  through the head-ref path. Measured: `git check-ref-format --branch`
  **rejects** that name (it contains a space), so the case probed a branch name
  that cannot exist. `$(>pwned)` is ref-format **valid** and still writes the
  file under a parser — that is the payload now.
- The safety argument said dropping the quotes changes nothing "because bash
  does not re-scan a variable's VALUE". True but not sufficient: unquoted
  expansion still word-splits and globs, and the old payload's space would have
  split it. The load-bearing reason is that no real ref can carry those
  characters — `check-ref-format` rejects space, `*`, `?`, `[`, `:`, `\`, `~`,
  `^`.

So the guard became what it already claimed to be. `[ -z "${head_ref}" ]` was
described as "the same fail-closed rule as `armed`", but `armed` accepts an
enumerated set while that tested **one** bad shape — whitespace-only and
option-shaped answers went straight through. It is now
`git check-ref-format --branch`, and the fetch names the ref in full
(`refs/heads/...`).

Also: the fork-reach bullet was short one condition (the branch must be STALE
too), the metacharacter case gained a message assertion it could otherwise pass
vacuously, and every count in the test docblock — "six invocations" (ten), "the
ten" (twelve), "those eight" (fourteen) — was deleted rather than corrected.
Three wrong revisions is enough evidence that nothing re-checks a number in
prose.
