### PR TITLE
chore(hooks): stop integ-destroy's patterns doing two jobs in one regex

### DIFF
--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -191,7 +191,14 @@ if [ -n "$diff_base" ]; then
   # have called stale. Measured. It also aligns this list with what markgate
   # actually digests -- its `DiffFrom` runs `--no-renames` too, so without the
   # flag the gate and the marker disagree about which files moved.
-  if ! changed_files=$(git diff --name-only --no-renames "$diff_base"...HEAD 2>/dev/null); then
+  # `-c core.quotePath=false`: the default is TRUE, so a path carrying a
+  # non-ASCII byte is printed C-quoted --
+  # `"src/provisioning/providers/caf\303\251-provider.ts"` -- and the leading
+  # `"` defeats the `^src/` anchor in all three patterns below, so the file
+  # matches nothing and the gate is skipped without consulting markgate. Same
+  # fail-open family as the rename flag beside it (issue 3047). Zero such paths
+  # exist in this repo today; the flag costs nothing for ASCII ones.
+  if ! changed_files=$(git -c core.quotePath=false diff --name-only --no-renames "$diff_base"...HEAD 2>/dev/null); then
     diff_base=""
   fi
 fi
@@ -228,11 +235,25 @@ if [ -n "$diff_base" ]; then
   # positives on substrings (e.g. an unrelated word containing `eni`)
   # — which only cost an integ-test run, vs false negatives that
   # cost a broken main.
-  delete_symbol_pattern='^[-+][^-+].*(delete|rollback|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)'
+  # Both patterns below used to open `^[-+][^-+]`, which did TWO jobs in one
+  # regex: skip the `+++` / `---` file headers, and match the content. The
+  # `[^-+]` is what skips the header, and it does so by CONSUMING the first
+  # content character — so a symbol starting at column 0 was invisible.
+  # Measured (issue 3046): `+delete globalThis.cache;` and `+deleteStack(name);`
+  # scored 0 while their indented twins scored 2. The jobs are separated now:
+  # `header_line_pattern` drops the headers in their own `grep -v` pass, beside
+  # the comment one that was already there, and the two content patterns start
+  # at the first content character.
+  #
+  # The comment pattern carried the mirror of the same bug, in the over-block
+  # direction: a column-0 `//` was NOT recognised as a comment and could arm the
+  # gate. Same fix, both directions closed at once.
+  header_line_pattern='^(\+\+\+|---) '
+  delete_symbol_pattern='^[-+].*(delete|rollback|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)'
   # Lines we consider "comment only" — drop them before the symbol grep.
   # Matches an added/removed line whose first non-whitespace content is
   # a JS/TS/SH comment introducer (`//`, `/*`, `*` mid-block, `#`).
-  comment_line_pattern='^[-+][^-+][[:space:]]*(\*|/\*|//|#)'
+  comment_line_pattern='^[-+][[:space:]]*(\*|/\*|//|#)'
 
   while IFS= read -r f; do
     [ -z "$f" ] && continue
@@ -259,7 +280,18 @@ if [ -n "$diff_base" ]; then
       # suite, including the renamed-provider case below it -- an unfenced flag
       # whose comment claims it is load-bearing is the defect this file keeps
       # finding, so it is left off.
+      # No `:(literal)` on the path, and that is a MEASUREMENT, not an
+      # oversight. What follows `--` is a pathspec, so it was reported that a
+      # file named `a[b]-provider.ts` would name something else and give an
+      # empty per-file diff. Measured against git 2.49 for `[`, `*` and `?`:
+      # the diff is byte-identical with and without `:(literal)`, because a
+      # pathspec that equals the path also matches it literally. The
+      # `git ls-files -- 'kee[p].ts'` demo behind the report shows a glob
+      # matching a DIFFERENT file, which is not what this call does -- `$f`
+      # comes from git's own changed-file list, so it always names a file that
+      # exists. Adding the flag fenced nothing, so it is left off.
       if git diff "$diff_base"...HEAD -- "$f" \
+         | grep -vE "$header_line_pattern" \
          | grep -vE "$comment_line_pattern" \
          | grep -qiE "$delete_symbol_pattern"; then
         delete_touch=1

