### PR TITLE
chore(work-issues): resolve a proposed mechanism's EFFECT, run a correction, count spellings, and gate a re-run on load

### DIFF
--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -98,7 +98,11 @@ produces `Test timed out in <N>ms` and ZERO `AssertionError`s (measured: 14
 failures, 12 timeouts, 0 assertions, at load 73+). **Past a certain load no
 local re-run settles it and CI is the authority** (at load 137-201 with 40
 peer vitest processes, `--maxWorkers=4` AND single-file isolation both still
-failed; the PR merged on a green dedicated-runner CI). **Do not use the stash
+failed; the PR merged on a green dedicated-runner CI). **A run KILLED under
+load has NO verdict — not red, not green, not "flaky" — so do not re-run into
+the same load**: gate the re-run on `uptime`'s load falling (two full suites
+killed at load 225-285 with no tally; a load-gated wrapper waited 30 minutes
+and ran clean at 110, go-to-k/cdkd#3029). **Do not use the stash
 test to decide this** — the stashed and unstashed runs are minutes apart, so a
 load spike ending in between reads as "the diff caused it" (drawn and
 falsified within the hour, 2026-09-02).

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -49,10 +49,11 @@
   a pass. **A BACKGROUNDED call starts from the session cwd**, not the
   `cd` of an earlier call — make every long-running call print its own `pwd`
   first. **The drift runs FORWARD too: a `cd` into a scratch copy persists
