### PR TITLE
test(provisioning): refuse a bogusTolerated entry that names no declared property

### DIFF
--- a/docs/provider-rules.md
+++ b/docs/provider-rules.md
@@ -2074,6 +2074,8 @@ A property in `handledProperties` (or `unhandledByDesign`) that is NOT in the CF
 
 The test reports these — but fixing each requires per-provider investigation that often touches the safety-net's runtime behavior. As a stopgap, the tolerance list at `tests/fixtures/cfn-schemas/_todo-backfill.json` under `bogusTolerated[<type>][<prop>]` accepts a one-line rationale per entry, the test stays green, and follow-up PRs investigate one at a time. Day-1 of issue #391 the test surfaced 10 such entries — see the rationale strings in that file for the canonical examples.
 
+An entry is a claim about a DECLARATION — "the provider declares `<prop>`, the schema no longer has it, and here is why the declaration stays" — and every reader keys on that premise: the coverage test consults it only while walking `handledProperties` / `unhandledByDesign` / the backfill list, and the schema-refresh diagnosis only for a property in the generated `handled` map. So when the declaration itself is renamed or removed (the usual fix), **retire the entry in the same change**: the test fails an entry that names a property no declaration on that type carries, because such an entry is inert while reading as protection — and if the declaration was meant to exist, it is masking a silent drop (issue [#3034](https://github.com/go-to-k/cdkd/issues/3034), where a `NetworkAclEntry.IcmpTypeCode` entry written on 2026-05-16 outlived the 2026-05-27 rename to `Icmp` until 2026-09-13). The other staleness direction — AWS re-adds the property — is reported by its own case.
+
 ## Admitting a type to the sticky-CC exemption
 
 Closing the last silent-drop gap for a type is not the end of the story for

--- a/tests/fixtures/cfn-schemas/_todo-backfill.json
+++ b/tests/fixtures/cfn-schemas/_todo-backfill.json
@@ -341,9 +341,6 @@
       "TableClass": "CFn schema exposes this only nested under Replicas[].TableClass; provider's top-level handledProperties entry predates the schema layout. Investigate per-replica drift handling separately.",
       "DeletionProtectionEnabled": "Same shape as TableClass — CFn nests this under Replicas[]; provider declares it at top level. Follow-up cleanup."
     },
-    "AWS::EC2::NetworkAclEntry": {
-      "IcmpTypeCode": "SDK input field name; CFn schema renamed to 'Icmp'. Provider keeps the SDK name to match its create() input; rename the safety-net entry separately."
-    },
     "AWS::ElastiCache::SubnetGroup": {
       "CacheSubnetGroupDescription": "SDK input field name; CFn schema names the same field 'Description'. Investigate whether to rename in a follow-up."
     },

--- a/tests/unit/provisioning/property-coverage.test.ts
+++ b/tests/unit/provisioning/property-coverage.test.ts
@@ -227,10 +227,42 @@ describe('SDK Provider property coverage', () => {
     }
   });
 
