### PR TITLE
test(cli): stop handing an argv prefix to parse(..., { from: 'user' }), and fence the shape

### DIFF
--- a/tests/unit/cli/local-run-task.test.ts
+++ b/tests/unit/cli/local-run-task.test.ts
@@ -47,20 +47,20 @@ describe('createLocalRunTaskCommand', () => {
   });
 
   it('parses bare --assume-task-role as boolean true', () => {
-    const parsed = cmd.parse(['node', 'cdkd', 'TD', '--assume-task-role'], { from: 'user' });
+    const parsed = cmd.parse(['TD', '--assume-task-role'], { from: 'user' });
     expect(parsed.opts().assumeTaskRole).toBe(true);
   });
 
   it('parses --assume-task-role <arn> as the ARN string', () => {
     const parsed = cmd.parse(
-      ['node', 'cdkd', 'TD', '--assume-task-role', 'arn:aws:iam::123:role/foo'],
+      ['TD', '--assume-task-role', 'arn:aws:iam::123:role/foo'],
       { from: 'user' }
     );
     expect(parsed.opts().assumeTaskRole).toBe('arn:aws:iam::123:role/foo');
   });
 
   it('parses --no-pull as pull=false', () => {
-    const parsed = cmd.parse(['node', 'cdkd', 'TD', '--no-pull'], { from: 'user' });
+    const parsed = cmd.parse(['TD', '--no-pull'], { from: 'user' });
     expect(parsed.opts().pull).toBe(false);
   });
 