-  into the next call**, so a RELATIVE-path edit there lands on the COPY and
-  `node --check` reports the copy's syntax ok; only a later relative path
-  failing revealed it (go-to-k/cdkd#3029) — absolute paths for every EDIT,
-  not only for verification commands. **When a stray main-tree edit has already happened, both obvious
+  into the next call**, so a relative-path edit run through Bash (a `python`
+  or `perl` rewrite) lands on the COPY and `node --check` reports the copy's
+  syntax ok; only a later relative path failing revealed it
+  (go-to-k/cdkd#3029) — absolute paths for every EDIT, not only for
+  verification commands. **When a stray main-tree edit has already happened, both obvious
   repairs are refused** (`git checkout -- <path>` trips
   `dirty-path-restore-gate`; writing the file back trips
   `main-tree-edit-gate`): re-apply the edit in the worktree with an ABSOLUTE

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -48,7 +48,11 @@
   tests vs 143) — an unexpectedly clean or short result is a `pwd` check, not
   a pass. **A BACKGROUNDED call starts from the session cwd**, not the
   `cd` of an earlier call — make every long-running call print its own `pwd`
-  first. **When a stray main-tree edit has already happened, both obvious
+  first. **The drift runs FORWARD too: a `cd` into a scratch copy persists
+  into the next call**, so a RELATIVE-path edit there lands on the COPY and
+  `node --check` reports the copy's syntax ok; only a later relative path
+  failing revealed it (go-to-k/cdkd#3029) — absolute paths for every EDIT,
+  not only for verification commands. **When a stray main-tree edit has already happened, both obvious
   repairs are refused** (`git checkout -- <path>` trips
   `dirty-path-restore-gate`; writing the file back trips
   `main-tree-edit-gate`): re-apply the edit in the worktree with an ABSOLUTE

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -7,8 +7,7 @@ issue, so its diffs, test output and review round-trips stay out of the parent
 context. Every rule below holds unchanged there: hooks fire on the lane's tool
 calls, markgate markers land in the lane's own tree. Two actions stay with the
 parent's serialization turn: a real-AWS integ run and the merge (§9). A lane
-stops at merge-ready. (Placement live-proven 2026-08-28: two skill-split PRs
-built end-to-end by lane subagents with every hook firing inside the lanes.)
+stops at merge-ready.
 
 ### 5-a. The tree
 
@@ -231,8 +230,8 @@ every character and rewrote an 11 KB file to 838 KB, scoring the three probes
 after it against a corrupted subject.
 
 **Probe the CALLER too, and the WAY IN** — `.claude/rules/testing.md` →
-"Mutation probes" owns both: wiring, and the vacuity a normalising entrypoint
-causes.
+"Mutation probes" owns both — wiring, and the vacuity a normalising entrypoint
+causes — plus the one-mutation-per-probe rule.
 
 **A mutation probe proves a test discriminates only if it changes the value
 the test READS.** Four vacuous tests shipped in one day, all one shape: the
@@ -363,22 +362,21 @@ regression sit in the "intended repair" bucket, fence green); and **carry a
 floor per class** (the walk reaches a class only if the input pool contains
 it — a pool that quietly stops covering one passes as "no regressions").
 
-**When a fence must read another tool's CONFIG, parse it with a real parser
-and fail CLOSED on anything unmodelled — never hand-roll a scanner, never
-patch one per spelling.** Measured across three sibling fences over
-`.markgate.yml` (go-to-k/cdkd#2383, go-to-k/cdk-real-drift#1838,
+**When a fence must read another tool's CONFIG — or a SOURCE file — parse it
+with a real parser and fail CLOSED on anything unmodelled — never hand-roll a
+scanner, never patch one per spelling.** Measured across three sibling fences
+over `.markgate.yml` (go-to-k/cdkd#2383, go-to-k/cdk-real-drift#1838,
 go-to-k/cdk-local#631): the unused key (`exclude` — read the tool's OWN
 schema from the pinned binary, not its `init` template); then the spelling
-treadmill — four spellings across four rounds (flow lists, quoted keys, a
-two-space comment ending a block scan, the YAML merge key splicing an
-`exclude` from a sibling gate), each patch moving the hole. **Three spellings
-in three rounds is the signal to change instrument**: parse for real
-(`yaml`'s `parse(text, { merge: true })`), allow-list the tool's own keys,
-fail closed outside them — or REFUSE the construct rather than model it
+treadmill — four spellings across four rounds, each patch moving the hole.
+**Three spellings in three rounds is the signal to change instrument — count
+them in the commit subjects**: go-to-k/cdkd#3029 reached SIX regex spellings
+of one TS function's term list before the compiler API (`typescript-v6`)
+ended it. Parse for real (`yaml`'s `parse(text, { merge: true })`),
+allow-list the tool's own keys, fail closed outside them — or REFUSE the
+construct rather than model it
 (refusal is the stricter option: an unmodelled shape stops the fence instead
-of passing through). And a probe establishing any of this must move ONE
-variable (an early draft's published probe had re-`set` the marker in
-between, making its headline sentence false).
+of passing through).
 
 **The general shape: a fence is not evidence until you have watched it go red
 on something you had not already counted.**
@@ -397,6 +395,10 @@ the second catches an over-tightening fix); **is it hermetic, and on WHICH
 axis?** (enumerate git history, environment, cwd, clock, locale, user; pin
 each or record a measured negative — prefer PINNING over normalizing, since a
 normalization layer sits exactly where a fence goes green-but-inert).
+`realpath` a scratch ROOT — macOS `tmpdir()` says `/var/…`, git
+`/private/var/…`, and three spawn cases under the raw root passed with stdout,
+stderr and rc identical to a clean run, caught only by a vacuity probe
+(go-to-k/cdkd#3029; second occurrence).
 
 ### 5-g. Fan-out mechanics
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -362,17 +362,17 @@ regression sit in the "intended repair" bucket, fence green); and **carry a
 floor per class** (the walk reaches a class only if the input pool contains
 it — a pool that quietly stops covering one passes as "no regressions").
 
-**When a fence must read another tool's CONFIG — or a SOURCE file — parse it
-with a real parser and fail CLOSED on anything unmodelled — never hand-roll a
+**When a fence must read another tool's CONFIG or a SOURCE file, parse it
+with a real parser and fail CLOSED on anything unmodelled: never hand-roll a
 scanner, never patch one per spelling.** Measured across three sibling fences
 over `.markgate.yml` (go-to-k/cdkd#2383, go-to-k/cdk-real-drift#1838,
 go-to-k/cdk-local#631): the unused key (`exclude` — read the tool's OWN
 schema from the pinned binary, not its `init` template); then the spelling
 treadmill — four spellings across four rounds, each patch moving the hole.
-**Three spellings in three rounds is the signal to change instrument — count
-them in the commit subjects**: go-to-k/cdkd#3029 reached SIX regex spellings
-of one TS function's term list before the compiler API (`typescript-v6`)
-ended it. Parse for real (`yaml`'s `parse(text, { merge: true })`),
+**Three spellings in three rounds is the signal to change instrument — and a
+table-driven regex is the SAME instrument**: go-to-k/cdkd#3029 counted three,
+cited this rule, tabled the regex, and reached SIX before the compiler API
+(`typescript-v6`) ended it. Parse for real (`yaml`'s `parse(text, { merge: true })`),
 allow-list the tool's own keys, fail closed outside them — or REFUSE the
 construct rather than model it
 (refusal is the stricter option: an unmodelled shape stops the fence instead
@@ -398,7 +398,7 @@ normalization layer sits exactly where a fence goes green-but-inert).
 `realpath` a scratch ROOT — macOS `tmpdir()` says `/var/…`, git
 `/private/var/…`, and three spawn cases under the raw root passed with stdout,
 stderr and rc identical to a clean run, caught only by a vacuity probe
-(go-to-k/cdkd#3029; second occurrence).
+(go-to-k/cdkd#3029).
 
 ### 5-g. Fan-out mechanics
 

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -240,8 +240,12 @@ Reading candidate bodies:
   first and whose staleness reads as "already fixed" (2026-08-26: THREE of
   six claimed issues had a false premise, each still worth doing as a
   DIFFERENT change; go-to-k/cdkd#2286 named the wrong file and its lines had
-  drifted ~290). Write what you found in the claim
-  comment and correct the issue body. The not-yet-true direction is commoner:
+  drifted ~290). **A body PROPOSING a mechanism has no symbol to grep — resolve
+  its EFFECT: what on `origin/main` already produces it** (go-to-k/cdkd#3005
+  asked for a decision-count gate; go-to-k/cdkd#2999's `ci-ok` already blocked
+  five of its six terms, and the run's triage comment read that PR as merely
+  removing an obstacle — the closure surfaced only at claim time). Write what
+  you found in the claim comment and correct the issue body. The not-yet-true direction is commoner:
   a body written from an unmerged branch describes THAT branch — on an empty
   grep, `gh pr list --state all --search <symbol>` separates "premise wrong"
   (post a correction) from "premise on an unmerged branch" (rebase and carry

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -325,7 +325,7 @@ false claim a review round had read past:
   ("X is load-bearing: deleting it would hard-fail" — X probed, the consequence
   never). Measured 2026-09-09 (go-to-k/cdkd#2842 / go-to-k/cdkd#2873): ten
   rounds, nine reassurances falsified — running caught all, re-reading none,
-  two past a security reviewer. Deleting a whole CLAIM cannot introduce a new
+  two endorsed by a security reviewer. Deleting a whole CLAIM cannot introduce a new
   false one; deleting a clause from INSIDE a sentence can falsify the survivor.
 - **A claim outlives the sweep that corrected it. Sweep by CLAIM, over
   NORMALISED text** — every TRACKED file, comment leaders stripped, whitespace

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -297,8 +297,10 @@ false claim a review round had read past:
 - **A claim inherited from the ISSUE BODY is the least trustworthy of all** —
   re-verify an issue's mechanism against current `main` before restating it
   (a later PR may already have falsified it).
-- **A correction can be a new false claim** — twice the replacement sentence
-  was wrong in the other direction. Re-read a correction against the code.
+- **A correction can be a new false claim — RUN it, do not re-read it** —
+  twice the replacement sentence was wrong in the other direction; a third
+  (go-to-k/cdkd#3029, withdrawing a refuted exemption) named a subtraction
+  the fixtures never make.
 - **A round finding the SAME CLASS twice, or TWO SPELLINGS of one question,
   means stop fixing instances** — name the site that OWNS the question and
   make every other site call or copy ONE
@@ -321,11 +323,10 @@ false claim a review round had read past:
   affirmative NAMES its backing; one that cannot is DELETED rather than
   verified. The recurring form is a CONSEQUENCE bolted onto a verified claim
   ("X is load-bearing: deleting it would hard-fail" — X probed, the consequence
-  never). Dated measurement (2026-09-09, go-to-k/cdkd#2842 / go-to-k/cdkd#2873):
-  over ten rounds, nine reassurances falsified — re-READING caught none, running
-  the claim caught all, two survived a security reviewer's endorsement. Deleting
-  a whole CLAIM cannot introduce a new false one; deleting a clause from INSIDE
-  a sentence can falsify the survivor.
+  never). Measured 2026-09-09 (go-to-k/cdkd#2842 / go-to-k/cdkd#2873): ten
+  rounds, nine reassurances falsified — running caught all, re-reading none,
+  two past a security reviewer. Deleting a whole CLAIM cannot introduce a new
+  false one; deleting a clause from INSIDE a sentence can falsify the survivor.
 - **A claim outlives the sweep that corrected it. Sweep by CLAIM, over
   NORMALISED text** — every TRACKED file, comment leaders stripped, whitespace
   collapsed, matched ACROSS line breaks — **subtracting only what you can name a

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -300,17 +300,20 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // which after a sync is every generated sub-issue -- and widened the fence's
     // population to both files.
     //
-    // The go-to-k/cdkd#3005 / go-to-k/cdkd#3029 retro then grew it by 1,113 B
-    // and swapped the leaders again (implement.md ahead by 5 B). Its two
-    // leader-file additions were each paid for in the same file -- a probe
-    // rule restated from `.claude/rules/testing.md` became a pointer, a
+    // The go-to-k/cdkd#3005 / go-to-k/cdkd#3029 retro then grew it by 1,156 B
+    // and swapped the leaders TWICE inside its own review round (the lead
+    // changed hands by 5 B and then back by 10 B, which is why no paragraph
+    // here names the holder). Its three leader-file amendments (two in
+    // implement.md, one in verify.md) were each paid for in the same file -- a
+    // probe rule restated from `.claude/rules/testing.md` became a pointer, a
     // placement-proven citation and a four-spelling narrative were dropped, a
     // dated measurement was compressed -- and the three non-leader additions
-    // (triage.md, gotchas.md, gates-and-pr.md) are what moved the floor; see
-    // beside MIN_REFERENCE_CORPUS_BYTES.
-    corpusBytes: 186_066,
-    largest: { file: 'implement.md', bytes: 29_982 },
-    runnerUp: { file: 'verify.md', bytes: 29_977 },
+    // (triage.md, gotchas.md, gates-and-pr.md) are most of what moved the
+    // floor, the leaders' own net growth the rest; see beside
+    // MIN_REFERENCE_CORPUS_BYTES.
+    corpusBytes: 186_109,
+    largest: { file: 'verify.md', bytes: 29_984 },
+    runnerUp: { file: 'implement.md', bytes: 29_974 },
   },
 };
 
@@ -742,20 +745,19 @@ const MIN_REFERENCE_FILES = 6;
 // headroom is quoted here: the caps' own failure messages print it live, and
 // the figure an earlier draft stated went stale in the very next retro (the
 // go-to-k/cdkd#2911 one, which moved a leader without moving either bound).
-// RE-DERIVED UPWARD 155_410 -> 156_450 by the go-to-k/cdkd#3005 /
-// go-to-k/cdkd#3029 retro (+1,113 B, corpus 184,953 -> 186,066), which landed
-// six amendments across five stage files. The growth is in the non-leader
-// files (triage.md, gotchas.md, gates-and-pr.md); in the two leaders each
-// addition was funded by a cut in the same file and both still ended net
-// larger, so the leaders SWAPPED — implement.md now leads verify.md by 5 B —
-// which is why MEASURED asserts the slots rather than this comment naming
-// them. Inputs at this date: corpus 186,066, largest 29,982, runner-up 29,977,
-// so the two thresholds are 156,084 (largest-side) and 156,089 (runner-up
-// side, binding); 156_450 clears the binding one by 361 B, the same slack the
-// derivations above carried. Both leaders are at the per-file cap's doorstep
-// (the cap's failure message prints the live headroom), so the next edit to
-// EITHER opens with a compression pass.
-const MIN_REFERENCE_CORPUS_BYTES = 156_450;
+// RE-DERIVED UPWARD 155_410 -> 156_500 by the go-to-k/cdkd#3005 /
+// go-to-k/cdkd#3029 retro (+1,156 B, corpus 184,953 -> 186,109), which landed
+// six amendments across five stage files. Most of the growth is in the
+// non-leader files (triage.md, gotchas.md, gates-and-pr.md); in the two
+// leaders each addition was funded by a cut in the same file and both still
+// ended net larger, so the leaders SWAPPED (MEASURED asserts which is which).
+// Inputs at this date: corpus 186,109, largest 29,984, runner-up 29,974, so
+// the two thresholds are 156,125 (largest-side) and 156,135 (runner-up side,
+// binding); 156_500 clears the binding one by 365 B, inside the 347-383 B
+// band the derivations above carried. Both leaders are at the per-file cap's
+// doorstep (the cap's failure message prints the live headroom), so the next
+// edit to EITHER opens with a compression pass.
+const MIN_REFERENCE_CORPUS_BYTES = 156_500;
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -299,9 +299,18 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // count to that set -- it selects issues whose body gained a `- [ ] ` row,
     // which after a sync is every generated sub-issue -- and widened the fence's
     // population to both files.
-    corpusBytes: 184_953,
-    largest: { file: 'verify.md', bytes: 29_928 },
-    runnerUp: { file: 'implement.md', bytes: 29_915 },
+    //
+    // The go-to-k/cdkd#3005 / go-to-k/cdkd#3029 retro then grew it by 1,113 B
+    // and swapped the leaders again (implement.md ahead by 5 B). Its two
+    // leader-file additions were each paid for in the same file -- a probe
+    // rule restated from `.claude/rules/testing.md` became a pointer, a
+    // placement-proven citation and a four-spelling narrative were dropped, a
+    // dated measurement was compressed -- and the three non-leader additions
+    // (triage.md, gotchas.md, gates-and-pr.md) are what moved the floor; see
+    // beside MIN_REFERENCE_CORPUS_BYTES.
+    corpusBytes: 186_066,
+    largest: { file: 'implement.md', bytes: 29_982 },
+    runnerUp: { file: 'verify.md', bytes: 29_977 },
   },
 };
 
@@ -733,7 +742,20 @@ const MIN_REFERENCE_FILES = 6;
 // headroom is quoted here: the caps' own failure messages print it live, and
 // the figure an earlier draft stated went stale in the very next retro (the
 // go-to-k/cdkd#2911 one, which moved a leader without moving either bound).
-const MIN_REFERENCE_CORPUS_BYTES = 155_410;
+// RE-DERIVED UPWARD 155_410 -> 156_450 by the go-to-k/cdkd#3005 /
+// go-to-k/cdkd#3029 retro (+1,113 B, corpus 184,953 -> 186,066), which landed
+// six amendments across five stage files. The growth is in the non-leader
+// files (triage.md, gotchas.md, gates-and-pr.md); in the two leaders each
+// addition was funded by a cut in the same file and both still ended net
+// larger, so the leaders SWAPPED — implement.md now leads verify.md by 5 B —
+// which is why MEASURED asserts the slots rather than this comment naming
+// them. Inputs at this date: corpus 186,066, largest 29,982, runner-up 29,977,
+// so the two thresholds are 156,084 (largest-side) and 156,089 (runner-up
+// side, binding); 156_450 clears the binding one by 361 B, the same slack the
+// derivations above carried. Both leaders are at the per-file cap's doorstep
+// (the cap's failure message prints the live headroom), so the next edit to
+// EITHER opens with a compression pass.
+const MIN_REFERENCE_CORPUS_BYTES = 156_450;
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })


### PR DESCRIPTION
Retrospective (`references/retro.md` section 10) for the single-lane `/work-issues` run that closed go-to-k/cdkd#3005 through go-to-k/cdkd#3029 (merged as 264db41e). Six amendments across five stage files, each an amended sentence carrying the run's evidence as one line, plus the MEASURED / floor re-derivation in `skill-file-payload.test.ts`. No cap moved.

## Backlog effect (section 10-0)

`closed 1 / filed 1 (new 1 / folded 0)`, taken from the run's own record (the claim on go-to-k/cdkd#3005 and the lane report), not from the window scan — the date window from 2026-09-11T15:00Z lists 8 closures and 13 filings, of which only go-to-k/cdkd#3005 and go-to-k/cdkd#3034 are this run's.

Promotion check on go-to-k/cdkd#3034 (the one `Session-fit: next` this run filed): the extraction found five path tokens and one hit, `scripts/diagnose-schema-refresh.mjs`. Read in its sentence it is a **citation** (`partitionSettledRemovals`, "added by go-to-k/cdkd#3029", is named as one of the two READERS), not the target — the targets are `property-coverage.test.ts` and `_todo-backfill.json`, which the run's PR did not touch. The reason (a provider-level judgement on `AWS::EC2::NetworkAclEntry` the count work does not supply) still stands and the next-session command is named. Not promoted.

## What changed, where, and the evidence

| Stage file | Amendment | Run evidence |
| --- | --- | --- |
| `triage.md` section 3, premise bullet | a body PROPOSING a mechanism has no symbol to grep — resolve its EFFECT against `origin/main` | the issue asked for a decision-count gate; go-to-k/cdkd#2999's `ci-ok` already blocked five of six terms. The run's triage comment (15:15Z) read that PR as removing an obstacle; the claim (15:39Z) found the closure |
| `verify.md` section 8-g, correction bullet | "re-read a correction against the code" → RUN it; re-reading is what let each through | the correction of a refuted exemption, written in commit 092e0dea on the PR branch and corrected by c7b17348, claimed a subtraction the fixtures never make (they commit fixtures verbatim, so `removed` is empty) — the third false correction on record. Paid for by compressing the 2026-09-09 measurement two bullets below |
| `implement.md` section 5-f', instrument paragraph | scope widened from "another tool's CONFIG" to source files; a table-driven regex is the SAME instrument | the run counted three spellings, cited this rule in its round-4 commit (b555af3d), "changed instrument" to a table-driven regex, and reached SIX before the TS compiler API (`typescript-v6`) ended it (2dc72639) — counting fired; the change of instrument did not leave the instrument class |
| `implement.md` section 5-f', hermetic-axis bullet | `realpath` a scratch ROOT | probe 19: `tmpdir()` `/var/…` vs git `/private/var/…` made three spawn cases vacuous — stdout, stderr, rc identical to a clean run (608cf919) |
| `gotchas.md`, cwd bullet | the drift runs FORWARD too: a `cd` into a scratch copy persists into the next call | a relative-path `python` edit run through Bash landed on the scratch COPY, `node --check` said syntax ok about the copy; found only when the next relative path failed. Session-internal — not in any commit body |
| `gates-and-pr.md` section 6, host-load paragraph | a run KILLED under load has NO verdict; gate the re-run on load falling | two full suites killed at load 225–285 with no tally; a load-gated wrapper waited 30 minutes and ran clean at 110. Session-internal — the commit bodies record only the smaller load 119 → 79 retry (83629f25) |

Paid for in the two leader files (both were at the cap's doorstep, 72 B / 85 B): `implement.md` dropped the placement-proven citation, the four-spelling narrative, and the one-variable probe sentence (a restatement of `.claude/rules/testing.md`'s rule, now a pointer from section 5-e); `verify.md` compressed a dated measurement. Both still ended net larger, and the lead changed hands twice inside this PR's own review round (by 5 B, then back by 10 B), which is why the test-file comment names no holder.

## Not added, and why

- **Reviewer-vs-author measurement dispute** ("all three red" vs "case 2 only", settled by re-measuring; the reviewer's harness lacked a fixture copy — session-internal, no commit records it): 8-h's "settle it in the code yourself" held as written. No evidence of a text defect.
- **The false fence comment citing a non-existent workflow line (608cf919), and the exemption twin that survived a round (092e0dea)**: 8-g's "every surviving affirmative NAMES its backing" and "sweep by CLAIM over every tracked file" were already in the text and were violated. Per 10-b that calls for escalation, not restatement, and no hook or test can see a claim about a sibling workflow step — so nothing was added, and this PR body records the disposition.

## Sibling-repo mirrors

Resolved against `origin/main`, open PRs and open issues of cdk-local and cdk-real-drift on 2026-09-12: none of the six lessons is carried in either. Both carry the config-scoped three-spellings rule (cdk-local `implement.md:391`, cdk-real-drift `implement.md:291`), which is the rule lesson 3 widens. Mirror issues are filed, each naming the other: go-to-k/cdk-local#725 and go-to-k/cdk-real-drift#1903. The landing is deferred per section 10-c's remainder rule because this retro runs as a delegated subagent of a cdkd IN-PLACE run whose tree still has to be restored, and both target skills are structurally divergent (no 8-g, no hermetic-axis bullet; their cwd bullets carry only the backward drift), so each mirror is a placement decision needing that repo's own claim-by-claim pass. The issue bodies carry the per-repo anchors, measured.

## Review round

`/review-pr` resolved `1-reviewer` (inline by size, up-biased on the recency signal for `.claude/**`: every recent commit on the touched files is a retro fold). Two reviewers ran in parallel — `pr-code-reviewer` and an independently briefed claim-verifier — and neither found a blocker. Fixed from their findings: two false statements in the test-file comment (the slack was "the same" as the derivations above — it sits inside their 347–383 B band; the leader-naming clause contradicted itself), the mis-attributed correction commit (the false correction lives in 092e0dea; c7b17348 fixed it), "nobody counted" (b555af3d did — the instrument change was the defect), a "second occurrence" the public reader cannot resolve (its first is in private memory), the "every command already exists in the stage files" claim (`realpath`, `tmpdir()` and `node --check` enter with this diff; only `uptime` pre-existed), the cdk-local omission in the sibling scan, and four wording nits. The mirror-issue sentence was written in the past tense before the issues existed; they exist now.

## Verification

A prose diff plus two numeric constants, so section 8-c's prose arm: every incident cited resolves (go-to-k/cdkd#3005 / #3029 / #2999 / #3034; commits 092e0dea, c7b17348, b555af3d, 2dc72639, 608cf919 on `refs/pull/3029/head`), and every gate, path and skill the new text names resolves in this repo. `skill-file-payload.test.ts` and `work-issues-skill-refs.test.ts` green; the MEASURED record and `MIN_REFERENCE_CORPUS_BYTES` (155_410 → 156_500, binding threshold 156,135) were pasted from the assertion's own failure message. Full unit suite 995 files / 21,965 passed / 1 skipped before the review-fix commit; `vp run check`, `typecheck:test`, `build`, `format:check` green after it.

https://claude.ai/code/session_0166XUF5inMyVX5PSwLiZP8k