--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -271,6 +271,25 @@ if [ -n "$diff_base" ]; then
 
   while IFS= read -r f; do
     [ -z "$f" ] && continue
+    # A path git hands back C-QUOTED arms the gate outright. `core.quotePath`
+    # is off above, which covers bytes >= 0x80, but git still quotes a path
+    # containing `"`, `\`, a tab or a newline -- measured on 2.49 with the flag
+    # set. Such a name reaches the buckets with a leading `"`, matches no
+    # `^src/` anchor, and the gate skips WITHOUT consulting markgate: the
+    # fail-open direction. Arming instead costs an integ run on a filename this
+    # repo does not have (`git ls-files | grep -cE '["\\]'` is 0), which is the
+    # trade this file declares everywhere else.
+    #
+    # This is the safe half of the remaining work on issue 3047, not the fix:
+    # correctly BUCKETING such a path needs `-z` and a NUL-delimited read,
+    # which bash cannot do through a variable and which restructures the rc
+    # handling above. That stays with the cross-gate sweep on that issue.
+    case "$f" in
+      '"'*)
+        delete_touch=1
+        break
+        ;;
+    esac
     # Strict-delete files: any change at all is delete-touching.
     if printf '%s' "$f" | grep -qE "$strict_delete"; then
       delete_touch=1
@@ -311,7 +330,25 @@ if [ -n "$diff_base" ]; then
       # glob could match, so it could not discriminate.) `:(literal)` was added,
       # measured to change no verdict, and left off rather than shipped as an
       # unfenced flag.
-      if git diff "$diff_base"...HEAD -- "$f" \
+      # The diff is CAPTURED before it is filtered, so its exit status is
+      # readable. Inside the pipeline it was not: `if` tests the last command,
+      # so a failed `git diff` and a clean one were the same verdict --
+      # `delete_touch` stays 0 and markgate is never consulted. Exactly the
+      # defect this file fixed for the name list above ("A FAILED diff and an
+      # empty one are the same string"), one call later. `PIPESTATUS[0]` is NOT
+      # the fix: `grep -q` exits on its first match and SIGPIPEs git to 141 on
+      # the very path where the gate should arm.
+      #
+      # No case constructs a failing per-file diff, and the comment says so
+      # rather than implying one: once the name-list diff has succeeded, this
+      # one fails only under conditions that would have failed that one too,
+      # which the earlier rc check already routes to markgate. It is
+      # defence-in-depth on the fail-CLOSED side.
+      if ! hunk_diff=$(git diff "$diff_base"...HEAD -- "$f" 2>/dev/null); then
+        delete_touch=1
+        break
+      fi
+      if printf '%s\n' "$hunk_diff" \
          | grep -vE "$header_line_pattern" \
          | grep -vE "$comment_line_pattern" \
          | grep -qiE "$delete_symbol_pattern"; then

--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -217,12 +217,16 @@ if [ -n "$diff_base" ]; then
   # (e.g. an ECS provider doc-comment containing the words "delete/update"
   # tripped the gate even though the diff didn't change any delete code).
   #
-  #   ^[-+]                  added or removed line
-  #   [^-+]                  one non-+/- char so we don't match the diff header `+++`/`---`
+  #   ^[-+]                  added or removed line, from its FIRST content
+  #                          character — this used to be `^[-+][^-+]`, where
+  #                          the `[^-+]` skipped the `+++`/`---` headers by
+  #                          eating that character; the headers have their own
+  #                          `grep -v` pass now (see below).
   #   [[:space:]]*           leading indent
   #   (?!//|\*|#)            negative lookahead — but POSIX grep -E doesn't
   #                          support lookahead. Workaround: filter comment
-  #                          lines with a second grep -v pass below.
+  #                          lines with grep -v passes below, one for the
+  #                          headers and one for comments.
   # `rollback` is included so a refactor that changes the order of
   # `partial state → rollback → final state` in `deploy-engine.ts`
   # (which would leak orphans on failure) trips the gate even when
@@ -252,8 +256,18 @@ if [ -n "$diff_base" ]; then
   delete_symbol_pattern='^[-+].*(delete|rollback|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)'
   # Lines we consider "comment only" — drop them before the symbol grep.
   # Matches an added/removed line whose first non-whitespace content is
