### PR TITLE
chore(integ): record the maintainer-side gating runs for the 2809 merge

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -151,7 +151,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-11T13:26:54Z	PASS	99	verify.sh	rc ok, orph clean; broad run for go-to-k/cdkd#2809
+lambda	2026-09-11T18:26:05Z	PASS	101	verify.sh	maintainer-side broad run gating PR 3020 at e67d273; 9 del 0 err 0 orph
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans
@@ -266,7 +266,7 @@ schema-v7-to-v8-migration	2026-08-01T09:51:12Z	PASS	92	verify.sh	0801 regression
 schema-v8-to-v9-migration	2026-08-26T02:45:22Z	PASS	171	verify.sh	maintainer-side run at post-blocker-fix head; v8 shadow repro + v9 migration, 0 err 0 orphans
 schema-v9-to-v10-migration	2026-09-11T10:27:16Z	PASS	158	verify.sh	re-run after rebase onto 2948
 sdk-ccapi-crossref	2026-08-10T04:23:28Z	PASS	85	verify.sh	0810 sweep b2; post-#1355 CC snapshot path, heterogeneous routing, 4 del 0 err, 0 orph
-sdk-to-cc-autoroute	2026-09-11T13:24:52Z	PASS	275	verify.sh	rc ok, orph clean; phases 4b/4c pin go-to-k/cdkd#2809 (pre-fix build FAILS 4b)
+sdk-to-cc-autoroute	2026-09-11T18:26:05Z	PASS	168	verify.sh	maintainer-side run gating PR 3020 at e67d273; phases 4b/4c rendered 'updated (metadata)'; 1 del 0 err 0 orph
 secrets-array-nested	2026-09-10T08:15:35Z	PASS	90	verify.sh	rc0 after fixture retired the plaintext residual (#2852); first run FAILed on the old assertion
 secrets-dynamic-ref	2026-09-11T06:24:07Z	PASS	461	verify.sh	gating PR 2945; RE-RUN after the harness killed the first attempt mid-deploy, which left state+secret+2 ssm+lambda+role orphans; the re-run cleaned them and verified 0 surviving versions
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean


### PR DESCRIPTION
## Summary

Records the two real-AWS integ runs that gated the go-to-k/cdkd#2809 merge, replacing the contributor's rows for the same fixtures.

Both rows in that PR were truthful records of runs on the contributor's own account. markgate markers are per-worktree, so the merge still required runs here — these are the ones that actually flipped `integ-broad` and `integ-destroy`.

| fixture | result | destroy | note |
| --- | --- | --- | --- |
| `sdk-to-cc-autoroute` | PASS, 168 s | 1 deleted, 0 errors, 0 orphans | phases 4b/4c rendered `updated (metadata)`, not the bare `updated` sentinel |
| `lambda` (broad set) | PASS, 101 s | 9 deleted, 0 errors, 0 orphans | SQS / IAM / Lambda / LayerVersion / DynamoDB Table + GlobalTable DAG |

The `sdk-to-cc-autoroute` row is the one carrying evidence: the verb it asserts is the live observation that the fix works on a real CloudWatch alarm, against the maintainer account rather than the contributor's.

## Why a separate branch

The rows describe runs on this account, not the contributor's change. Pushing a maintainer commit onto their fork branch would have restarted their CI for a data file and put a maintainer commit on a contributor PR.

## Verification

- `vp run check`, `typecheck:test`, `build`, `gen:all-matrices`, `audit:coverage:check` — all clean.
- `vp test run` — 992 files, 21884 passed, 1 skipped.
- One-row-per-test invariant confirmed after `vp run integ-ledger-normalize`.

Worth recording, because it cost a wrong diagnosis first: this worktree's `node_modules` had drifted from the lockfile (`@aws-sdk/client-s3` 3.1126.0 against the pinned 3.1129.0). That made `vp run check` exit 1 on a pristine `main` tree, and made `gen:all-matrices` report a CI-blocking `no-sdk-member` divergence for `ObjectLockConfiguration.Rule.DefaultRetention.DefaultEventHold` — the property go-to-k/cdkd#3002 had just added. Both symptoms pointed at `main` being broken; neither was, and `main`'s own CI was green throughout. `pnpm install --frozen-lockfile` cleared both.

The mtime spot-check `/verify-pr` step 0 prescribes (`pnpm-lock.yaml` older than `node_modules/.modules.yaml`) PASSED throughout — an install had run, just not from this lockfile — so it does not detect this class.