@@ -74,19 +74,19 @@ describe('createLocalRunTaskCommand', () => {
 
   it('parses --from-state as fromState=true', () => {
     const fresh = createLocalRunTaskCommand();
-    const parsed = fresh.parse(['node', 'cdkd', 'TD', '--from-state'], { from: 'user' });
+    const parsed = fresh.parse(['TD', '--from-state'], { from: 'user' });
     expect(parsed.opts().fromState).toBe(true);
   });
 
   it('defaults --from-state to false', () => {
     const fresh = createLocalRunTaskCommand();
-    const parsed = fresh.parse(['node', 'cdkd', 'TD'], { from: 'user' });
+    const parsed = fresh.parse(['TD'], { from: 'user' });
     expect(parsed.opts().fromState).toBe(false);
   });
 
   it('parses --stack-region <region> as stackRegion=<region>', () => {
     const fresh = createLocalRunTaskCommand();
-    const parsed = fresh.parse(['node', 'cdkd', 'TD', '--stack-region', 'us-west-2'], {
+    const parsed = fresh.parse(['TD', '--stack-region', 'us-west-2'], {
       from: 'user',
     });
     expect(parsed.opts().stackRegion).toBe('us-west-2');

--- a/tests/unit/cli/local-start-agentcore.test.ts
+++ b/tests/unit/cli/local-start-agentcore.test.ts
@@ -83,14 +83,14 @@ describe('createLocalStartAgentCoreCommand', () => {
   it('parses --from-state as a flag (no value)', () => {
     const fresh = createLocalStartAgentCoreCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Agent', '--from-state'], { from: 'user' });
+    const parsed = fresh.parse(['My/Agent', '--from-state'], { from: 'user' });
     expect(parsed.opts().fromState).toBe(true);
   });
 
   it('parses --state-bucket <bucket>', () => {
     const fresh = createLocalStartAgentCoreCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Agent', '--state-bucket', 'my-bucket'], {
+    const parsed = fresh.parse(['My/Agent', '--state-bucket', 'my-bucket'], {
       from: 'user',
     });
     expect(parsed.opts().stateBucket).toBe('my-bucket');

--- a/tests/unit/cli/local-start-alb.test.ts
+++ b/tests/unit/cli/local-start-alb.test.ts
@@ -95,7 +95,7 @@ describe('createLocalStartAlbCommand', () => {
   it('parses --from-state as a flag (no value)', () => {
     const fresh = createLocalStartAlbCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Alb', '--from-state'], { from: 'user' });
+    const parsed = fresh.parse(['My/Alb', '--from-state'], { from: 'user' });
     expect(parsed.opts().fromState).toBe(true);
   });
 
@@ -103,7 +103,7 @@ describe('createLocalStartAlbCommand', () => {
     const fresh = createLocalStartAlbCommand();
     fresh.action(() => {});
     const parsed = fresh.parse(
-      ['node', 'cdkd', 'My/Alb', '--state-bucket', 'cdkd-state-123'],
+      ['My/Alb', '--state-bucket', 'cdkd-state-123'],
       { from: 'user' }
     );
     expect(parsed.opts().stateBucket).toBe('cdkd-state-123');
@@ -113,7 +113,7 @@ describe('createLocalStartAlbCommand', () => {
     const fresh = createLocalStartAlbCommand();
     fresh.action(() => {});
     const parsed = fresh.parse(
-      ['node', 'cdkd', 'My/Alb', '--lb-port', '80=8080', '443=8443'],
+      ['My/Alb', '--lb-port', '80=8080', '443=8443'],
       { from: 'user' }
     );
     expect(parsed.opts().lbPort).toEqual(['80=8080', '443=8443']);
@@ -122,7 +122,7 @@ describe('createLocalStartAlbCommand', () => {
   it('parses --tls as a boolean flag (no value)', () => {
     const fresh = createLocalStartAlbCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Alb', '--tls'], { from: 'user' });
+    const parsed = fresh.parse(['My/Alb', '--tls'], { from: 'user' });
     expect(parsed.opts().tls).toBe(true);
   });
 });

--- a/tests/unit/cli/local-start-api-assume-role-auto.test.ts
+++ b/tests/unit/cli/local-start-api-assume-role-auto.test.ts
@@ -207,13 +207,13 @@ describe('createLocalStartApiCommand --assume-role-auto flag plumbing', () => {
 
   it('--assume-role-auto defaults to false', () => {
     const cmd = freshCommand();
-    const parsed = cmd.parse(['node', 'cdkd'], { from: 'user' });
+    const parsed = cmd.parse([], { from: 'user' });
     expect(parsed.opts().assumeRoleAuto).toBe(false);
   });
 
   it('parses bare --assume-role-auto as assumeRoleAuto=true', () => {
     const cmd = freshCommand();
-    const parsed = cmd.parse(['node', 'cdkd', '--assume-role-auto'], { from: 'user' });
+    const parsed = cmd.parse(['--assume-role-auto'], { from: 'user' });
     expect(parsed.opts().assumeRoleAuto).toBe(true);
   });
 });

--- a/tests/unit/cli/local-start-api-from-state.test.ts
+++ b/tests/unit/cli/local-start-api-from-state.test.ts
@@ -41,20 +41,20 @@ describe('createLocalStartApiCommand --from-state flag plumbing', () => {
 
   it('--from-state defaults to false', () => {
     const cmd = freshCommand();
-    const parsed = cmd.parse(['node', 'cdkd'], { from: 'user' });
+    const parsed = cmd.parse([], { from: 'user' });
     expect(parsed.opts().fromState).toBe(false);
   });
 
   it('parses bare --from-state as fromState=true', () => {
     const cmd = freshCommand();
-    const parsed = cmd.parse(['node', 'cdkd', '--from-state'], { from: 'user' });
+    const parsed = cmd.parse(['--from-state'], { from: 'user' });
     expect(parsed.opts().fromState).toBe(true);
   });
 
   it('parses --stack-region <region> as stackRegion=<region>', () => {
     const cmd = freshCommand();
     const parsed = cmd.parse(
-      ['node', 'cdkd', '--from-state', '--stack-region', 'us-west-2'],
+      ['--from-state', '--stack-region', 'us-west-2'],
       { from: 'user' }
     );
     expect(parsed.opts().stackRegion).toBe('us-west-2');
@@ -63,7 +63,7 @@ describe('createLocalStartApiCommand --from-state flag plumbing', () => {
   it('parses --state-bucket <bucket> as stateBucket=<bucket>', () => {
     const cmd = freshCommand();
     const parsed = cmd.parse(
-      ['node', 'cdkd', '--from-state', '--state-bucket', 'my-state-bucket'],
+      ['--from-state', '--state-bucket', 'my-state-bucket'],
       { from: 'user' }
     );
     expect(parsed.opts().stateBucket).toBe('my-state-bucket');
@@ -71,14 +71,14 @@ describe('createLocalStartApiCommand --from-state flag plumbing', () => {
 
   it('defaults --state-prefix to "cdkd"', () => {
     const cmd = freshCommand();
-    const parsed = cmd.parse(['node', 'cdkd'], { from: 'user' });
+    const parsed = cmd.parse([], { from: 'user' });
     expect(parsed.opts().statePrefix).toBe('cdkd');
   });
 
   it('parses --state-prefix <prefix> as statePrefix=<prefix>', () => {
     const cmd = freshCommand();
     const parsed = cmd.parse(
-      ['node', 'cdkd', '--from-state', '--state-prefix', 'custom-prefix'],
+      ['--from-state', '--state-prefix', 'custom-prefix'],
       { from: 'user' }
     );
     expect(parsed.opts().statePrefix).toBe('custom-prefix');

--- a/tests/unit/cli/local-start-cloudfront.test.ts
+++ b/tests/unit/cli/local-start-cloudfront.test.ts
@@ -83,7 +83,7 @@ describe('createLocalStartCloudFrontCommand', () => {
   it('parses --tls as a boolean flag (no value)', () => {
     const fresh = createLocalStartCloudFrontCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Dist', '--tls'], { from: 'user' });
+    const parsed = fresh.parse(['My/Dist', '--tls'], { from: 'user' });
     expect(parsed.opts().tls).toBe(true);
   });
 
@@ -91,7 +91,7 @@ describe('createLocalStartCloudFrontCommand', () => {
     const fresh = createLocalStartCloudFrontCommand();
     fresh.action(() => {});
     const parsed = fresh.parse(
-      ['node', 'cdkd', 'My/Dist', '--origin', 'O1=./dist', '--origin', 'O2=./admin'],
+      ['My/Dist', '--origin', 'O1=./dist', '--origin', 'O2=./admin'],
       { from: 'user' }
     );
     expect(parsed.opts().origin).toEqual(['O1=./dist', 'O2=./admin']);
@@ -100,7 +100,7 @@ describe('createLocalStartCloudFrontCommand', () => {
   it('parses --port <port>', () => {
     const fresh = createLocalStartCloudFrontCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'My/Dist', '--port', '8080'], { from: 'user' });
+    const parsed = fresh.parse(['My/Dist', '--port', '8080'], { from: 'user' });
     expect(parsed.opts().port).toBe('8080');
   });
 });

--- a/tests/unit/cli/local-start-service.test.ts
+++ b/tests/unit/cli/local-start-service.test.ts
@@ -85,14 +85,14 @@ describe('createLocalStartServiceCommand', () => {
   it('parses --max-tasks <n> as a positive integer', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '5'], { from: 'user' });
+    const parsed = fresh.parse(['Svc', '--max-tasks', '5'], { from: 'user' });
     expect(parsed.opts().maxTasks).toBe(5);
   });
 
   it('parses --restart-policy values', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--restart-policy', 'always'], {
+    const parsed = fresh.parse(['Svc', '--restart-policy', 'always'], {
       from: 'user',
     });
     expect(parsed.opts().restartPolicy).toBe('always');
@@ -102,7 +102,7 @@ describe('createLocalStartServiceCommand', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
     expect(() =>
-      fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '0'], { from: 'user' })
+      fresh.parse(['Svc', '--max-tasks', '0'], { from: 'user' })
     ).toThrow(/--max-tasks must be a positive integer/);
   });
 
@@ -110,14 +110,14 @@ describe('createLocalStartServiceCommand', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
     expect(() =>
-      fresh.parse(['node', 'cdkd', 'Svc', '--restart-policy', 'forever'], { from: 'user' })
+      fresh.parse(['Svc', '--restart-policy', 'forever'], { from: 'user' })
     ).toThrow(/--restart-policy must be one of/);
   });
 
   it('parses --no-pull as pull=false (Commander auto-negation)', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--no-pull'], { from: 'user' });
+    const parsed = fresh.parse(['Svc', '--no-pull'], { from: 'user' });
     expect(parsed.opts().pull).toBe(false);
   });
 
@@ -129,7 +129,7 @@ describe('createLocalStartServiceCommand', () => {
     // octet (the shared-svc network's `169.254.171.0/24`).
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '83'], { from: 'user' });
+    const parsed = fresh.parse(['Svc', '--max-tasks', '83'], { from: 'user' });
     expect(parsed.opts().maxTasks).toBe(83);
   });
 
@@ -145,7 +145,7 @@ describe('createLocalStartServiceCommand', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
     expect(() =>
-      fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '84'], { from: 'user' })
+      fresh.parse(['Svc', '--max-tasks', '84'], { from: 'user' })
     ).toThrow(/--max-tasks 84 exceeds the per-replica link-local \/24 subnet allocator's range \(83\)/);
   });
 
@@ -153,7 +153,7 @@ describe('createLocalStartServiceCommand', () => {
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
     expect(() =>
-      fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '100'], { from: 'user' })
+      fresh.parse(['Svc', '--max-tasks', '100'], { from: 'user' })
     ).toThrow(/--max-tasks 100 exceeds.*83/);
   });
 });

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -458,7 +458,13 @@ describe('cli/options.ts', () => {
       cmd.action(() => {
         // no-op; we read opts off the parsed command below
       });
-      cmd.parse(['node', 'cdkd', ...args], { from: 'user' });
+      // `from: 'user'` means the array is USER arguments — it carries no
+      // argv[0]/argv[1] prefix. An `['node', 'cdkd', ...]` prefix made those
+      // two excess operands on a command declaring no `.argument()`.
+      // Measured: commander 12 accepted them (they landed in `cmd.args`),
+      // commander 14 rejects with "too many arguments. Expected 0 arguments
+      // but got 2" — with or without an action handler.
+      cmd.parse(args, { from: 'user' });
       return cmd.opts<{ resourceTimeout?: ResourceTimeoutOption }>().resourceTimeout;
     }
 

--- a/tests/unit/scripts/commander-parse-from-user-convention.test.ts
+++ b/tests/unit/scripts/commander-parse-from-user-convention.test.ts
@@ -1,0 +1,229 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * A `parse(argv, { from: 'user' })` call must not carry an argv[0]/argv[1]
+ * prefix.
+ *
+ * `from: 'user'` tells Commander the array is USER arguments — everything
+ * after the script name. Handing it an argv-shaped array makes the leading
+ * `node` / `cdkd` OPERANDS. Measured on commander 12.1.0 against a command
+ * declaring `<target>`:
+ *
+ *     parse(['node', 'cdkd', 'My/Dist', '--tls'], { from: 'user' })
+ *       -> processedArgs = ["node"]        args = ["node","cdkd","My/Dist"]
+ *     parse(['My/Dist', '--tls'], { from: 'user' })
+ *       -> processedArgs = ["My/Dist"]     args = ["My/Dist"]
+ *
+ * So the case believed it was targeting `My/Dist` while the command received
+ * `node`. Every such site asserted only `opts()`, which parses identically
+ * either way, so the whole family passed while exercising a target no user
+ * would ever type.
+ *
+ * The second cost is forward-looking: a command declaring no `.argument()`
+ * tolerated the excess operands on commander 12 but ERRORS from 14 on
+ * ("too many arguments"). Under `tests/setup.ts`, whose stream fence drops a
+ * passing test's stderr, that arrives as a silent `error()` — 19 such sites
+ * were found this way while evaluating the bump (go-to-k/cdkd#2533), each in
+ * a test reporting green.
+ *
+ * Both failure modes are invisible from reading the assertion, which is why
+ * this is a source-shape lint rather than a runtime one.
+ *
+ * Out of scope by construction: a call with NO `from` option (or
+ * `from: 'node'`) is argv-shaped BY DEFINITION and must keep its prefix —
+ * `program.parseAsync(['node', 'cdkd', 'deploy'])` is correct and common.
+ *
+ * Per "a checker must prove it sees its input" (.claude/rules/testing.md),
+ * the scan carries a file-count floor and a floor on the number of
+ * `from: 'user'` sites it actually recognized, so a walker or matcher
+ * regression cannot pass vacuously.
+ */
+
+const TESTS_ROOT = join(import.meta.dirname, '..', '..');
+
+/**
+ * One `parse(...)` / `parseAsync(...)` call, matched across line breaks:
+ * the sites in this repo wrap in three different shapes (all on one line,
+ * array on its own line, options object on its own line), and a line-anchored
+ * needle silently misses the wrapped ones — which is exactly how the first
+ * sweep of this family left 7 sites behind.
+ */
+const PARSE_CALL_RE = /\.parse(?:Async)?\s*\(\s*(\[[\s\S]*?\])\s*,\s*(\{[\s\S]*?\})\s*,?\s*\)/g;
+
+/** An argv[0]/argv[1] prefix: a runtime, then this repo's binary names. */
+const ARGV_PREFIX_RE = /^\[\s*(['"])(?:node|npx|tsx)\1\s*,\s*(['"])(?:cdkd|cdkl|cdk)\2/;
+
+const FROM_USER_RE = /\bfrom\s*:\s*(['"])user\1/;
+
+/**
+ * Blank out comments, preserving offsets and line structure.
+ *
+ * Not optional hygiene — measured. `local-start-cloudfront.test.ts:23` carries
+ * the prose ``// `cmd.parse([...])` runs the registered `.action(handler)`
+ * body``, and {@link PARSE_CALL_RE}'s non-greedy array ran from that `[` to
+ * the first `]` SIXTY-THREE lines later, swallowing the real violating call at
+ * line 86 inside one match. The scan reported six sites and zero violations
+ * for a file that had one, and only a real-code probe (re-introducing the
+ * prefix and watching the lint stay green) exposed it.
+ *
+ * Quote-aware, because blanking `//` inside a string would corrupt any URL a
+ * fixture carries and shift the very offsets this exists to keep honest.
+ */
+function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i]!;
+    const next = source[i + 1];
+    if (c === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') {
+        out += ' ';
+        i++;
+      }
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        out += source[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      out += '  ';
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c;
+      out += c;
+      i++;
+      while (i < source.length) {
+        out += source[i];
+        if (source[i] === '\\') {
+          i++;
+          if (i < source.length) out += source[i];
+          i++;
+          continue;
+        }
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function walkTestFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'cdk.out') continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkTestFiles(full, out);
+    } else if (
+      entry.endsWith('.test.ts') &&
+      // Skip this lint itself — its doc comment spells the banned shape out
+      // as prose, which would self-match.
+      entry !== 'commander-parse-from-user-convention.test.ts'
+    ) {
+      out.push(full);
+    }
+  }
+}
+
+interface Site {
+  readonly file: string;
+  readonly array: string;
+}
+
+function collectFromUserSites(files: string[]): { sites: Site[]; violations: Site[] } {
+  const sites: Site[] = [];
+  const violations: Site[] = [];
+  for (const file of files) {
+    const source = stripComments(readFileSync(file, 'utf8'));
+    for (const match of source.matchAll(PARSE_CALL_RE)) {
+      const [, array, options] = match as unknown as [string, string, string];
+      if (!FROM_USER_RE.test(options)) continue;
+      const site: Site = { file: file.replace(`${TESTS_ROOT}/`, 'tests/'), array };
+      sites.push(site);
+      if (ARGV_PREFIX_RE.test(array)) violations.push(site);
+    }
+  }
+  return { sites, violations };
+}
+
+describe("commander parse(argv, { from: 'user' }) must not carry an argv prefix", () => {
+  const files: string[] = [];
+  walkTestFiles(TESTS_ROOT, files);
+  const { sites, violations } = collectFromUserSites(files);
+
+  it('scans a plausible number of test files (walker coverage floor)', () => {
+    expect(files.length).toBeGreaterThan(400);
+  });
+
+  it("recognizes the repo's from: 'user' parse sites (matcher coverage floor)", () => {
+    // ~50 such calls at the time of writing, across the local-* CLI suites.
+    // A matcher that stops recognizing the wrapped call shapes drops well
+    // below this, which is the regression that would make the check vacuous.
+    expect(sites.length).toBeGreaterThan(30);
+  });
+
+  it('matches the wrapped call shapes, not just the single-line one', () => {
+    // The single-line and array-on-its-own-line spellings both occur in this
+    // repo. Deriving the check from a synthetic pair keeps it honest about
+    // the multi-line half even if every real site were reformatted.
+    const probe = [
+      "cmd.parse(['--flag'], { from: 'user' });",
+      "cmd.parse(\n  ['node', 'cdkd', 'Target', '--flag'],\n  { from: 'user' }\n);",
+    ].join('\n');
+    const matches = [...probe.matchAll(PARSE_CALL_RE)].filter((m) =>
+      FROM_USER_RE.test(m[2] as string)
+    );
+    expect(matches).toHaveLength(2);
+    expect(ARGV_PREFIX_RE.test(matches[0]![1] as string)).toBe(false);
+    expect(ARGV_PREFIX_RE.test(matches[1]![1] as string)).toBe(true);
+  });
+
+  it('a commented-out parse call cannot swallow the real one after it', () => {
+    // The exact shape that defeated the first cut of this check, reduced:
+    // prose whose `[` opens 60-odd lines before the first `]`. Without
+    // `stripComments` the two calls below collapse into ONE match whose array
+    // starts in the comment, so the violation goes unseen.
+    const probe = [
+      "// `cmd.parse([...])` runs the registered `.action(handler)` body.",
+      "cmd.parse(['node', 'cdkd', 'My/Dist', '--tls'], { from: 'user' });",
+    ].join('\n');
+
+    const rawViolations = [...probe.matchAll(PARSE_CALL_RE)].filter(
+      (m) => FROM_USER_RE.test(m[2] as string) && ARGV_PREFIX_RE.test(m[1] as string)
+    );
+    expect(rawViolations, 'unstripped: the comment hides it — this is the defect').toHaveLength(0);
+
+    const strippedViolations = [...stripComments(probe).matchAll(PARSE_CALL_RE)].filter(
+      (m) => FROM_USER_RE.test(m[2] as string) && ARGV_PREFIX_RE.test(m[1] as string)
+    );
+    expect(strippedViolations, 'stripped: the real call is visible').toHaveLength(1);
+  });
+
+  it('blanks comments without touching a // inside a string literal', () => {
+    const probe = `const url = 'https://example.com/x'; // trailing\ncmd.parse(['a'], { from: 'user' });`;
+    const stripped = stripComments(probe);
+    expect(stripped).toContain("'https://example.com/x'");
+    expect(stripped).not.toContain('trailing');
+    // Offsets are preserved, so a reported position still points at the source.
+    expect(stripped).toHaveLength(probe.length);
+  });
+
+  it("no from: 'user' parse passes an argv[0]/argv[1] prefix", () => {
+    expect(
+      violations.map((v) => `${v.file}: ${v.array.replace(/\s+/g, ' ').slice(0, 80)}`),
+      "`from: 'user'` means the array is USER arguments — drop the leading runtime/binary names, or remove the `from` option if the array really is argv"
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Prerequisite for the `commander` 12 -> 14 bump (dependabot #2533), but **correct and worth landing on its own** — the defect below is live on the commander 12 this branch still pins.

## The defect

`from: 'user'` tells Commander the array is USER arguments — everything after the script name — so an `['node', 'cdkd', ...]` prefix makes those two OPERANDS. 22 call sites across 8 files did that.

Measured on the **currently pinned commander 12.1.0**, against a command declaring `<target>`:

```
parse(['node', 'cdkd', 'My/Dist', '--tls'], { from: 'user' })
  -> processedArgs = ["node"]     args = ["node","cdkd","My/Dist"]
parse(['My/Dist', '--tls'], { from: 'user' })
  -> processedArgs = ["My/Dist"]  args = ["My/Dist"]
```

So the `local-start-cloudfront`, `local-start-alb`, `local-start-agentcore`, `local-start-service` and `local-run-task` cases believed they were parsing their real target and were handing the command `node`. Every one asserts only `opts()`, which parses identically either way — which is why the whole family passed while exercising a target no user would ever type.

## The second cost, which is what surfaced it

A command declaring no `.argument()` tolerated the excess operands on commander 12 but calls `error()` from 14 on. `tests/setup.ts` no-ops `process.exit`, and its stream fence drops a passing test's stderr, so under 14 that lands as a **silent failure inside a green test**.

Measured in a cdkd worktree with `overrides: { commander: ^14.0.0 }`:

| | before this change | after |
| --- | --- | --- |
| hard failures | 3 (`options.test.ts`) | 0 |
| silent `error()` calls in passing tests | 19 | 0 |

Zero is also what commander 12 gives, so the fix is neutral on the pinned version and required on the next one.

## The fence

`tests/unit/scripts/commander-parse-from-user-convention.test.ts`. Neither failure mode is visible from reading an assertion, so this is a source-shape lint.

Two things about it are load-bearing, and both came out of probing it rather than writing it:

- **It strips comments before scanning.** Without that, `local-start-cloudfront.test.ts:23`'s prose ``// `cmd.parse([...])` runs the registered `.action(handler)` body`` opened a non-greedy array match that ran to the first `]` **sixty-three lines later**, swallowing the real call at line 86 inside one match. The scan reported six sites and zero violations for a file that had one.
- **That miss was found by the real-code probe** the testing rules require — re-introduce a violation, watch the checker — not by a synthetic fixture. And line 86 turned out to be a genuine site this branch's own sweep had missed, not the probe's own edit. Both halves are now regression cases in the fence.

Calibration: 53 `from: 'user'` sites across 990 test files. The checker carries floors on the file count and on the recognized-site count, so a walker or matcher regression cannot pass vacuously.

## Out of scope by construction

A call with no `from` option is argv-shaped **by definition** and keeps its prefix — `program.parseAsync(['node', 'cdkd', 'deploy'])` is correct, is exercised by `program.test.ts` / `deploy-unaddressed-exit.test.ts` / `config-loader.test.ts`, and is untouched. The lint only inspects calls whose options object carries `from: 'user'`.

## Verification

- `vp run check`, `vp run typecheck:test`, `vp run build`: pass.
- `vp test run`: **993 files, 21883 passed / 1 skipped**.
- The 46 files containing a `from: 'user'` parse, re-run with `CDKD_TEST_STREAM_PASSTHROUGH=1` so the stream fence cannot hide a commander `error()`: 1339 passed, **0** commander error lines — on commander 12 (unchanged baseline) and on a forced commander 14.

No `changelog.d/` entry: tests only, no shipped-binary behaviour delta.

## Follow-on

The `commander` bump itself is blocked until `cdk-local` releases a version on the same major (go-to-k/cdk-local#723) — cdkd and cdk-local must resolve ONE commander copy, since cdk-local's command factories are spliced into cdkd's tree. Node-floor context for stopping at 14 rather than 15: #3037.