-  # a JS/TS/SH comment introducer (`//`, `/*`, `*` mid-block, `#`).
-  comment_line_pattern='^[-+][[:space:]]*(\*|/\*|//|#)'
+  # a JS/TS/SH comment introducer (`//`, `/*`, `*` mid-block, `# `).
+  #
+  # `#` REQUIRES a following space, and that is the fix for a hole this file's
+  # own widening opened plus one that predated it. In TypeScript -- and the
+  # hunk-filtered buckets are 100% `.ts` -- `#name` is a PRIVATE FIELD, not a
+  # comment. Measured: `+#deleteQueue = new Set();` armed the gate under the
+  # old `^[-+][^-+]` pattern and was DROPPED once that pattern lost the
+  # character-eating prefix, and its indented twin `+  #deleteQueue` was
+  # dropped under BOTH. Requiring the space arms both while still dropping a
+  # genuine `# comment`. A shell comment written without a space is now
+  # over-blocked, which costs one integ run rather than a missed one.
+  comment_line_pattern='^[-+][[:space:]]*(\*|/\*|//|#[[:space:]])'
 
   while IFS= read -r f; do
     [ -z "$f" ] && continue
@@ -280,16 +294,23 @@ if [ -n "$diff_base" ]; then
       # suite, including the renamed-provider case below it -- an unfenced flag
       # whose comment claims it is load-bearing is the defect this file keeps
       # finding, so it is left off.
-      # No `:(literal)` on the path, and that is a MEASUREMENT, not an
-      # oversight. What follows `--` is a pathspec, so it was reported that a
-      # file named `a[b]-provider.ts` would name something else and give an
-      # empty per-file diff. Measured against git 2.49 for `[`, `*` and `?`:
-      # the diff is byte-identical with and without `:(literal)`, because a
-      # pathspec that equals the path also matches it literally. The
-      # `git ls-files -- 'kee[p].ts'` demo behind the report shows a glob
-      # matching a DIFFERENT file, which is not what this call does -- `$f`
-      # comes from git's own changed-file list, so it always names a file that
-      # exists. Adding the flag fenced nothing, so it is left off.
+      # No `:(literal)` on the path, and the reasoning is measured -- including
+      # the correction. What follows `--` is a pathspec, so it was reported
+      # that a file named `a[b]-provider.ts` would name something ELSE and give
+      # an empty per-file diff, i.e. a missed delete symbol. It cannot: a
+      # pathspec equal to the path always matches it literally, so the file's
+      # own hunks are always present.
+      #
+      # What the glob DOES do is match SIBLINGS as well. Measured, git 2.49:
+      # `a*b-provider.ts` with two glob-matching siblings returns 3 files under
+      # a plain pathspec and 1 under `:(literal)`. That direction can only
+      # ADD hunks, so it can over-arm and never miss -- and each sibling is
+      # separately iterated by this same loop anyway, so no verdict changes.
+      # (An earlier revision of this comment said the two spellings were
+      # "byte-identical". That was measured on a fixture with no sibling the
+      # glob could match, so it could not discriminate.) `:(literal)` was added,
+      # measured to change no verdict, and left off rather than shipped as an
+      # unfenced flag.
       if git diff "$diff_base"...HEAD -- "$f" \
          | grep -vE "$header_line_pattern" \
          | grep -vE "$comment_line_pattern" \

--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -1083,13 +1083,45 @@ run_case "hunk filter: the +++ header is not read as content (3046)" 0 stale "" 
 # patterns cannot match, so the gate is skipped without consulting markgate.
 #
 # `core.quotePath` defaults to TRUE, so a non-ASCII path comes back C-quoted