-  // Bogus-tolerance entries must (a) reference a registered type and
-  // (b) carry a non-empty rationale. The rationale is what makes the
-  // tolerance auditable — without it the entry is indistinguishable
-  // from a bug nobody investigated.
+  // Bogus-tolerance entries must (a) reference a registered type, (b) carry
+  // a non-empty rationale, and (c) name a property the type actually
+  // DECLARES. The rationale is what makes the tolerance auditable — without
+  // it the entry is indistinguishable from a bug nobody investigated. (c) is
+  // the direction that was missing (issue #3034): an entry says "the provider
+  // declares this and the schema no longer has it", and every reader keys on
+  // that premise — `classifyCoverage` consults it only while walking the
+  // three declaration sets below, `partitionSettledRemovals` only for a
+  // property in the generated `handled` map. A name in none of them is a
+  // rationale asserting nothing: it reads as protection and is inert, and if
+  // the declaration was MEANT to exist it is masking a silent drop. Measured
+  // 2026-09-12: 13 entries, 12 declared, 1 not (`AWS::EC2::NetworkAclEntry.
+  // IcmpTypeCode`, left over from #408 after #623 renamed the declaration to
+  // `Icmp`; deleted with this fence).
+  //
+  // The sets are read from the REGISTERED provider's runtime maps, exactly as
+  // the per-type case above hands them to `classifyCoverage` — not from the
+  // generated module — so this fence cannot disagree with the reader it
+  // exists to protect.
+  //
+  // ONE helper, two callers: the live case below and the synthetic one after
+  // it. Measured 2026-09-12, every remaining entry is `handledProperties`-
+  // backed, so the other two arms of this union have no witness in the real
+  // data and were individually deletable with the live case green; the
+  // synthetic case is what gives each arm a red.
+  const declaredFor = (
+    provider: ReturnType<typeof registry.getProvider>,
+    type: string,
+    backfillProps: readonly string[] | undefined
+  ): Set<string> =>
+    new Set<string>([
+      ...(provider.handledProperties?.get(type) ?? []),
+      ...(provider.unhandledByDesign?.get(type)?.keys() ?? []),
+      ...(backfillProps ?? []),
+    ]);
+
   it('every bogus-tolerated entry is well-formed', () => {
     const registeredSet = new Set(registeredTypes);
     const problems: string[] = [];
@@ -243,13 +275,51 @@ describe('SDK Provider property coverage', () => {
         problems.push(`bogusTolerated.${type}: must be an object`);
         continue;
       }
+      const declared = declaredFor(registry.getProvider(type), type, backfill[type]);
       for (const [propName, rationale] of Object.entries(entries)) {
         if (typeof rationale !== 'string' || rationale.trim().length === 0) {
           problems.push(`bogusTolerated.${type}.${propName}: rationale must be a non-empty string`);
         }
+        if (!declared.has(propName)) {
+          problems.push(
+            `bogusTolerated.${type}.${propName}: no declaration names this property ` +
+              '(not in handledProperties, unhandledByDesign, or the backfill list), so no ' +
+              'reader ever consults the entry. Delete it, or restore the declaration it was ' +
+              'written for.'
+          );
+        }
       }
     }
     expect(problems, problems.join('\n')).toEqual([]);
+  });
+
+  it('the declaration union reaches each of the three sets classifyCoverage walks', () => {
+    // Synthetic providers, one per arm, each declaring `P` through that arm
+    // ALONE — so dropping any one arm from `declaredFor` reds here even while
+    // the live entries (all handled-backed today) keep the case above green.
+    // Shapes mirror `ResourceProvider`'s optional maps; nothing else on the
+    // provider is consulted.
+    const T = 'AWS::Synthetic::Thing';
+    const asProvider = (p: object): ReturnType<typeof registry.getProvider> =>
+      p as ReturnType<typeof registry.getProvider>;
+    const handledOnly = asProvider({ handledProperties: new Map([[T, new Set(['P'])]]) });
+    const byDesignOnly = asProvider({
+      unhandledByDesign: new Map([[T, new Map([['P', 'a rationale']])]]),
+    });
+    const bare = asProvider({});
+
+    expect(declaredFor(handledOnly, T, undefined).has('P'), 'handledProperties arm').toBe(true);
+    expect(declaredFor(byDesignOnly, T, undefined).has('P'), 'unhandledByDesign arm').toBe(true);
+    expect(declaredFor(bare, T, ['P']).has('P'), 'backfill arm').toBe(true);
+    // ...and the control: a name in none of the three is NOT declared, which
+    // is the verdict the live case turns into a problem line.
+    expect(declaredFor(bare, T, undefined).has('P'), 'no arm').toBe(false);
+    // A declaration under a DIFFERENT type must not vouch — the maps are
+    // keyed by resource type and the lookup must be too.
+    expect(
+      declaredFor(asProvider({ handledProperties: new Map([['AWS::Other::Type', new Set(['P'])]]) }), T, undefined).has('P'),
+      'a sibling type\'s declaration'
+    ).toBe(false);
   });
 
   // Staleness guard: when AWS later adds a property previously listed in

