### PR TITLE
docs(deploy-engine): the step 3.5 comment claimed it cannot throw, and it can

### DIFF
--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -2824,10 +2824,18 @@ export class DeployEngine {
       // info-log that cdkd is auto-routing it via Cloud Control (which
       // forwards the full property map). For each resource explicitly
       // opted out via `--allow-unsupported-properties Type:Prop`, warn
-      // that the silent drop has been accepted. No throw — the legacy
-      // PR #608 fail-fast was reversed by #614 to a default-on
-      // auto-route. Skips AWS::CDK::Metadata (filtered by the same
-      // predicate as the type set).
+      // that the silent drop has been accepted. Neither of those throws —
+      // the legacy PR #608 fail-fast was reversed by #614 to a default-on
+      // auto-route — but this step CAN still refuse, and the comment said
+      // it could not until issue #3028. A drop on a type the Cloud Control
+      // route cannot serve (`isNonProvisionable`, or a provider declaring
+      // `disableCcApiFallback`) has nowhere to be auto-routed, so
+      // `ProviderRegistry.reportSilentDropDecisions` throws rather than
+      // letting the route fail later with an opaque error. That refusal
+      // lands HERE — ahead of the DAG at step 4 and the diff at step 5 —
+      // so the deploy ends having provisioned nothing. Skips
+      // AWS::CDK::Metadata (filtered by the same predicate as the type
+      // set).
       const resourcesForPropertyCheck = Object.entries(effectiveTemplate.Resources || {})
         .filter(([, r]) => r.Type !== 'AWS::CDK::Metadata')
         .map(([logicalId, r]) => ({


### PR DESCRIPTION
## Summary

Closes #3028.

The comment above `validateResourceProperties` (step 3.5) claimed the step cannot throw. It can.

`validateResourceProperties` (`src/provisioning/provider-registry.ts:721`) calls `reportSilentDropDecisions` (`:734` → `:797`), which throws at `:843` whenever a resource carries an actionable silent drop **and** the type is `isNonProvisionable` or its provider sets `disableCcApiFallback === true` — the sub-case Cloud Control cannot serve, so the auto-route has nowhere to send it.

## Why it mattered

The comment sits directly above the call, which is where a reader decides whether this step can abort a deploy. Step 3.5 runs ahead of the DAG (step 4) and the diff (step 5), so a throw here ends the deploy having provisioned nothing — a materially different control flow from the report-and-continue the comment described. Anyone reasoning about where a deploy can exit, or adding error handling around the pre-flight block, was reading a false premise.

The clause was written when go-to-k/cdkd#614 reversed the go-to-k/cdkd#608 fail-fast, and was not revisited when the unroutable sub-case was added back.

`.claude/rules/layout-provisioning.md` already recorded the exception — "The only throw on this path is the sub-case Cloud Control cannot serve (`isNonProvisionable` / `disableCcApiFallback`)" — so the rules corpus and the code comment disagreed. They now agree.

## Scope

Comment only. No behavior change, hence no changelog entry and no test.

A source-text fence over the comment was considered and skipped, as the issue anticipated: it would pin the wording rather than the claim, and the claim is already carried by the rules-corpus sentence above.

**Deliberately not changed in the same edit**: the comment names `--allow-unsupported-properties`, deprecated in favour of `--prefer-sdk-route` but still accepted until the first minor release after 2026-12-01 (`src/cli/options.ts:808`). Dozens of sibling mentions across `src/provisioning/**` use the same spelling, so renaming this one alone would leave a half-applied refactor.

## Verification

- `vp run check`, `typecheck:test`, `build`, `gen:all-matrices`, `audit:coverage:check` — all rc=0.
- `vp test run` — 992 files, 21884 passed, 1 skipped.
- Call chain and step ordering re-derived from source rather than from the issue: `:721` → `:734` → `:797` → throw at `:843`; step 4 is "Build dependency graph", step 5 is "Calculate diff".
- `integ-broad` is fresh from a `lambda` run earlier today (0 errors, 0 orphans); this change is comment-only and touches no routing or deletion logic.

Found while reviewing go-to-k/cdkd#3020.