-# and the leading `"` defeats every `^src/` anchor. Note this case depends on
-# git's DEFAULT, which is exactly what the config isolation at the top of this
-# file makes reliable -- without it, a maintainer with `core.quotePath=false`
-# globally would see it pass with the fix absent.
+# and the leading `"` defeats every `^src/` anchor.
+#
+# The fence for the FLAG has to be a case whose expected verdict is 0, and the
+# reason is worth stating because the obvious case does not work. An armed
+# (exit 2) non-ASCII case stopped discriminating the moment the quoted-path arm
+# landed: without the flag the path comes back quoted, the arm fires, and the
+# case still scores 2 -- passing without ever reaching the patterns it is named
+# for. Measured: with the flag removed the suite stayed 87/0; removing the flag
+# AND the arm reddened it.
+#
+# So the fence is BUCKETING. A non-ASCII provider path with symbol-free content
+# must score 0: with the flag it is unquoted, matches `provider_pattern`, enters
+# the hunk filter and finds no delete symbol. Without it the leading `"` makes
+# the arm fire instead and the case reds. This one genuinely depends on git's
+# DEFAULT, which is what the config isolation at the top of this file makes
+# reliable -- a maintainer with `core.quotePath=false` globally would otherwise
+# see it pass with the fix absent.
+stage_filter_change "src/provisioning/providers/café-b-provider.ts" \
+  "  private readonly label = 'b';"
+run_case "a non-ASCII path is BUCKETED, not just armed (3047)" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+# And the armed twin, kept as a regression guard rather than a fence: it scores
+# 2 with the flag (reaches `provider_pattern`, finds the symbol) and 2 without
+# it (the quoted-path arm fires), so no mutation of the hook reddens it alone.
 stage_filter_hunk "src/provisioning/providers/café-provider.ts" \
   "  async deleteResource(id: string) { return this.client.send(id); }"
-run_case "a non-ASCII path still reaches the patterns (3047)" 2 stale "$filter_repo" \
+run_case "a non-ASCII path with a delete symbol arms (3047, regression guard)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+# `core.quotePath=false` covers bytes >= 0x80 and nothing else: a path holding
+# `"`, `\`, a tab or a newline still comes back C-quoted, reaches the buckets
+# with a leading `"`, matches no `^src/` anchor, and skips the gate. The hook
+# arms on any quoted path rather than letting that happen -- an integ run on a
+# filename this repo does not have, versus a merge with no destroy verification.
+# Correctly BUCKETING such a path is the `-z` work left on issue 3047.
+stage_filter_hunk 'src/provisioning/providers/qu"ote-provider.ts' \
+  "  async deleteResource(id: string) { return this.client.send(id); }"
+run_case "a C-quoted path arms the gate rather than skipping it (3047)" 2 stale "$filter_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
 
 # A path carrying glob metacharacters is kept as a case even though it fences
@@ -1108,17 +1140,6 @@ run_case "a non-ASCII path still reaches the patterns (3047)" 2 stale "$filter_r
 # of this comment said the two spellings were "byte-identical" -- measured on a
 # fixture with no sibling for the glob to match, so it could not discriminate.
 # `:(literal)` was added, measured to change no verdict, and removed.
-# `core.quotePath=false` covers bytes >= 0x80 and nothing else: a path holding
-# `"`, `\`, a tab or a newline still comes back C-quoted, reaches the buckets
-# with a leading `"`, matches no `^src/` anchor, and skips the gate. The hook
-# arms on any quoted path rather than letting that happen -- an integ run on a
-# filename this repo does not have, versus a merge with no destroy verification.
-# Correctly BUCKETING such a path is the `-z` work left on issue 3047.
-stage_filter_hunk 'src/provisioning/providers/qu"ote-provider.ts' \
-  "  async deleteResource(id: string) { return this.client.send(id); }"
-run_case "a C-quoted path arms the gate rather than skipping it (3047)" 2 stale "$filter_repo" \
-  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
-
 stage_filter_hunk "src/provisioning/providers/a[b]-provider.ts" \
   "  async deleteResource(id: string) { return this.client.send(id); }"
 run_case "a glob-magic path reaches the hunk filter (3047, regression guard)" 2 stale "$filter_repo" \

--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -676,8 +676,10 @@ stage_filter_change() {
   # hook and putting `detach` in a content line gives Fail: 1). It cannot fail
   # open in the dangerous direction, because over-strict is a loud,
   # self-correcting suite failure. The guard is also stricter than the hook by
-  # construction: the hook's `^[-+][^-+]` skips the first content character,
-  # this scans the whole string.
+  # construction: the hook drops comment and header lines with `grep -v` passes
+  # before matching, this scans the whole string. (It used to say the hook's
+  # `^[-+][^-+]` skips the first content character -- that prefix is gone, and
+  # removing it is what issue 3046 was.)
   case "$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')" in
     *delete*|*rollback*|*hyperplane*|*dependencyviolation*|*eni*|*detach*)
       fail=$((fail + 1))