--- a/tests/unit/provisioning/property-coverage.test.ts
+++ b/tests/unit/provisioning/property-coverage.test.ts
@@ -297,11 +297,13 @@ describe('SDK Provider property coverage', () => {
     // Synthetic providers, one per arm, each declaring `P` through that arm
     // ALONE — so dropping any one arm from `declaredFor` reds here even while
     // the live entries (all handled-backed today) keep the case above green.
-    // Shapes mirror `ResourceProvider`'s optional maps; nothing else on the
-    // provider is consulted.
+    // The parameter is typed against the two maps `declaredFor` reads, so a
+    // shape change in `ResourceProvider` fails here at compile time rather
+    // than leaving a synthetic literal silently un-matched.
     const T = 'AWS::Synthetic::Thing';
-    const asProvider = (p: object): ReturnType<typeof registry.getProvider> =>
-      p as ReturnType<typeof registry.getProvider>;
+    type Provider = ReturnType<typeof registry.getProvider>;
+    const asProvider = (p: Pick<Provider, 'handledProperties' | 'unhandledByDesign'>): Provider =>
+      p as Provider;
     const handledOnly = asProvider({ handledProperties: new Map([[T, new Set(['P'])]]) });
     const byDesignOnly = asProvider({
       unhandledByDesign: new Map([[T, new Map([['P', 'a rationale']])]]),


### PR DESCRIPTION
Closes go-to-k/cdkd#3034.

## The defect

A `bogusTolerated` entry in `tests/fixtures/cfn-schemas/_todo-backfill.json` says: the provider DECLARES this property, the CFn schema no longer carries it, and here is why the declaration stays. Every reader keys on that premise — `classifyCoverage` consults the map only while walking `handledProperties` / `unhandledByDesign` / the backfill list, and `partitionSettledRemovals` (go-to-k/cdkd#3029) only for a property in the generated `handled` map. An entry naming a property that no declaration on its type carries is therefore a rationale asserting nothing: inert while reading as protection, and — if the declaration was meant to exist — masking a silent drop. Nothing reported the shape; the one staleness case that existed fires on the opposite condition (AWS re-adds the property).

## The live instance, and which reading survived

Measured with the shipped parser: 13 entries, 12 declared, 1 not — `AWS::EC2::NetworkAclEntry.IcmpTypeCode`. The issue left two readings open. History settles it as the leftover: the entry was written by go-to-k/cdkd#408 on 2026-05-16, when the provider declared `IcmpTypeCode`; go-to-k/cdkd#623 renamed the declaration to `Icmp` on 2026-05-27 (the go-to-k/cdkd#613 fix) and moved the both-keys acceptance into code (`ec2-provider.ts` reads `properties['Icmp'] ?? properties['IcmpTypeCode']`, pinned by `silent-drop-aliases.test.ts` and `ec2-provider-readcurrentstate.test.ts`). Nothing in the tolerance file was load-bearing for that behaviour. Deleted.

## The fence

`property-coverage.test.ts`'s well-formed case gains the third condition: the property must be in the union of the three declaration sets, read from the REGISTERED provider's runtime maps exactly as the per-type case hands them to `classifyCoverage` — not from the generated module, so the fence cannot disagree with the reader it protects. It reds on the live entry BEFORE the deletion (naming it) and is green after.

All twelve surviving entries are `handledProperties`-backed, so the `unhandledByDesign` and backfill arms had no witness in the real data and were individually deletable with the live case green. The union is one helper both the live case and a synthetic case call; the synthetic case declares a property through each arm ALONE, plus a no-arm control and a sibling-type control (the maps are keyed by type and the lookup must be too).

| Probe | Mutation | Red |
| --- | --- | --- |
| 1 | the live entry present, fence added | `every bogus-tolerated entry is well-formed`, naming `IcmpTypeCode` |
| 2 | drop the `handledProperties` arm | the live case (all 12 entries named) and the synthetic case |
| 3 | drop the `unhandledByDesign` arm | the synthetic case only |
| 4 | drop the backfill arm | the synthetic case only |

`docs/provider-rules.md` records the retirement rule in the paragraph that already describes the list. A duration I first wrote there ("five months") was measured wrong and replaced with the three dates.

Review (one reader, every claim re-measured on a scratch copy): no blockers. Two corrections taken — this table first said probe 2 named 24 entries, which was the failure text counted twice (the assertion message plus the Received diff); and the synthetic providers' cast now takes `Pick<Provider, 'handledProperties' | 'unhandledByDesign'>` rather than `object`, so a shape change in `ResourceProvider` fails at compile time instead of leaving a literal silently un-matched. The reviewer also ran a type-agnostic-lookup mutant (`values().flatMap`): it reds ONLY the sibling-type control, which is therefore the sole fence for keyed lookup and does discriminate.

## Verification

`vp run check` / `typecheck:test` / `build` green; `gen:all-matrices` + `audit:coverage:check` regenerate nothing beyond the two edited files; full unit suite 993 files / 21,966 passed, 1 skipped. No `src/**` change, so no integ gate and no changelog entry.

https://claude.ai/code/session_0166XUF5inMyVX5PSwLiZP8k
