### PR TITLE
docs(readme): lead with the short catch line, keep the mechanism below it

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
   <a href="./LICENSE">
     <img src="https://img.shields.io/npm/l/@go-to-k/cdkd.svg" alt="License: Apache-2.0" />
   </a>
-  <h3>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</h3>
+  <h3>The fastest way to deploy AWS CDK.</h3>
+  <p>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</p>
   <p>
     📚 Documentation: <a href="https://cdkd.dev"><b>cdkd.dev</b></a>
   </p>


### PR DESCRIPTION
## What

Split the README hero's single `<h3>` into two tiers:

```html
<h3>The fastest way to deploy AWS CDK.</h3>
<p>Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.</p>
```

## Why

The positioning sentence is the most accurate one-liner we have — it is also the GitHub About text, `package.json`'s `description`, and `src/cli/program.ts`'s CLI description. But putting it in the `<h3>` meant the heaviest type on the page carried a line that has to be **read** rather than scanned: it wraps to two lines even at a 1280px viewport (see the before/after below).

The fix is hierarchy, not deletion. The short catch line takes the heading; the positioning sentence keeps every word one tier down.

This also makes the README hero match what `docs/index.md` (the cdkd.dev landing page) has been doing all along — `hero.text` is already `The fastest way to deploy AWS CDK.` with the long sentence as `hero.tagline` — and it matches the OGP image, which renders the same short line for the home page (`docs-site/og-template.ts`). So a visitor arriving from a social card now lands on the same words.

## What is deliberately unchanged

- The positioning sentence is **verbatim**, so README / GitHub About / `package.json` / `src/cli/program.ts` still read identically. No surface drifts out of sync.
- Both differentiators stay above the fold: drop-in compatibility, the 15x number, and — the part the bullet list below does *not* carry — "instead of CloudFormation". The existing bullet says `direct SDK calls` but never names what is being bypassed, which is the actual mechanism and the actual differentiator.

## Verification

- `vp run check`, `vp run typecheck:test`, `vp run build`: pass.
- `vp test run`: 992 files, 21877 passed / 1 skipped, no type errors.
- Confirmed nothing pins the old heading text: no hit for the tagline in `tests/`, `scripts/`, or `.claude/`.
- Rendered the branch's README on GitHub at a 1280px desktop viewport and compared against `main`.

No changelog entry: README-only, no behavior delta in the shipped binary.