@@ -1014,6 +1016,26 @@ stage_filter_hunk "src/cli/commands/destroy.ts" "// deleteStack is documented he
 run_case "hunk filter: a column-0 comment does NOT arm the gate (3046)" 0 stale "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
 
+# `#` in the comment alternation REQUIRES a following space, because in
+# TypeScript -- and the hunk-filtered buckets are 100% `.ts` -- `#name` is a
+# PRIVATE FIELD. Both directions, both measured:
+#   `+#deleteQueue = new Set();`   armed pre-PR, was DROPPED by the widening
+#                                  above until the space was required
+#   `+  #deleteQueue = new Set();` dropped BOTH before and after the widening
+#                                  -- a hole that predates this PR
+#   `+# delete the bucket`         a genuine comment, still dropped
+stage_filter_hunk "src/cli/commands/destroy.ts" "#deleteQueue = new Set();"
+run_case "hunk filter: a column-0 private field is not a comment (3046)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+stage_filter_hunk "src/cli/commands/destroy.ts" "  #deleteQueue = new Set();"
+run_case "hunk filter: an indented private field is not a comment (3046)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+stage_filter_hunk "src/cli/commands/destroy.ts" "# delete the bucket first"
+run_case "hunk filter: a real '# ' comment is still dropped (3046)" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
 # The header-skipping pass is now separate, so it needs its own case -- and the
 # case has to be a file whose PATH carries delete vocabulary, because that is
 # the only way a `+++ b/<path>` line can match the content pattern. Content is
@@ -1040,15 +1062,21 @@ run_case "a non-ASCII path still reaches the patterns (3047)" 2 stale "$filter_r
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
 
 # A path carrying glob metacharacters is kept as a case even though it fences
-# nothing, because the measurement behind it is worth not repeating: the review
-# that found the quoting defect also reported that the per-file `-- "$f"`
-# pathspec would fail to match `a[b]-provider.ts` and give an empty diff. It
-# does not. Measured for `[`, `*` and `?` against git 2.49: the diff is
-# byte-identical with and without `:(literal)`, because a pathspec equal to the
-# path matches it literally; the `git ls-files -- 'kee[p].ts'` demo behind the
-# report shows a glob matching a DIFFERENT file, which this call cannot do since
-# `$f` comes from git's own changed-file list. `:(literal)` was added, measured
-# to change no verdict, and removed.
+# nothing, because the measurement behind it is worth not repeating -- and
+# because the FIRST version of that measurement was wrong.
+#
+# Reported: the per-file `-- "$f"` pathspec would fail to match
+# `a[b]-provider.ts`, give an empty diff, and miss the delete symbol. It cannot
+# -- a pathspec equal to the path always matches it literally, so the file's own
+# hunks are always there.
+#
+# What the glob DOES do is match SIBLINGS too: measured on git 2.49,
+# `a*b-provider.ts` with two glob-matching siblings returns 3 files plain and 1
+# under `:(literal)`. That can only ADD hunks, so it over-arms and never misses,
+# and each sibling is separately iterated by the same loop. An earlier revision
+# of this comment said the two spellings were "byte-identical" -- measured on a
+# fixture with no sibling for the glob to match, so it could not discriminate.
+# `:(literal)` was added, measured to change no verdict, and removed.
 stage_filter_hunk "src/provisioning/providers/a[b]-provider.ts" \
   "  async deleteResource(id: string) { return this.client.send(id); }"
 run_case "a glob-magic path reaches the hunk filter (3047, regression guard)" 2 stale "$filter_repo" \

--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -993,6 +993,67 @@ for delete_word in hyperplane DependencyViolation ENI; do
     "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
 done
 
+# --- Two jobs in one regex: the column-0 pair (issue 3046) ---
+#
+# `^[-+][^-+]` skipped the `+++` / `---` headers by CONSUMING the first content
+# character, so a delete symbol at column 0 was invisible to the symbol grep and
+# a column-0 `//` was invisible to the comment filter. Measured before the fix:
+# `+deleteStack(name);` scored 0 while `+  deleteStack(name);` scored 2. The
+# header skip is its own `grep -v` pass now, and both content patterns start at
+# the first content character.
+#
+# Both directions, because the two patterns broke in OPPOSITE directions: the
+# symbol one fails open (gate skipped), the comment one fails closed (an
+# unrelated doc comment arms the gate, the PR-73 false positive the filter was
+# added for).
+stage_filter_hunk "src/cli/commands/destroy.ts" "deleteStack({ stackName });"
+run_case "hunk filter: a column-0 delete symbol arms the gate (3046)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+stage_filter_hunk "src/cli/commands/destroy.ts" "// deleteStack is documented here, not called"
+run_case "hunk filter: a column-0 comment does NOT arm the gate (3046)" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+# The header-skipping pass is now separate, so it needs its own case -- and the
+# case has to be a file whose PATH carries delete vocabulary, because that is
+# the only way a `+++ b/<path>` line can match the content pattern. Content is
+# symbol-free (staged through the guard that enforces it), so the ONLY thing
+# that could arm this is the header line.
+stage_filter_change "src/provisioning/providers/delete-marker-provider.ts" \
+  "  private readonly label = 'marker';"
+run_case "hunk filter: the +++ header is not read as content (3046)" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+# --- Paths git does not hand back verbatim (issue 3047) ---
+#
+# Two mechanisms, one consequence: the changed-file list names a file the
+# patterns cannot match, so the gate is skipped without consulting markgate.
+#
+# `core.quotePath` defaults to TRUE, so a non-ASCII path comes back C-quoted
+# and the leading `"` defeats every `^src/` anchor. Note this case depends on
+# git's DEFAULT, which is exactly what the config isolation at the top of this
+# file makes reliable -- without it, a maintainer with `core.quotePath=false`
+# globally would see it pass with the fix absent.
+stage_filter_hunk "src/provisioning/providers/café-provider.ts" \
+  "  async deleteResource(id: string) { return this.client.send(id); }"
+run_case "a non-ASCII path still reaches the patterns (3047)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
+# A path carrying glob metacharacters is kept as a case even though it fences
+# nothing, because the measurement behind it is worth not repeating: the review
+# that found the quoting defect also reported that the per-file `-- "$f"`
+# pathspec would fail to match `a[b]-provider.ts` and give an empty diff. It
+# does not. Measured for `[`, `*` and `?` against git 2.49: the diff is
+# byte-identical with and without `:(literal)`, because a pathspec equal to the
+# path matches it literally; the `git ls-files -- 'kee[p].ts'` demo behind the
+# report shows a glob matching a DIFFERENT file, which this call cannot do since
+# `$f` comes from git's own changed-file list. `:(literal)` was added, measured
+# to change no verdict, and removed.
+stage_filter_hunk "src/provisioning/providers/a[b]-provider.ts" \
+  "  async deleteResource(id: string) { return this.client.send(id); }"
+run_case "a glob-magic path reaches the hunk filter (3047, regression guard)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
 # --- A FAILED diff is not an empty one ---
 #
 # `origin/main` can resolve while sharing no history with HEAD: a shallow clone,

--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -694,6 +694,36 @@ stage_filter_change() {
   printf '%s\n' "$line" > "$filter_repo/$rel"
   git -C "$filter_repo" add -A
   git -C "$filter_repo" -c user.email=t@t -c user.name=t commit -q -m "change $rel"
+  assert_single_file_delta stage_filter_change "$rel"
+}
+
+# Both staging helpers share `filter_repo` and rely on `reset --hard` to carry
+# nothing from the previous case. Nothing asserted that, and the failure would be
+# INVISIBLE: a leftover file can only ADD to the changed-file list, which can
+# only ARM the gate, and every case staged after the first pass-through control
+# expects exit 2. A contaminated fixture would pass for the wrong reason and the
+# tally would stay green.
+#
+# So each staging call proves its own delta is exactly the one file it staged.
+# Cheap, and it covers every case at once rather than one suspicious pair.
+#
+# It asserts the COUNT, not the name. Comparing names was the first spelling and
+# it failed on the two fixtures that matter most: git hands back
+# `"src/…/caf\303\251-provider.ts"` and `"src/…/qu\"ote-provider.ts"` C-quoted,
+# which is the defect those cases exist for -- so a name comparison would have
+# to re-implement git's unquoting to say anything, and would red for the reason
+# under test rather than for contamination.
+assert_single_file_delta() {
+  local helper="$1"; local rel="$2"; local got
+  got=$(git -C "$filter_repo" diff --name-only --no-renames \
+          refs/remotes/origin/main...HEAD | grep -c . || true)
+  if [ "$got" != "1" ]; then
+    fail=$((fail + 1))
+    fail_log+="FAIL $helper left a delta of $got files, not 1, after staging "
+    fail_log+="[$rel] -- a case reading this fixture may arm on the leftover "
+    fail_log+="rather than on what it stages\n"
+    printf 'FAIL %s fixture delta is %s files, not 1 (staged %s)\n' "$helper" "$got" "$rel"
+  fi
 }
 
 # Control: an out-of-scope file must pass through. If this ever blocks, the
@@ -879,6 +909,7 @@ stage_filter_hunk() {
   printf '%s\n' "$line" > "$filter_repo/$rel"
   git -C "$filter_repo" add -A
   git -C "$filter_repo" -c user.email=t@t -c user.name=t commit -q -m "hunk $rel"
+  assert_single_file_delta stage_filter_hunk "$rel"
 }
 
 # A provider whose diff ADDS a delete symbol: the hunk filter must arm the gate.

--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -1077,6 +1077,17 @@ run_case "a non-ASCII path still reaches the patterns (3047)" 2 stale "$filter_r
 # of this comment said the two spellings were "byte-identical" -- measured on a
 # fixture with no sibling for the glob to match, so it could not discriminate.
 # `:(literal)` was added, measured to change no verdict, and removed.
+# `core.quotePath=false` covers bytes >= 0x80 and nothing else: a path holding
+# `"`, `\`, a tab or a newline still comes back C-quoted, reaches the buckets
+# with a leading `"`, matches no `^src/` anchor, and skips the gate. The hook
+# arms on any quoted path rather than letting that happen -- an integ run on a
+# filename this repo does not have, versus a merge with no destroy verification.
+# Correctly BUCKETING such a path is the `-z` work left on issue 3047.
+stage_filter_hunk 'src/provisioning/providers/qu"ote-provider.ts' \
+  "  async deleteResource(id: string) { return this.client.send(id); }"
+run_case "a C-quoted path arms the gate rather than skipping it (3047)" 2 stale "$filter_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$filter_repo")"
+
 stage_filter_hunk "src/provisioning/providers/a[b]-provider.ts" \
   "  async deleteResource(id: string) { return this.client.send(id); }"
 run_case "a glob-magic path reaches the hunk filter (3047, regression guard)" 2 stale "$filter_repo" \


### PR DESCRIPTION
## What this changes

Four fail-opens in `integ-destroy-gate.sh`'s changed-file pre-filter, all in the
same handful of lines. Two were filed from the review rounds on
go-to-k/cdkd#3026; one was introduced by this PR's own first revision and caught
in review; one was found in round 2.

### Two jobs in one regex (go-to-k/cdkd#3046)

`delete_symbol_pattern` and `comment_line_pattern` both opened `^[-+][^-+]`,
conflating "skip the `+++` / `---` file headers" with "match the content". The
`[^-+]` does the skipping by **consuming the first content character**, so
anything at column 0 was invisible:

| changed line in a hunk-filtered file | before | after |
| --- | --- | --- |
| `+deleteStack(name);` | **0 — gate skipped** | 2 |
| `+// deleteStack is documented here` | **2 — gate armed** | 0 |

The header skip is its own `grep -v` pass now, and both content patterns start
at the first content character.

Widening the comment pattern then opened a hole of its own, which review caught:
in TypeScript — and both hunk-filtered buckets are 100% `.ts` — `#name` is a
**private field**, not a comment.

| | pre-PR | after widening | shipped |
| --- | --- | --- | --- |
| `+#deleteQueue = new Set();` | ARM | **drop** | ARM |
| `+  #deleteQueue = new Set();` | **drop** | **drop** | ARM |
| `+# delete the bucket` | ARM | drop | drop |

`#` requires a following space, which arms both field shapes — including one
that predates this PR — and still drops a genuine comment.

### Paths git does not hand back verbatim (go-to-k/cdkd#3047, in part)

`core.quotePath` defaults to **true**, so a non-ASCII path comes back C-quoted
(`"src/.../caf\303\251-provider.ts"`) and the leading `"` defeats the `^src/`
anchor in all three bucket patterns: the gate skips without consulting markgate.
Fixed with `-c core.quotePath=false`.

That flag covers bytes >= 0x80 and nothing else — measured, a path holding `"`,
`\`, a tab or a newline is still quoted — so the hook now **arms** on any quoted
path rather than skipping. Correctly bucketing one needs `-z` and a
NUL-delimited read, which bash cannot do through a variable; that stays with the
cross-gate sweep on go-to-k/cdkd#3047, recorded there with the measurement.

### An rc discarded by a pipeline

The per-file `git diff` ran inside the filter pipeline, so a failed diff and a
clean one produced the same verdict — the defect this PR's parent fixed for the
name list, one call later. Captured first now. `PIPESTATUS[0]` is not the fix:
`grep -q` exits on its first match and SIGPIPEs git to 141 on exactly the path
where the gate should arm.

## Two claims this PR got wrong, and how

Both were comments of mine that measurement contradicted, and both are corrected
in place rather than left to be inherited:

- **`:(literal)`.** Added for a reported pathspec-glob fail-open, then retracted
  as "byte-identical with and without" — measured on a fixture with **no sibling
  for the glob to match**, so the measurement could not discriminate. Re-measured
  with siblings: `a*b-provider.ts` returns 3 files plain and 1 under
  `:(literal)`. The decision stands (a pathspec equal to the path always matches
  it literally, so no miss is possible; the extras only over-arm, and each
  sibling is separately iterated) but for the true reason. This mattered beyond
  the comment: go-to-k/cdkd#3047's sweep would have carried "pathspec globbing
  cannot change this diff" to call sites where over-match is not obviously safe.
- **The pattern legend** still listed `[^-+]` as a live component seventeen lines
  above the block explaining its removal, and `stage_filter_change`'s guard
  justified itself with the same deleted premise.

## Tests

87 cases (was 78 on the parent). Every fix is probed:

| mutation | result |
| --- | --- |
| symbol pattern back to `^[-+][^-+]` | 1 RED |
| comment pattern back to `^[-+][^-+]` | 2 RED |
| drop the space requirement after `#` | 2 RED |
| header `grep -v` neutered to never-match | 1 RED |
| drop `-c core.quotePath=false` | 1 RED |
| neuter the quoted-path arm | 1 RED |
| unmutated | 87/0, bash 5.x and `/bin/bash` 3.2 |

The header-pass case needs a file whose **path** carries delete vocabulary,
since a `+++ b/<path>` line is the only way the header can reach the content
pattern. The non-ASCII case depends on git's **default**, which is what the
config isolation added in go-to-k/cdkd#3026 makes reliable.

Round 2 also ran this suite against `main`'s hook: **81/5**, with
`an indented private field is not a comment` among the reds — the new cases
fence holes that predate the PR, not only its own edits.

One change ships without a case and says so: the per-file rc check. Once the
name-list diff has succeeded, that one fails only under conditions which would
have failed the name list too, and the earlier rc check already routes those to
markgate. Defence-in-depth on the fail-closed side.

No changelog entry: `.claude/hooks/**` only, no shipped-binary behavior delta.

Closes #3046

go-to-k/cdkd#3047 stays open for its cross-gate sweep — `flatten-before-rebase-gate`,
`integ-local-gate`, `integ-stale-base-detector` and three `scripts/check-pr-*.ts`
build path lists the same way — plus the `-z` read described above.

https://claude.ai/code/session_017KvkEYV3Z3V3ZF2GKibkBS
